### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This library is a CBOR encoder and decoder.  Each release passes 375+ tests and 
 
 __What is CBOR__?  [CBOR](CBOR_GOLANG.md) ([RFC 7049](https://tools.ietf.org/html/rfc7049)) is a binary data format inspired by JSON and MessagePack.  CBOR is used in [IETF](https://www.ietf.org) Internet Standards such as COSE ([RFC 8152](https://tools.ietf.org/html/rfc8152)) and CWT ([RFC 8392 CBOR Web Token](https://tools.ietf.org/html/rfc8392)). Even WebAuthn uses CBOR.
 
-__Why this CBOR library?__ It doesn't crash and it has well-balanced qualities: small, fast, safe and easy. It can provide "preferred serialization" by correctly converting floating-point values to float16 (if they fit) using IEEE 754 default rounding.
+__Why this CBOR library?__ It doesn't crash and it has well-balanced qualities: small, fast, safe and easy. It can provide "preferred serialization" by correctly converting floating-point values to float16 (if they fit).
 
 * __Small apps__.  Same programs are 4-9 MB smaller by switching to this library.  No code gen and the only imported pkg is [cbor-go/float16](https://github.com/cbor-go/float16) which is maintained by the same team as this library.
 
@@ -69,7 +69,7 @@ Recent activity:
 * [x] [Release v1.3](https://github.com/fxamacker/cbor/releases) -- Add `keyasint` struct tag to simplify using CBOR maps with int keys.
 * [x] [Release v1.3.4](https://github.com/fxamacker/cbor/releases) -- Bugfixes and refactoring.  Limit nested levels to 32 for arrays, maps, tags.
 * [x] [Release v1.4](https://github.com/fxamacker/cbor/releases) -- Deprecate bool encoding options and add int SortMode.  Use float16 to float32 conversion func that had all 65536 results verified to be correct. Fix decoding of float16 subnormal numbers.
-* [x] unreleased -- Add option to shrink floating-point values to smaller sizes like float16 (if they preserve value) and use IEEE 754 default rounding, which is the most accurate and statistically unbiased estimate of the true value.
+* [x] unreleased -- Add option to shrink floating-point values to smaller sizes like float16 (if they preserve value).
 * [x] unreleased -- Add options for encoding floating-point NaN values: NaNConvertNone, NanConvert7e00, NanConvertQuiet, or NaNConvertPreserveSignal.
 
 Coming soon: support for CBOR tags (major type 6). After that, options for handling duplicate map keys.


### PR DESCRIPTION
Removed my goofy mention of rounding for floating-point conversions that "fit" (aka "preserves value"). It's only relevant to cbor-go/float16 as a standalone library.