### PR TITLE
Update CI to use amd64, arm64, ppc64le, s390x and add golangci-lint 1.23.1 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,7 @@ linters:
     - goconst
     - gocyclo
     - gofmt
+    - goimports
     - golint
     - gosec
     - govet
@@ -56,7 +57,6 @@ linters:
     - structcheck
     - typecheck
     - unconvert
-    - unparam
     - unused
     - varcheck
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+# Do not delete linter settings. Linters like gocritic can be enabled on the command line.
+
 linters-settings:
   dupl:
     threshold: 100
@@ -39,35 +41,19 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - bodyclose
     - deadcode
-    - depguard
-    - dogsled
-    - dupl
     - errcheck
-    - funlen
-    - gochecknoinits
     - goconst
-    - gocritic
     - gocyclo
     - gofmt
-    - goimports
     - golint
-    - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
-    - interfacer
-    - lll
     - maligned
     - misspell
-    - nakedret
-    - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
-    - stylecheck
     - typecheck
     - unconvert
     - unparam
@@ -75,14 +61,6 @@ linters:
     - varcheck
 
 
-  # don't enable:
-  # - gochecknoglobals
-  # - gocognit
-  # - godox
-  # - gomnd
-  # - prealloc
-  # - whitespace
-    
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,97 @@
+linters-settings:
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - paramTypeCombine
+      - whyNoLint
+      - wrapperFunc    
+  gofmt:
+    simplify: false    
+  goimports:
+    local-prefixes: github.com/fxamacker/cbor
+  golint:
+    min-confidence: 0
+  govet:
+    check-shadowing: true
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - maligned
+    - misspell
+    - nakedret
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+
+
+  # don't enable:
+  # - gochecknoglobals
+  # - gocognit
+  # - godox
+  # - gomnd
+  # - prealloc
+  # - whitespace
+    
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gomnd
+        - lll        
+
+# golangci.com configuration
+# https://github.com/golangci/golangci/wiki/Configuration
+service:
+  golangci-lint-version: 1.23.x # use the fixed version to not introduce new linters unexpectedly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: go
 
-# Use latest 2-3 Go versions and uncomment all arch when preparing to release. It's too slow to have all combos enabled.
+# Use 1-3 Go versions.  Any more is overkill.
 go:
   - 1.13.x
   - 1.12.x
 
+# Uncomment all arch only when preparing to release. It's too slow to always have all of them enabled.
 arch:
   - amd64
 #  - arm64
@@ -23,12 +24,12 @@ script:
   - go test -short ./... -v
 
 # These jobs are run only on linux_amd64 using first version of Go listed above.
-# Tinylint shouldn't be allowed to fail, while Biglint can be allowed to fail.
-# TODO: Remove allow_failures for Tinylint after it succeeds.
+# Lint shouldn't be allowed to fail, while Biglint can be allowed to fail.
+# Remove allow_failures for Tinylint to make failures more obvious at the cost of speed (fast_finish).
 jobs:
   fast_finish: true
   allow_failures:
-  - script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E staticcheck -E typecheck -E unconvert
+  - script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E staticcheck -E structcheck -E typecheck -E unconvert -E unused -E varcheck
   - script: golangci-lint run --timeout=5m
   include:
     - os: linux
@@ -38,9 +39,9 @@ jobs:
       - go test -short -race ./... -v
       - go test -short -coverprofile=coverage.txt -covermode=atomic ./...
       after_success: bash <(curl -s https://codecov.io/bash)      
-    - name: "Tinylint"
+    - name: "Lint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
-      script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E staticcheck -E typecheck -E unconvert
+      script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E staticcheck -E structcheck -E typecheck -E unconvert -E unused -E varcheck
     - name: "Biglint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
       script: golangci-lint run --timeout=5m

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
 
 # These jobs are run only on linux_amd64 using first version of Go listed above.
 # Lint shouldn't be allowed to fail, while Biglint can be allowed to fail.
-# Remove allow_failures for Tinylint to make failures more obvious at the cost of speed (fast_finish).
+# Remove allow_failures for Lint at the cost of speed (fast_finish).
 jobs:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 jobs:
   fast_finish: true
   allow_failures:
-  - script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E typecheck -E unconvert
+  - script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E staticcheck -E typecheck -E unconvert
   - script: golangci-lint run --timeout=5m
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,12 @@ script:
 
 # These jobs are run only on linux_amd64 using first version of Go listed above.
 # Tinylint is not allowed to fail, while Biglint is allowed to fail.
-# Remove allow_failures for biglint if desired, but this allows more aggressive linting.
+# Remove allow_failures for Tinylint after it succeeds.
 jobs:
   fast_finish: true
   allow_failures:
-  - script: golangci-lint run --deadline=5m
+  - script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E maligned -E typecheck -E unconvert
+  - script: golangci-lint run --timeout=5m
   include:
     - os: linux
       arch: amd64
@@ -35,10 +36,10 @@ jobs:
       script: go test -short -race ./... -v     
     - name: "Tinylint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
-      script: golangci-lint run --no-config --deadline=3m --disable-all -E errcheck -E gofmt -E golint -E govet -E ineffassign -E typecheck -E unconvert
+      script: golangci-lint run --no-config --timeout=3m --disable-all -E errcheck -E gofmt -E golint -E govet -E ineffassign -E typecheck -E unconvert
     - name: "Biglint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
-      script: golangci-lint run --deadline=5m
+      script: golangci-lint run --timeout=5m
     - name: "Coverage"
       script:
       - go test -short -coverprofile=coverage.txt -covermode=atomic ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script: go test -short ./... -v
 # These jobs are run only on linux_amd64.  Remove allow_failures for golangci-lint after code cleanup.
 jobs:
   allow_failures:
-  - script: golangci-lint
+  - script: golangci-lint run --deadline=5m
   include:
     - os: linux
       arch: amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,13 @@ env:
 # This is run on all arch. Go doesn't support -race on s390x.
 script: go test -short ./... -v
 
-# These jobs are run only on linux_amd64.  Remove allow_failures for golangci-lint after code cleanup.
+# These jobs are run only on linux_amd64.  Optionally, remove allow_failures for golangci-lint after code cleanup.
 jobs:
+  fast_finish: true
   allow_failures:
   - script: golangci-lint run --deadline=5m
   include:
+    - go: 1.13.x
     - os: linux
       arch: amd64
     - name: "race"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ script:
 
 # These jobs are run only on linux_amd64 using first version of Go listed above.
 # Tinylint shouldn't be allowed to fail, while Biglint can be allowed to fail.
-# TODO: Remove allow_failures for Tinylint after it succeeds. Maybe add staticcheck to Tinylint.
+# TODO: Remove allow_failures for Tinylint after it succeeds.
 jobs:
   fast_finish: true
   allow_failures:
-  - script: golangci-lint run --no-config --timeout=3m --disable-all -E errcheck -E gofmt -E golint -E govet -E ineffassign -E typecheck -E unconvert
+  - script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E typecheck -E unconvert
   - script: golangci-lint run --timeout=5m
   include:
     - os: linux
@@ -40,7 +40,7 @@ jobs:
       after_success: bash <(curl -s https://codecov.io/bash)      
     - name: "Tinylint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
-      script: golangci-lint run --no-config --timeout=3m --disable-all -E errcheck -E gofmt -E golint -E govet -E ineffassign -E typecheck -E unconvert
+      script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E staticcheck -E typecheck -E unconvert
     - name: "Biglint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
       script: golangci-lint run --timeout=5m

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,36 @@ go:
   - 1.12.x
   - 1.13.x
 
+arch:
+  - amd64
+  - arm64
+  - ppc64le
+  - s390x
+
+os:
+  - linux  
+
 env:
-  - GO111MODULE=on 
-  
+  - GO111MODULE=on
+
+# This is run on all arch. Go doesn't support -race on s390x.
+script: go test -short ./... -v
+
+# These jobs are run only on linux_amd64.  Remove allow_failures for golangci-lint after code cleanup.
 jobs:
+  allow_failures:
+  - script: golangci-lint
   include:
-    - name: "build"
-      script: go build ./...
+    - os: linux
+      arch: amd64
+    - name: "race"
+      script: 
+        - go build ./...
+        - go test -short -race ./... -v
     - name: "lint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
       script: golangci-lint run --deadline=5m
     - name: "coverage"
       script:
-      - go test -coverprofile=coverage.txt -covermode=atomic ./...
+      - go test -short -coverprofile=coverage.txt -covermode=atomic ./...
       after_success: bash <(curl -s https://codecov.io/bash)
-    - name: "race"
-      script:
-      - go test -race ./... -v
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ script:
 jobs:
   fast_finish: true
   allow_failures:
-  - script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E staticcheck -E structcheck -E typecheck -E unconvert -E unused -E varcheck
-  - script: golangci-lint run --timeout=5m
+  - script: golangci-lint run --timeout=3m
+  - script: golangci-lint run --timeout=5m -E gocritic -E gosimple -E gomnd -E lll -E dupl
   include:
     - os: linux
       arch: amd64
@@ -41,7 +41,7 @@ jobs:
       after_success: bash <(curl -s https://codecov.io/bash)      
     - name: "Lint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
-      script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E staticcheck -E structcheck -E typecheck -E unconvert -E unused -E varcheck
+      script: golangci-lint run --timeout=3m
     - name: "Biglint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
-      script: golangci-lint run --timeout=5m
+      script: golangci-lint run --timeout=5m -E gocritic -E gosimple -E gomnd -E lll -E dupl

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,13 @@ env:
   - GO111MODULE=on
 
 # This is run on all arch. Go doesn't support -race on s390x.
-script: go test -short ./... -v
+script:
+  - go build ./...
+  - go test -short ./... -v
 
-# These jobs are run only on linux_amd64.  
-# Remove allow_failures for golangci-lint if desired, but this is faster and allows more aggressive linting.
+# These jobs are run only on linux_amd64 using first version of Go listed above.
+# Tinylint is not allowed to fail, while Biglint is allowed to fail.
+# Remove allow_failures for biglint if desired, but this allows more aggressive linting.
 jobs:
   fast_finish: true
   allow_failures:
@@ -28,14 +31,15 @@ jobs:
   include:
     - os: linux
       arch: amd64
-    - name: "race"
-      script: 
-        - go build ./...
-        - go test -short -race ./... -v
-    - name: "lint"
+    - name: "Race"
+      script: go test -short -race ./... -v     
+    - name: "Tinylint"
+      install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
+      script: golangci-lint run --no-config --deadline=3m --disable-all -E errcheck -E gofmt -E golint -E govet -E ineffassign -E typecheck -E unconvert
+    - name: "Biglint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
       script: golangci-lint run --deadline=5m
-    - name: "coverage"
+    - name: "Coverage"
       script:
       - go test -short -coverprofile=coverage.txt -covermode=atomic ./...
       after_success: bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ jobs:
     - name: "race"
       script:
       - go test -race ./... -v
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
       script: go build ./...
     - name: "lint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
-      script: golangci-lint run --deadline=7m
+      script: golangci-lint run --deadline=5m
     - name: "coverage"
       script:
       - go test -coverprofile=coverage.txt -covermode=atomic ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: go
 
+# Use latest 2-3 Go versions and uncomment all arch when preparing to release. It's too slow to have all combos enabled.
 go:
   - 1.13.x
   - 1.12.x
 
 arch:
   - amd64
-  - arm64
-  - ppc64le
-  - s390x
+#  - arm64
+#  - ppc64le
+#  - s390x
 
 os:
   - linux  
@@ -16,14 +17,14 @@ os:
 env:
   - GO111MODULE=on
 
-# This is run on all arch. Go doesn't support -race on s390x.
+# This script is run on all arch. Go doesn't support -race on s390x.
 script:
   - go build ./...
   - go test -short ./... -v
 
 # These jobs are run only on linux_amd64 using first version of Go listed above.
-# Tinylint is not allowed to fail, while Biglint is allowed to fail.
-# Remove allow_failures for Tinylint after it succeeds.
+# Tinylint shouldn't be allowed to fail, while Biglint can be allowed to fail.
+# TODO: Remove allow_failures for Tinylint after it succeeds. Maybe add staticcheck to Tinylint.
 jobs:
   fast_finish: true
   allow_failures:
@@ -32,15 +33,14 @@ jobs:
   include:
     - os: linux
       arch: amd64
-    - name: "Race"
-      script: go test -short -race ./... -v     
+    - name: "RaceAndCover"
+      script:
+      - go test -short -race ./... -v
+      - go test -short -coverprofile=coverage.txt -covermode=atomic ./...
+      after_success: bash <(curl -s https://codecov.io/bash)      
     - name: "Tinylint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
       script: golangci-lint run --no-config --timeout=3m --disable-all -E errcheck -E gofmt -E golint -E govet -E ineffassign -E typecheck -E unconvert
     - name: "Biglint"
       install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
       script: golangci-lint run --timeout=5m
-    - name: "Coverage"
-      script:
-      - go test -short -coverprofile=coverage.txt -covermode=atomic ./...
-      after_success: bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.12.x
   - 1.13.x
+  - 1.12.x
 
 arch:
   - amd64
@@ -19,13 +19,13 @@ env:
 # This is run on all arch. Go doesn't support -race on s390x.
 script: go test -short ./... -v
 
-# These jobs are run only on linux_amd64.  Optionally, remove allow_failures for golangci-lint after code cleanup.
+# These jobs are run only on linux_amd64.  
+# Remove allow_failures for golangci-lint if desired, but this is faster and allows more aggressive linting.
 jobs:
   fast_finish: true
   allow_failures:
   - script: golangci-lint run --deadline=5m
   include:
-    - go: 1.13.x
     - os: linux
       arch: amd64
     - name: "race"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 jobs:
   fast_finish: true
   allow_failures:
-  - script: golangci-lint run --disable-all --timeout=3m -E errcheck -E gofmt -E golint -E govet -E ineffassign -E maligned -E typecheck -E unconvert
+  - script: golangci-lint run --no-config --timeout=3m --disable-all -E errcheck -E gofmt -E golint -E govet -E ineffassign -E typecheck -E unconvert
   - script: golangci-lint run --timeout=5m
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,17 @@ go:
 env:
   - GO111MODULE=on 
   
-script:
-  - go test -coverprofile=coverage.txt -covermode=count ./...
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)  
+jobs:
+  include:
+    - name: "build"
+      script: go build ./...
+    - name: "lint"
+      install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
+      script: golangci-lint run --deadline=7m
+    - name: "coverage"
+      script:
+      - go test -coverprofile=coverage.txt -covermode=atomic ./...
+      after_success: bash <(curl -s https://codecov.io/bash)
+    - name: "race"
+      script:
+      - go test -race ./... -v

--- a/README.md
+++ b/README.md
@@ -58,15 +58,14 @@ The resource intensive `codec.CborHandle` initialization (in the other library) 
 Doing your own comparisons is highly recommended.  Use your most common message sizes and data types.
 
 ## Current Status
-Version 1.x has:
+Latest version is v1.5, which has:
 
 * __Stable API__ – won't make breaking API changes except:
   * CoreDetEncOptions() is subject to change because it uses draft standard not yet approved by IETF.
   * PreferredUnsortedEncOptions() is subject to change because it uses draft standard not yet approved by IETF.
 * __Stable requirements__ – will support Go v1.12 (unless there's compelling reason to require newer).
-* __Passed fuzzing__ – Fuzzing for v1.5 passed 4.75 billion execs in coverage-guided fuzzing on linux_amd64.
-
-Each commit passes 375+ tests on amd64, arm64, ppc64le and s390x with linux. Each release also passes 250+ million execs in coverage-guided fuzzing using 1,100+ CBOR files (corpus) on linux_amd64. See [Fuzzing and Code Coverage](#fuzzing-and-code-coverage).
+* __Passed all tests__ – v1.5 passed all 375+ tests on amd64, arm64, ppc64le and s390x with linux.
+* __Passed fuzzing__ – v1.5 passed 4.75 billion execs in coverage-guided fuzzing on linux_amd64.
 
 Recent activity:
 
@@ -224,7 +223,7 @@ Over 1,100 files (corpus) are used for fuzzing because it includes fuzz-generate
 ## System Requirements
 
 * Go 1.12 (or newer)
-* amd64, arm64, ppc64le and s390x. Other architectures may also work but they are not tested on each commit. 
+* amd64, arm64, ppc64le and s390x. Other architectures may also work but they are not tested as frequently. 
 
 ## Versions and API Changes
 This project uses [Semantic Versioning](https://semver.org), so the API is always backwards compatible unless the major version number changes.  Newly added API documented as "subject to change" are excluded from this rule.

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ Doing your own comparisons is highly recommended.  Use your most common message 
 Version 1.x has:
 
 * __Stable API__ – won't make breaking API changes except:
-  * CoreDetEncOptions() is subject to change because it uses draft standard not yet approved.
-  * PreferredUnsortedEncOptions() is subject to change because it uses draft standard not yet approved.
-* __Stable requirements__ – will always support Go v1.12 (unless there's compelling reason).
-* __Passed fuzzing__ – Fuzzing for v1.5 passed 2.75+ billion execs and is in progress. v1.4 passed 532+ million execs in coverage-guided fuzzing at the time of release and reached 4+ billion execs 18 days after release.
+  * CoreDetEncOptions() is subject to change because it uses draft standard not yet approved by IETF.
+  * PreferredUnsortedEncOptions() is subject to change because it uses draft standard not yet approved by IETF.
+* __Stable requirements__ – will support Go v1.12 (unless there's compelling reason to require newer).
+* __Passed fuzzing__ – Fuzzing for v1.5 passed 4.75 billion execs in coverage-guided fuzzing on linux_amd64.
 
-Each commit passes 375+ tests. Each release also passes 250+ million execs in coverage-guided fuzzing using 1,100+ CBOR files (corpus). See [Fuzzing and Code Coverage](#fuzzing-and-code-coverage).
+Each commit passes 375+ tests on amd64, arm64, ppc64le and s390x with linux. Each release also passes 250+ million execs in coverage-guided fuzzing using 1,100+ CBOR files (corpus) on linux_amd64. See [Fuzzing and Code Coverage](#fuzzing-and-code-coverage).
 
 Recent activity:
 
@@ -181,6 +181,8 @@ __EncOptions.NaNConvert__:
 
 Float16 conversions use [x448/float16](https://github.com/x448/float16) maintained by the same team as this library.  All 4+ billion possible conversions are verified to be correct in that library.
 
+Go nil values for slices, maps, pointers, etc. are encoded as CBOR null.  Empty slices, maps, etc. are encoded as empty CBOR arrays and maps.
+
 Decoder checks for all required well-formedness errors, including all "subkinds" of syntax errors and too little data.
 
 After well-formedness is verified, basic validity errors are handled as follows:
@@ -199,13 +201,13 @@ Known limitations:
 * Currently, duplicate map keys are not checked during decoding.  Option to handle duplicate map keys in different ways will be added.
 * Nested levels for CBOR arrays, maps, and tags are limited to 32 to quickly reject potentially malicious data.  This limit will be reconsidered upon request.
 * CBOR negative int (type 1) that cannot fit into Go's int64 are not supported, such as RFC 7049 example -18446744073709551616.  Decoding these values returns `cbor.UnmarshalTypeError` like Go's `encoding/json`.
-* CBOR `Undefined` (0xf7) value decodes to Go's `nil` value.  Use CBOR `Null` (0xf6) to round-trip with Go's `nil`.
+* CBOR `Undefined` (0xf7) value decodes to Go's `nil` value.  CBOR `Null` (0xf6) more closely matches Go's `nil`.
 
 Like Go's `encoding/json`, data validation checks the entire message to prevent partially filled (corrupted) data. This library also prevents crashes and resource exhaustion attacks from malicious CBOR data. Use Go's `io.LimitReader` when decoding very large data to limit size.
 
 ## Fuzzing and Code Coverage
 
-__Over 375 tests__ must pass before tagging a release.  They include all RFC 7049 examples, bugs found by fuzzing, 2 maliciously crafted CBOR data, and over 87 tests with malformed data.
+__Over 375 tests__ must pass on 4 architectures before tagging a release.  They include all RFC 7049 examples, bugs found by fuzzing, 2 maliciously crafted CBOR data, and over 87 tests with malformed data.
 
 __Code coverage__ must not fall below 95% when tagging a release.  Code coverage is 97.9% (`go test -cover`) for cbor v1.5 which is among the highest for libraries (in Go) of this type.
 
@@ -222,10 +224,10 @@ Over 1,100 files (corpus) are used for fuzzing because it includes fuzz-generate
 ## System Requirements
 
 * Go 1.12 (or newer)
-* Tested and fuzzed on linux_amd64, but it should work on other little-endian platforms.
+* amd64, arm64, ppc64le and s390x. Other architectures may also work but they are not tested on each commit. 
 
 ## Versions and API Changes
-This project uses [Semantic Versioning](https://semver.org), so the API is always backwards compatible unless the major version number changes.
+This project uses [Semantic Versioning](https://semver.org), so the API is always backwards compatible unless the major version number changes.  Newly added API documented as "subject to change" are excluded from this rule.
 
 ## API 
 The API is the same as `encoding/json` when possible.


### PR DESCRIPTION
Add golangci-lint and use jobs for: build, lint, coverage, and race.