### PR TITLE
Update example_test.go

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/fxamacker/cbor/v2"
+	"github.com/fxamacker/cbor/v2" // remove "/v2" suffix if you're not using Go modules (see README.md)
 )
 
 func ExampleMarshal() {


### PR DESCRIPTION
Added comment to remove "/v2" suffix when not using Go modules.


