### PR TITLE
Update godoc overview to provide short API & usage at a glance

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -15,9 +15,27 @@ Function signatures that are identical to encoding/json include:
     Marshal, Unmarshal, NewEncoder, NewDecoder, encoder.Encode, decoder.Decode.  
 
 Codec functions are available at package-level (default options) or by
-creating modes by using options at runtime.  
+creating modes by using options at runtime.
 
-EncMode and DecMode are interfaces created from EncOptions or DecOptions structs.  For example,
+Default encoding options are listed at https://github.com/fxamacker/cbor#api
+
+EncMode and DecMode Interfaces
+
+    // EncMode interface uses immutable options and is safe for concurrent use.
+    type EncMode interface {
+	Marshal(v interface{}) ([]byte, error)
+	NewEncoder(w io.Writer) *Encoder
+	EncOptions() EncOptions  // returns copy of options
+    }
+
+    // DecMode interface uses immutable options and is safe for concurrent use.
+    type DecMode interface {
+	Unmarshal(data []byte, v interface{}) error
+	NewDecoder(r io.Reader) *Decoder
+	DecOptions() DecOptions  // returns copy of options
+    }
+
+EncMode and DecMode are created from EncOptions or DecOptions structs.  For example,
 
     em := cbor.EncOptions{...}.EncMode()
     em := cbor.CanonicalEncOptions().EncMode()
@@ -70,10 +88,6 @@ Creating and Using Encoding Modes
     // or
     encoder := em.NewEncoder(w)
     err := encoder.Encode(v)
-
-Default Options
-
-Default encoding options are listed at https://github.com/fxamacker/cbor#api
 
 Tests and Fuzzing
 

--- a/cache.go
+++ b/cache.go
@@ -5,10 +5,10 @@
 Package cbor provides a fuzz-tested CBOR encoder and decoder with full support
 for float16, Canonical CBOR, CTAP2 Canonical CBOR, and custom settings.
 
-Encoding options allow "preferred serialization" by encoding integers and floats
+CBOR encoding options allow "preferred serialization" by encoding integers and floats
 to their smallest forms (like float16) when values fit.
 
-Struct tags like "keyasint", "toarray" and "omitempty" makes data size smaller.
+Struct tags like "keyasint", "toarray" and "omitempty" makes CBOR data smaller.
 
 For example, "toarray" makes struct fields encode to array elements.  And "keyasint"
 makes struct fields encode to elements of CBOR map with int keys.

--- a/cache.go
+++ b/cache.go
@@ -8,16 +8,32 @@ for float16, Canonical CBOR, CTAP2 Canonical CBOR, and custom settings.
 Encoding options allow "preferred serialization" by encoding integers and floats
 to their smallest forms (like float16) when values fit.
 
-API Overview
+Struct tags like "keyasint", "toarray" and "omitempty" makes data size smaller.
 
-Function signatures that are identical to encoding/json include:
+For example, "toarray" makes struct fields encode to array elements.  And "keyasint"
+makes struct fields encode to elements of CBOR map with int keys.
+
+Basics
+
+Function signatures identical to encoding/json include:
 
     Marshal, Unmarshal, NewEncoder, NewDecoder, encoder.Encode, decoder.Decode.  
 
-Codec functions are available at package-level (default options) or by
-creating modes from options at runtime.
+Codec functions are available at package-level (using defaults) or by creating modes 
+from options at runtime.
 
-Default encoding options are listed at https://github.com/fxamacker/cbor#api
+"Mode" in this API means definite way of encoding or decoding. Specifically, EncMode or DecMode.
+
+EncMode and DecMode interfaces are created from EncOptions or DecOptions structs.  For example,
+
+    em := cbor.EncOptions{...}.EncMode()
+    em := cbor.CanonicalEncOptions().EncMode()
+    em := cbor.CTAP2EncOptions().EncMode()
+
+Modes use immutable options to avoid side-effects and simplify concurrency. Behavior of modes 
+won't accidentally change at runtime after they're created.  
+
+Modes are intended to be reused and are safe for concurrent use.
 
 EncMode and DecMode Interfaces
 
@@ -34,29 +50,6 @@ EncMode and DecMode Interfaces
 	NewDecoder(r io.Reader) *Decoder
 	DecOptions() DecOptions  // returns copy of options
     }
-
-EncMode and DecMode are created from EncOptions or DecOptions structs.  For example,
-
-    em := cbor.EncOptions{...}.EncMode()
-    em := cbor.CanonicalEncOptions().EncMode()
-    em := cbor.CTAP2EncOptions().EncMode()
-
-EncMode and DecMode use immutable options so their behavior won't accidentally change at runtime.  
-
-Modes are intended to be reused and are safe for concurrent use.
-
-Struct Tags  
-
-Go struct tags like `cbor:"name,omitempty"` and `json:"name,omitempty"` work as expected.
-If both struct tags are specified then `cbor` is used.
-
-Struct tags like "keyasint", "toarray", and "omitempty" make it easy to use
-very compact formats like COSE and CWT (CBOR Web Tokens) with structs.
-
-For example, the "toarray" struct tag encodes/decodes struct fields as array elements.
-And "keyasint" struct tag encodes/decodes struct fields to values of maps with specified int keys.
-
-https://raw.githubusercontent.com/fxamacker/images/master/cbor/v2.0.0/cbor_easy_api.png
 
 Using Default Encoding Mode
 
@@ -88,6 +81,23 @@ Creating and Using Encoding Modes
     // or
     encoder := em.NewEncoder(w)
     err := encoder.Encode(v)
+
+Default Options
+
+Default encoding options are listed at https://github.com/fxamacker/cbor#api
+
+Struct Tags  
+
+Struct tags like `cbor:"name,omitempty"` and `json:"name,omitempty"` work as expected.
+If both struct tags are specified then `cbor` is used.
+
+Struct tags like "keyasint", "toarray", and "omitempty" make it easy to use
+very compact formats like COSE and CWT (CBOR Web Tokens) with structs.
+
+For example, "toarray" makes struct fields encode to array elements.  And "keyasint"
+makes struct fields encode to elements of CBOR map with int keys.
+
+https://raw.githubusercontent.com/fxamacker/images/master/cbor/v2.0.0/cbor_easy_api.png
 
 Tests and Fuzzing
 

--- a/cache.go
+++ b/cache.go
@@ -43,9 +43,16 @@ https://raw.githubusercontent.com/fxamacker/images/master/cbor/v2.0.0/cbor_easy_
 Using Default Encoding Mode
 
     b, err := cbor.Marshal(v)
-    err := cbor.Unmarshal(b, &v)
+    
     encoder := cbor.NewEncoder(w)
+    err = encoder.Encode(v)
+    
+Using Default Decoding Mode
+
+    err := cbor.Unmarshal(b, &v)
+    
     decoder := cbor.NewDecoder(r)
+    err = decoder.Decode(&v)
 
 Creating and Using Encoding Modes
 

--- a/cache.go
+++ b/cache.go
@@ -15,7 +15,7 @@ Function signatures that are identical to encoding/json include:
     Marshal, Unmarshal, NewEncoder, NewDecoder, encoder.Encode, decoder.Decode.  
 
 Codec functions are available at package-level (default options) or by
-creating modes by using options at runtime.
+creating modes from options at runtime.
 
 Default encoding options are listed at https://github.com/fxamacker/cbor#api
 

--- a/cache.go
+++ b/cache.go
@@ -8,6 +8,27 @@ for float16, Canonical CBOR, CTAP2 Canonical CBOR, and custom settings.
 Encoding options allow "preferred serialization" by encoding integers and floats
 to their smallest forms (like float16) when values fit.
 
+API Overview
+
+Function signatures that are identical to encoding/json include:
+
+    Marshal, Unmarshal, NewEncoder, NewDecoder, encoder.Encode, decoder.Decode.  
+
+Codec functions are available at package-level (default options) or by
+creating modes by using options at runtime.  
+
+EncMode and DecMode are interfaces created from EncOptions or DecOptions structs.  For example,
+
+    em := cbor.EncOptions{...}.EncMode()
+    em := cbor.CanonicalEncOptions().EncMode()
+    em := cbor.CTAP2EncOptions().EncMode()
+
+EncMode and DecMode use immutable options so their behavior won't accidentally change at runtime.  
+
+Modes are intended to be reused and are safe for concurrent use.
+
+Struct Tags  
+
 Go struct tags like `cbor:"name,omitempty"` and `json:"name,omitempty"` work as expected.
 If both struct tags are specified then `cbor` is used.
 
@@ -17,7 +38,40 @@ very compact formats like COSE and CWT (CBOR Web Tokens) with structs.
 For example, the "toarray" struct tag encodes/decodes struct fields as array elements.
 And "keyasint" struct tag encodes/decodes struct fields to values of maps with specified int keys.
 
-fxamacker/cbor-fuzz provides coverage-guided fuzzing for this package.
+https://raw.githubusercontent.com/fxamacker/images/master/cbor/v2.0.0/cbor_easy_api.png
+
+Using Default Encoding Mode
+
+    b, err := cbor.Marshal(v)
+    err := cbor.Unmarshal(b, &v)
+    encoder := cbor.NewEncoder(w)
+    decoder := cbor.NewDecoder(r)
+
+Creating and Using Encoding Modes
+
+    // Create EncOptions using either struct literal or a function.
+    opts := cbor.CanonicalEncOptions()
+
+    // If needed, modify encoding options
+    opts.Time = cbor.TimeUnix
+
+    // Create reusable EncMode interface with immutable options, safe for concurrent use.
+    em, err := opts.EncMode()   
+
+    // Use EncMode like encoding/json, with same function signatures.
+    b, err := em.Marshal(v)
+    // or
+    encoder := em.NewEncoder(w)
+    err := encoder.Encode(v)
+
+Default Options
+
+Default encoding options are listed at https://github.com/fxamacker/cbor#api
+
+Tests and Fuzzing
+
+Over 375 tests are included in this package. Cover-guided fuzzing is handled by a separate package: 
+fxamacker/cbor-fuzz.
 */
 package cbor
 


### PR DESCRIPTION
Rewrite overview for godoc.  Only comments were modified at top of file, no coding changes.  Include CBOR encoding example.  This should've been done in v2.0.0 or v2.0.1 but it's better late than never.