### PR TITLE
Strip CBOR tag number 55799 when it is a prefix

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -249,6 +249,9 @@ func newTagItem(opts TagOptions, contentType reflect.Type, num uint64, nestedNum
 	if num == 0 || num == 1 {
 		return nil, errors.New("cbor: cannot add tag number 0 or 1 to TagSet, use EncOptions.TimeTag and DecOptions.TimeTag instead")
 	}
+	if num == selfDescribedCBORTagNum {
+		return nil, errors.New("cbor: cannot add tag number 55799 to TagSet, it's built-in and ignored automatically")
+	}
 	//if reflect.PtrTo(contentType).Implements(typeMarshaler) && opts.EncTag != EncTagNone {
 	//return nil, errors.New("cbor: cannot add cbor.Marshaler to TagSet with EncTag != EncTagNone")
 	//}

--- a/tag_test.go
+++ b/tag_test.go
@@ -363,6 +363,13 @@ func TestAddTagError(t *testing.T) {
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: cannot add tag number 0 or 1 to TagSet, use EncOptions.TimeTag and DecOptions.TimeTag instead",
 		},
+		{
+			name:         "tag number 55799",
+			typ:          reflect.TypeOf(myInt(0)),
+			num:          55799,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
+			wantErrorMsg: "cbor: cannot add tag number 55799 to TagSet, it's built-in and ignored automatically",
+		},
 	}
 	tags := NewTagSet()
 	for _, tc := range testCases {
@@ -1252,7 +1259,11 @@ func (n *number3) UnmarshalCBOR(data []byte) (err error) {
 	}
 
 	if rawTag.Number != 100 {
-		return fmt.Errorf("wrong tag number %d, want %d", rawTag.Number, 101)
+		return fmt.Errorf("wrong tag number %d, want %d", rawTag.Number, 100)
+	}
+
+	if rawTag.Content[0]&0xe0 != 0xa0 {
+		return fmt.Errorf("wrong tag content type, want map")
 	}
 
 	var v map[string]uint64


### PR DESCRIPTION
Tag number 55799 is normally prefixed to data to indicate that it is CBOR encoded.

This library strips tag number 55799 (when it is a prefix) to provide the same decoding behavior as if CBOR data is not tagged.

* When decoding to empty interface or other Go types, tag number 55799 is skipped and tag content is decoded.

* When decoding to Unmarshaler, tag number 55799 is skipped and only the tag content is provided to UnmarshalCBOR.

Closes #228

