### PR TITLE
Replace codecov.io badge with one that offers more privacy

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -14,7 +14,7 @@
 # 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.  
 # 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
 
-name: cover 97%
+name: cover ≥97%
 on: [push]
 jobs:
 

--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -1,0 +1,33 @@
+# Copyright 2020-present Montgomery Edwards⁴⁴⁸ (github.com/x448).
+# This file is licensed under the MIT License. See LICENSE at https://github.com/x448/workflows for the full text.
+#
+# CI Go Cover 2020.1.28.
+# This GitHub Actions workflow checks if Go (Golang) code coverage satisfies the required minimum.
+# The required minimum is specified in the workflow name to keep badge.svg and verified minimum in sync.
+#
+# To help protect your privacy, this workflow avoids external services.
+# This workflow simply runs `go test -short -cover` --> grep --> python.
+# The python script is embedded and readable in this file.
+# 
+# Steps to install and set minimum required coverage:
+# 0. Copy this file to github.com/OWNER_NAME/REPO_NAME/.github/workflows/ci-go-cover.yml
+# 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.  
+# 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
+
+name: cover 97%
+on: [push]
+jobs:
+
+  # Verify minimum coverage is reached using `go test -short -cover` on latest-ubuntu with default version of Go.
+  # The grep expression can't be too strict, it needed to be relaxed to work with different versions of Go.
+  cover:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Go Coverage
+      run: |
+        go version
+        go test -short -cover | grep "^.*coverage:.*of statements$" | python -c "import os,re,sys; cover_rpt = sys.stdin.read(); print(cover_rpt) if len(cover_rpt) != 0 and len(cover_rpt.splitlines()) == 1 else sys.exit(1); min_cover = float(re.findall(r'\d*\.\d+|\d+', os.environ['GITHUB_WORKFLOW'])[0]); cover = float(re.findall(r'\d*\.\d+|\d+', cover_rpt)[0]); sys.exit(1) if (cover > 100) or (cover < min_cover) else sys.exit(0)"
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
-# GitHub Actions - CI for Go with 3 jobs: lint, tests, and cover.
+# GitHub Actions - CI for Go to build & test.  See ci-go-cover.yml for code coverage.
 # https://github.com/fxamacker/cbor/workflows/ci.yml
-# Original version:
-#   https://github.com/x448/float16/workflows/ci.yml
-#   Author: Montgomery Edwards⁴⁴⁸ (github.com/x448)
-name: CI
+name: ci
 on: [push]
 jobs:
 
@@ -49,23 +46,3 @@ jobs:
       run: |
         go version
         go test -short -race -v ./...
-
-  # Check code coverage on latest-ubuntu with default version of Go.   Using codecov token.
-  cover:
-    name: Coverage
-    needs: [lint]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 2
-    - name: Generate coverprofile
-      run: |
-        go version
-        go test -short -coverprofile=coverage.txt -covermode=atomic ./...
-    - name: Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 # CBOR library in Go
 This is a generic CBOR encoder and decoder.  It can encode integers and floats to their smallest forms (like float16) when values fit.  Each release passes 375+ tests and 250+ million execs fuzzing with 1100+ CBOR files.
 
-![](https://github.com/fxamacker/cbor/workflows/CI/badge.svg)
-[![codecov](https://codecov.io/gh/fxamacker/cbor/branch/master/graph/badge.svg?v=4)](https://codecov.io/gh/fxamacker/cbor)
+[![](https://github.com/fxamacker/cbor/workflows/ci/badge.svg)](https://github.com/fxamacker/cbor/blob/master/.github/workflows/ci.yml)
+[![](https://github.com/fxamacker/cbor/workflows/cover%20%E2%89%A597%25/badge.svg)](https://github.com/fxamacker/cbor/blob/master/.github/workflows/ci-go-cover.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/fxamacker/cbor)](https://goreportcard.com/report/github.com/fxamacker/cbor)
 [![Release](https://img.shields.io/github/release/fxamacker/cbor.svg?style=flat-square)](https://github.com/fxamacker/cbor/releases)
 [![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/fxamacker/cbor/master/LICENSE)


### PR DESCRIPTION
Because:

* their "application will be able to read your organization, team membership, and private project boards."
* their "application will be able to read your private email addresses."

I created ci-go-cover.yml at github.com/x448/workflows to resolve this.  If there's enough demand, I may even improve it to compare coverage since last commit.

After merging, please revoke permission for codecov.io because I thought our conversations on private project boards were more private (limited to GitHub Inc.)