### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,13 +349,13 @@ Integers always encode to the shortest form that preserves value.  By default, t
 
 Encoding of other data types and map key sort order are determined by encoder options.
 
-![alt text](https://github.com/fxamacker/images/raw/master/cbor/v2.2.0/cbor_encoptions.svg?sanitize=1) "CBOR Encoding Options")
+![alt text](https://github.com/fxamacker/images/raw/master/cbor/v2.2.0/cbor_encoptions.svg?sanitize=1 "CBOR Encoding Options")
 
 See [Options](#options) section for details about each setting.
 
 ### Decoding Options
 
-![alt text](https://github.com/fxamacker/images/raw/master/cbor/v2.2.0/cbor_decoptions.svg?sanitize=1) "CBOR Decoding Options")
+![alt text](https://github.com/fxamacker/images/raw/master/cbor/v2.2.0/cbor_decoptions.svg?sanitize=1 "CBOR Decoding Options")
 
 See [Options](#options) section for details about each setting.
 


### PR DESCRIPTION
Remove extra parenthesis from svg link that caused alt text to appear.