### PR TITLE
Update README.md for today's v2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This library is safe and fast. Here's how it compares to another library using t
 
 &nbsp;
 
-Speed is only one factor. There's more important criteria (like not crashing and producing correct results).
+Speed is only one factor. There are more important factors.
 
 |                   | fxamacker/cbor 2.1               |ugorji/go 1.1.7                   |
 |-------------------|----------------------------------|----------------------------------|

--- a/README.md
+++ b/README.md
@@ -653,7 +653,10 @@ Comparisons are between this newer library and a well-known library that had 1,0
 
 __This library is safer__.  Small malicious CBOR messages are rejected quickly before they exhaust system resources.
 
-![alt text](https://github.com/fxamacker/images/raw/master/cbor/v2.1.0/cbor_safety_comparison.png "CBOR library safety comparison")
+|                   | fxamacker/cbor 2.1.0             |ugorji/go 1.1.7                   |
+|-------------------|----------------------------------|----------------------------------|
+|Malformed data #1  | 57.4 ns/op, 32 B/op, 1 allocs/op |⚠️ fatal error: out of memory
+|Malformed data #2  | 67.7 ns/op, 32 B/op, 1 allocs/op |⚠️ runtime: out of memory: cannot allocate
 
 __This library is smaller__. Programs like senmlCat can be 4 MB smaller by switching to this library.  Programs using more complex CBOR data types can be 9.2 MB smaller.
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,16 @@ This library is safe and fast. Here's how it compares to another library using t
 |Encode CWT claims  | 457 ns/op, 176 B/op, 2 allocs/op | 995 ns/op, 1424 B/op, 4 allocs/op
 |Decode CWT claims  | 796 ns/op, 176 B/op,	6 allocs/op | 1105 ns/op, 568 B/op, 6 allocs/op
 
-Speed is just one factor. There's more important criteria (like not crashing and producing correct results).
+&nbsp;
+
+Speed is only one factor. There's more important criteria (like not crashing and producing correct results).
 
 |                   | fxamacker/cbor 2.1               |ugorji/go 1.1.7                   |
 |-------------------|----------------------------------|----------------------------------|
 |Malformed data #1  | 57.4 ns/op, 32 B/op, 1 allocs/op |⚠️ fatal error: out of memory
 |Malformed data #2  | 67.7 ns/op, 32 B/op, 1 allocs/op |⚠️ runtime: out of memory: cannot allocate
+
+&nbsp;
 
 __Why this CBOR library?__ It doesn't crash and it has well-balanced qualities: small, fast, safe and easy. It also has a standard API, CBOR tags (built-in and user-defined), 16/32/64-bit floats, and duplicate map key options.
 
@@ -657,6 +661,8 @@ __This library is safer__.  Small malicious CBOR messages are rejected quickly b
 |-------------------|----------------------------------|----------------------------------|
 |Malformed data #1  | 57.4 ns/op, 32 B/op, 1 allocs/op |⚠️ fatal error: out of memory
 |Malformed data #2  | 67.7 ns/op, 32 B/op, 1 allocs/op |⚠️ runtime: out of memory: cannot allocate
+
+&nbsp;
 
 __This library is smaller__. Programs like senmlCat can be 4 MB smaller by switching to this library.  Programs using more complex CBOR data types can be 9.2 MB smaller.
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,12 @@
 
 __What is CBOR__?  [CBOR](CBOR_GOLANG.md) ([RFC 7049](https://tools.ietf.org/html/rfc7049)) is a binary data format inspired by JSON and MessagePack.  CBOR is used in [IETF](https://www.ietf.org) Internet Standards such as COSE ([RFC 8152](https://tools.ietf.org/html/rfc8152)) and CWT ([RFC 8392 CBOR Web Token](https://tools.ietf.org/html/rfc8392)). WebAuthn also uses CBOR.
 
-This library is safe and fast. Here's how it compares to another library using test data from RFC 8392 A.1.  Benchmarks used Go 1.12, linux_amd64, and default options for each CBOR library.
+This library is safe and fast. Here's how it compares to another library using test data from RFC 8392 A.1.
 
 |                   | fxamacker/cbor 2.1          |ugorji/go 1.1.7                   |
 |-------------------|-----------------------------|----------------------------------|
 |Encode CWT claims  | 457 ns/op, 176 B/op, 2 allocs/op | 995 ns/op, 1424 B/op, 4 allocs/op
 |Decode CWT claims  | 796 ns/op, 176 B/op,	6 allocs/op | 1105 ns/op, 568 B/op, 6 allocs/op
-
-&nbsp;
 
 Speed is only one factor. There are more important factors.
 
@@ -28,7 +26,8 @@ Speed is only one factor. There are more important factors.
 |Malformed data #1  | 57.4 ns/op, 32 B/op, 1 allocs/op |⚠️ fatal error: out of memory
 |Malformed data #2  | 67.7 ns/op, 32 B/op, 1 allocs/op |⚠️ runtime: out of memory: cannot allocate
 
-&nbsp;
+Benchmarks used Go 1.12, linux_amd64, and default options for each CBOR library.
+
 
 __Why this CBOR library?__ It doesn't crash and it has well-balanced qualities: small, fast, safe and easy. It also has a standard API, CBOR tags (built-in and user-defined), 16/32/64-bit floats, and duplicate map key options.
 
@@ -47,9 +46,6 @@ __Why this CBOR library?__ It doesn't crash and it has well-balanced qualities: 
 * __Safe__ and reliable. It prevents crashes on malicious CBOR data by using extensive tests, coverage-guided fuzzing, data validation, and avoiding Go's [`unsafe`](https://golang.org/pkg/unsafe/) pkg. Nested levels for CBOR arrays, maps, and tags are limited to 32.
 
 * __Easy__ and saves time. Simple (no param) functions return preset `EncOptions` so you don't have to know the differences between Canonical CBOR and CTAP2 Canonical CBOR to use those standards.
-
-Modifying EncOptions is also easy.  For example, EncOptions.Time can be set to:  
-`TimeUnix`, `TimeUnixMicro`, `TimeUnixDynamic`, `TimeRFC3339`, or `TimeRFC3339Nano`.
 
 Go struct tags for CBOR and JSON like `` `cbor:"name,omitempty"` `` and `` `json:"name,omitempty"` `` are supported so you can leverage your existing code.  If both `cbor:` and `json:` tags exist then it will use `cbor:`.
 

--- a/README.md
+++ b/README.md
@@ -358,10 +358,8 @@ APF suffix means "Allow Partial Fill" so the destination map or struct can conta
 
 ## Limitations
 
-Known limitations:
-
 * Nested levels for CBOR arrays, maps, and tags are intentionally limited to 32 to quickly reject potentially malicious data.  This limit may be turned into a user-configurable setting in a future release.
-* CBOR negative int (type 1) that cannot fit into Go's int64 are not supported, such as RFC 7049 example -18446744073709551616.  Decoding these values returns `cbor.UnmarshalTypeError` like Go's `encoding/json`. However, this may be resolved in a future release by adding support for `big.Int`. Until then, users can either use custom decoding allowed by the API.
+* CBOR negative int (type 1) that cannot fit into Go's int64 are not supported, such as RFC 7049 example -18446744073709551616.  Decoding these values returns `cbor.UnmarshalTypeError` like Go's `encoding/json`. However, this may be resolved in a future release by adding support for `big.Int`. Until then, users can use the API for custom encoding and decoding.
 * CBOR `Undefined` (0xf7) value decodes to Go's `nil` value.  CBOR `Null` (0xf6) more closely matches Go's `nil`.
 * CBOR map keys with data types not supported by Go for map keys are ignored and an error is returned after continuing to decode remaining items.  
 * When using io.Reader interface to read very large or indefinite length CBOR data, Go's `io.LimitReader` should be used to limit size.

--- a/README.md
+++ b/README.md
@@ -93,13 +93,16 @@ from `"github.com/fxamacker/cbor/v2"` to `"github.com/fxamacker/cbor"`
 Functions with identical signatures to encoding/json include:  
 `Marshal`, `Unmarshal`, `NewEncoder`, `NewDecoder`, `encoder.Encode`, `decoder.Decode`.
 
-__Default Mode of Encoding__  
+__Default Mode__  
 
 If default options are acceptable, package level functions can be used for encoding and decoding.
 ```
 b, err := cbor.Marshal(v)
+
 err := cbor.Unmarshal(b, &v)
+
 encoder := cbor.NewEncoder(w)
+
 decoder := cbor.NewDecoder(r)
 ```
 
@@ -110,7 +113,7 @@ If you need to use options or CBOR tags, then you'll want to create a mode.
 "Mode" means defined way of encoding or decoding -- it links the standard API to your CBOR options and CBOR tags.  This way, you don't pass around options and the API remains identical to `encoding/json`.
 
 EncMode and DecMode are interfaces created from EncOptions or DecOptions structs.  
-For example, `em := cbor.EncOptions{...}.EncMode()` or `em := cbor.CanonicalEncOptions().EncMode()`.
+For example, `em, err := cbor.EncOptions{...}.EncMode()` or `em, err := cbor.CanonicalEncOptions().EncMode()`.
 
 EncMode and DecMode use immutable options so their behavior won't accidentally change at runtime.  Modes are intended to be reused and are safe for concurrent use.
 
@@ -135,39 +138,6 @@ encoder := em.NewEncoder(w)
 err := encoder.Encode(v)
 ```
 
-__Struct Tags (keyasint, toarray, omitempty)__
-
-The `keyasint`, `toarray`, and `omitempty` struct tags make it easy to use compact CBOR message formats.  Internet standards often use CBOR arrays and CBOR maps with int keys to save space.
-
-__API for Default Mode of Encoding & Decoding__
-
-If default options are acceptable, then you don't need to create EncMode or DecMode.
-```
-Marshal(v interface{}) ([]byte, error)
-NewEncoder(w io.Writer) *Encoder
-
-Unmarshal(data []byte, v interface{}) error
-NewDecoder(r io.Reader) *Decoder
-```
-
-__API for Creating & Using Encoding Modes__
-```
-// EncMode interface uses immutable options and is safe for concurrent use.
-type EncMode interface {
-	Marshal(v interface{}) ([]byte, error)
-	NewEncoder(w io.Writer) *Encoder
-	EncOptions() EncOptions  // returns copy of options
-}
-
-// EncOptions specifies encoding options.
-type EncOptions struct {
-...
-}
-
-// EncMode returns an EncMode interface created from EncOptions.
-func (opts EncOptions) EncMode() (EncMode, error) 
-```
-
 __API for Predefined Encoding Options__
 ```
 func CanonicalEncOptions() EncOptions     // settings for RFC 7049 Canonical CBOR
@@ -175,6 +145,10 @@ func CTAP2EncOptions() EncOptions         // settings for FIDO2 CTAP2 Canonical 
 func CoreDetEncOptions() EncOptions       // modern settings from a draft RFC (subject to change)
 func PreferredUnsortedEncOptions() EncOptions  // modern settings from a draft RFC (subject to change)
 ```
+
+__Struct Tags (keyasint, toarray, omitempty)__
+
+The `keyasint`, `toarray`, and `omitempty` struct tags make it easy to use compact CBOR message formats.  Internet standards often use CBOR arrays and CBOR maps with int keys to save space.
 
 See [API](#api), [Options](#options), and [Usage](#usage) sections for more details.
 
@@ -184,12 +158,12 @@ Latest version is v2.x, which has:
 * __Stable API__ –  Six codec function signatures will never change.  No breaking API changes for other funcs in same major version.  And these two functions are subject to change until the draft RFC is approved by IETF (est. in 2020):
   * CoreDetEncOptions() is subject to change because it uses draft standard.
   * PreferredUnsortedEncOptions() is subject to change because it uses draft standard.
-* __Passed all tests__ – v2.0 passed all 375+ tests on amd64, arm64, ppc64le and s390x with linux.
-* __Passed fuzzing__ – v2.0 passed 1+ billion execs in coverage-guided fuzzing on Feb. 2, 2020.
+* __Passed all tests__ – v2.x passed all 375+ tests on amd64, arm64, ppc64le and s390x with linux.
+* __Passed fuzzing__ – v2.1 passed 275+ million execs in coverage-guided fuzzing on Feb 17, 2020 and is still fuzzing.
 
 __Why v2.x?__:
 
-v1 required breaking API changes to support upcoming new features like CBOR tags, detection of duplicate map keys, and having more functions with identical signatures to `encoding/json`.
+v1 required breaking API changes to support new features like CBOR tags, detection of duplicate map keys, and having more functions with identical signatures to `encoding/json`.
 
 v2.1 is roughly 26% faster and uses 57% fewer allocs than v1 when decoding COSE and CWT using default options.
 
@@ -197,9 +171,9 @@ __Roadmap__:
 
 * v2.1 (Feb. 17, 2020) 
    - [x] CBOR tags (major type 6) for encoding and decoding (pushed to master branch)
+   - [x] Decoding options for duplicate map key detection: `DupMapKeyQuiet` (default) and `DupMapKeyEnforcedAPF`
    - [x] Decoding optimizations (pushed to master branch). Structs using keyasint tag (like COSE and CWT) is  
    24-28% faster and 53-61% fewer allocs than v1.5 and v2.0.1.
-   - [x] Options for duplicate map key detection: `DupMapKeyQuiet` (on) and `DupMapKeyEnforcedAPF` (off)
 
 * v2.2
    - [ ] CBOR BSTR <--> Go byte array. In the meantime, use CBOR BSTR with Go byte slice.


### PR DESCRIPTION
CBOR Tags, Duplicate Map Key detection, 26% faster CBOR decoding, 57% fewer allocs, etc.  Add "Quick Start" section. Too many other changes to list.