### PR TITLE
Update ci-go-cover.yml to bump min coverage to 98% for v2.1

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -14,7 +14,7 @@
 # 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.  
 # 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
 
-name: cover ≥97%
+name: cover ≥98%
 on: [push]
 jobs:
 


### PR DESCRIPTION
Since `go test -cover` reports 98.5% (it was 97.9% in v2.0), lets bump this up to 98% for v2.1.

New CBOR features like CBOR tags and detection of duplicate map keys were 100% coverage (or near it) so it boosted overall coverage.