### PR TITLE
Increase MaxArrayElements and MaxMapPairs max limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,13 +696,13 @@ Go's `time` package provides `IsZero` function, which reports whether t represen
 
 | DecOptions.MaxArrayElements | Description |
 | --------------------------- | ----------- |
-| 131072 (default) | allowed setting is [16, 134217728] |
+| 131072 (default) | allowed setting is [16, 2147483647] |
 
 <br>
 
 | DecOptions.MaxMapPairs | Description |
 | ---------------------- | ----------- |
-| 131072 (default) | allowed setting is [16, 134217728] |
+| 131072 (default) | allowed setting is [16, 2147483647] |
 
 ### Encoding Options
 

--- a/decode.go
+++ b/decode.go
@@ -269,11 +269,11 @@ type DecOptions struct {
 	MaxNestedLevels int
 
 	// MaxArrayElements specifies the max number of elements for CBOR arrays.
-	// Default is 128*1024=131072 and it can be set to [16, 134217728]
+	// Default is 128*1024=131072 and it can be set to [16, 2147483647]
 	MaxArrayElements int
 
 	// MaxMapPairs specifies the max number of key-value pairs for CBOR maps.
-	// Default is 128*1024=131072 and it can be set to [16, 134217728]
+	// Default is 128*1024=131072 and it can be set to [16, 2147483647]
 	MaxMapPairs int
 
 	// IndefLength specifies whether to allow indefinite length CBOR items.
@@ -347,11 +347,11 @@ func (opts DecOptions) DecModeWithSharedTags(tags TagSet) (DecMode, error) {
 const (
 	defaultMaxArrayElements = 131072
 	minMaxArrayElements     = 16
-	maxMaxArrayElements     = 134217728
+	maxMaxArrayElements     = 2147483647
 
 	defaultMaxMapPairs = 131072
 	minMaxMapPairs     = 16
-	maxMaxMapPairs     = 134217728
+	maxMaxMapPairs     = 2147483647
 )
 
 func (opts DecOptions) decMode() (*decMode, error) {

--- a/decode_test.go
+++ b/decode_test.go
@@ -3068,12 +3068,12 @@ func TestDecModeInvalidMaxMapPairs(t *testing.T) {
 		{
 			name:         "MaxMapPairs < 16",
 			opts:         DecOptions{MaxMapPairs: 1},
-			wantErrorMsg: "cbor: invalid MaxMapPairs 1 (range is [16, 134217728])",
+			wantErrorMsg: "cbor: invalid MaxMapPairs 1 (range is [16, 2147483647])",
 		},
 		{
-			name:         "MaxMapPairs > 134217728",
-			opts:         DecOptions{MaxMapPairs: 134217729},
-			wantErrorMsg: "cbor: invalid MaxMapPairs 134217729 (range is [16, 134217728])",
+			name:         "MaxMapPairs > 2147483647",
+			opts:         DecOptions{MaxMapPairs: 2147483648},
+			wantErrorMsg: "cbor: invalid MaxMapPairs 2147483648 (range is [16, 2147483647])",
 		},
 	}
 	for _, tc := range testCases {
@@ -3109,12 +3109,12 @@ func TestDecModeInvalidMaxArrayElements(t *testing.T) {
 		{
 			name:         "MaxArrayElements < 16",
 			opts:         DecOptions{MaxArrayElements: 1},
-			wantErrorMsg: "cbor: invalid MaxArrayElements 1 (range is [16, 134217728])",
+			wantErrorMsg: "cbor: invalid MaxArrayElements 1 (range is [16, 2147483647])",
 		},
 		{
-			name:         "MaxArrayElements > 134217728",
-			opts:         DecOptions{MaxArrayElements: 134217729},
-			wantErrorMsg: "cbor: invalid MaxArrayElements 134217729 (range is [16, 134217728])",
+			name:         "MaxArrayElements > 2147483647",
+			opts:         DecOptions{MaxArrayElements: 2147483648},
+			wantErrorMsg: "cbor: invalid MaxArrayElements 2147483648 (range is [16, 2147483647])",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Increased MaxArrayElements and MaxMapPairs max limits from 134217728 to 2147483647.

Default limits are unchanged.

Closes #207

