### PR TITLE
Update README.md for v2.1

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 /*
-Package cbor provides a fuzz-tested CBOR encoder and decoder with full support
-for float16, Canonical CBOR, CTAP2 Canonical CBOR, and custom settings.
+Package cbor is a fast & safe CBOR encoder & decoder (RFC 7049) with a 
+standard API + toarray & keyasint struct tags, CBOR tags, float64->32->16, 
+CTAP2 & Canonical CBOR, duplicate map key options, and is customizable via 
+simple API.
 
 CBOR encoding options allow "preferred serialization" by encoding integers and floats
 to their smallest forms (like float16) when values fit.

--- a/doc.go
+++ b/doc.go
@@ -2,9 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 /*
-Package cbor is a fast & safe CBOR encoder & decoder (RFC 7049) with a 
-standard API + toarray & keyasint struct tags, CBOR tags, float64->32->16, 
-CTAP2 & Canonical CBOR, duplicate map key options, and is customizable via 
+Package cbor is a fast & safe CBOR encoder & decoder (RFC 7049) with a
+standard API + toarray & keyasint struct tags, CBOR tags, float64->32->16,
+CTAP2 & Canonical CBOR, duplicate map key options, and is customizable via
 simple API.
 
 CBOR encoding options allow "preferred serialization" by encoding integers and floats

--- a/example_test.go
+++ b/example_test.go
@@ -454,7 +454,10 @@ func Example_signedCWTWithTag() {
 
 	// Register tag COSE_Sign1 18 with signedCWT type.
 	tags := cbor.NewTagSet()
-	if err := tags.Add(cbor.TagOptions{EncTag: cbor.EncTagRequired, DecTag: cbor.DecTagRequired}, reflect.TypeOf(signedCWT{}), 18); err != nil {
+	if err := tags.Add(
+		cbor.TagOptions{EncTag: cbor.EncTagRequired, DecTag: cbor.DecTagRequired},
+		reflect.TypeOf(signedCWT{}),
+		18); err != nil {
 		fmt.Println("error:", err)
 	}
 


### PR DESCRIPTION
* Add CBOR tags example, "Encoding and Decoding CWT (CBOR Web Token) with CBOR Tags".
* v2.1 passed 361+ million execs in coverage-guided fuzzing on Feb 17, 2020.