### PR TITLE
Fix API bug introduced in v2.0.0

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -102,7 +102,7 @@ func Unmarshal(data []byte, v interface{}) error {
 // of a CBOR value. UnmarshalCBOR must copy the CBOR data if it wishes to retain
 // the data after returning.
 type Unmarshaler interface {
-	UnmarshalCBOR(DecMode, []byte) error
+	UnmarshalCBOR([]byte) error
 }
 
 // InvalidUnmarshalError describes an invalid argument passed to Unmarshal.
@@ -369,7 +369,7 @@ func (d *decodeState) parseToUnmarshaler(v reflect.Value) error {
 	if u, ok := v.Interface().(Unmarshaler); ok {
 		start := d.off
 		d.skip()
-		return u.UnmarshalCBOR(d.dm, d.data[start:d.off])
+		return u.UnmarshalCBOR(d.data[start:d.off])
 	}
 	d.skip()
 	return errors.New("cbor: failed to assert " + v.Type().String() + " as cbor.Unmarshaler")

--- a/decode_test.go
+++ b/decode_test.go
@@ -1861,14 +1861,14 @@ func TestBinaryMarshalerError(t *testing.T) {
 
 type number2 uint64
 
-func (n number2) MarshalCBOR(em EncMode) (data []byte, err error) {
+func (n number2) MarshalCBOR() (data []byte, err error) {
 	m := map[string]uint64{"num": uint64(n)}
-	return em.Marshal(m)
+	return Marshal(m)
 }
 
-func (n *number2) UnmarshalCBOR(dm DecMode, data []byte) (err error) {
+func (n *number2) UnmarshalCBOR(data []byte) (err error) {
 	var v map[string]uint64
-	if err := dm.Unmarshal(data, &v); err != nil {
+	if err := Unmarshal(data, &v); err != nil {
 		return err
 	}
 	*n = number2(v["num"])
@@ -1879,14 +1879,14 @@ type stru2 struct {
 	a, b, c string
 }
 
-func (s *stru2) MarshalCBOR(em EncMode) ([]byte, error) {
+func (s *stru2) MarshalCBOR() ([]byte, error) {
 	v := []string{s.a, s.b, s.c}
-	return em.Marshal(v)
+	return Marshal(v)
 }
 
-func (s *stru2) UnmarshalCBOR(dm DecMode, data []byte) (err error) {
+func (s *stru2) UnmarshalCBOR(data []byte) (err error) {
 	var v []string
-	if err := dm.Unmarshal(data, &v); err != nil {
+	if err := Unmarshal(data, &v); err != nil {
 		return err
 	}
 	if len(v) > 0 {
@@ -1903,7 +1903,7 @@ func (s *stru2) UnmarshalCBOR(dm DecMode, data []byte) (err error) {
 
 type marshalCBORError string
 
-func (n marshalCBORError) MarshalCBOR(em EncMode) (data []byte, err error) {
+func (n marshalCBORError) MarshalCBOR() (data []byte, err error) {
 	return nil, errors.New(string(n))
 }
 

--- a/encode.go
+++ b/encode.go
@@ -88,7 +88,7 @@ func Marshal(v interface{}) ([]byte, error) {
 // Marshaler is the interface implemented by types that can marshal themselves
 // into valid CBOR.
 type Marshaler interface {
-	MarshalCBOR(EncMode) ([]byte, error)
+	MarshalCBOR() ([]byte, error)
 }
 
 // UnsupportedTypeError is returned by Marshal when attempting to encode an
@@ -1003,7 +1003,7 @@ func encodeMarshalerType(e *encodeState, em *encMode, v reflect.Value) (int, err
 		pv.Elem().Set(v)
 		m = pv.Interface().(Marshaler)
 	}
-	data, err := m.MarshalCBOR(em)
+	data, err := m.MarshalCBOR()
 	if err != nil {
 		return 0, err
 	}

--- a/stream.go
+++ b/stream.go
@@ -179,7 +179,7 @@ func (enc *Encoder) startIndefinite(typ cborType) error {
 type RawMessage []byte
 
 // MarshalCBOR returns m as the CBOR encoding of m.
-func (m RawMessage) MarshalCBOR(em EncMode) ([]byte, error) {
+func (m RawMessage) MarshalCBOR() ([]byte, error) {
 	if len(m) == 0 {
 		return cborNil, nil
 	}
@@ -187,7 +187,7 @@ func (m RawMessage) MarshalCBOR(em EncMode) ([]byte, error) {
 }
 
 // UnmarshalCBOR sets *m to a copy of data.
-func (m *RawMessage) UnmarshalCBOR(dm DecMode, data []byte) error {
+func (m *RawMessage) UnmarshalCBOR(data []byte) error {
 	if m == nil {
 		return errors.New("cbor.RawMessage: UnmarshalCBOR on nil pointer")
 	}


### PR DESCRIPTION
Instead of adding (Un)MarshalerWithMode interfaces, the existing interfaces (Un)Marshaler was replaced by adding an extra parameter.

Fixed this by restoring (Un)Marshaler to the original API.

