### PR TITLE
Update linters.yml

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,9 +13,8 @@ jobs:
     - name: Install golangci-lint 
       run: |
         go version
-        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
+        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
     - name: Run required linters in .golangci.yml plus hard-coded ones here
-      run: $(go env GOPATH)/bin/golangci-lint run --timeout=5m -E deadcode -E errcheck -E gofmt -E golint -E gosec -E govet -E ineffassign -E maligned -E staticcheck -E structcheck -E unconvert -E varcheck
+      run: $(go env GOPATH)/bin/golangci-lint run --timeout=3m
     - name: Run optional linters (not required to pass)
-      run: $(go env GOPATH)/bin/golangci-lint run --timeout=5m --issues-exit-code=0 -E dupl -E gocritic -E gosimple -E lll -E prealloc -E deadcode -E errcheck -E gofmt -E golint -E gosec -E govet -E ineffassign -E maligned -E staticcheck -E structcheck -E unconvert -E varcheck
-
+      run: $(go env GOPATH)/bin/golangci-lint run --timeout=3m --issues-exit-code=0 -E dupl -E gocritic -E gosimple -E lll -E prealloc


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

#### Description (motivation)

ubuntu-latest image started to use Go 1.14 now, which broke CI linters.

Fix this by bumping golangci-lint from 1.23.1 to 1.23.8.  Also cleanup parameters passed to golangci-lint by removing params already specified in separate config file.

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->
