### PR TITLE
Update README and LICENSE to add Go's copyright and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - present Faye Amacker
+Copyright (c) 2019-present Faye Amacker
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,33 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+Portions (from Go) Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1071,9 +1071,11 @@ __Words of encouragement and support__
 
 
 ## License 
-Copyright © 2019-present [Faye Amacker](https://github.com/fxamacker).
+Copyright © 2019-present [Faye Amacker](https://github.com/fxamacker).  
+Portions (from [Go](https://github.com/golang/go)) Copyright © 2009 The Go Authors.
 
-fxamacker/cbor is licensed under the MIT License.  See [LICENSE](LICENSE) for the full license text.
+fxamacker/cbor is licensed under the MIT License.  See [LICENSE](LICENSE) for the full license text.  
+[Go](https://github.com/golang/go) is licensed under BSD-style license.  See [LICENSE](LICENSE) for the full license text.
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![](https://github.com/fxamacker/cbor/workflows/linters/badge.svg)](https://github.com/fxamacker/cbor/actions?query=workflow%3Alinters)
 [![Go Report Card](https://goreportcard.com/badge/github.com/fxamacker/cbor)](https://goreportcard.com/report/github.com/fxamacker/cbor)
 [![](https://github.com/fxamacker/images/raw/master/cbor/v2.2.0/release_version_badge.svg?sanitize=1)](https://github.com/fxamacker/cbor/releases)
-[![](https://github.com/fxamacker/images/raw/master/cbor/v2.2.0/license_badge.svg?sanitize=1)](https://raw.githubusercontent.com/fxamacker/cbor/master/LICENSE)
+<!--[![](https://github.com/fxamacker/images/raw/master/cbor/v2.2.0/license_badge.svg?sanitize=1)](https://raw.githubusercontent.com/fxamacker/cbor/master/LICENSE)-->
 
 __fxamacker/cbor__ is secure.  It rejects malformed CBOR data, can detect duplicate map keys, and more.
 
@@ -1077,6 +1077,7 @@ Portions (from [Go](https://github.com/golang/go)) Copyright © 2009 The Go Auth
 fxamacker/cbor is licensed under the MIT License.  See [LICENSE](LICENSE) for the full license text.  
 [Go](https://github.com/golang/go) is licensed under BSD-style license.  See [LICENSE](LICENSE) for the full license text.
 
+This library contains a small amount of code from the [Go](https://github.com/golang/go) standard library.
 <hr>
 
 ⚓  [Quick Start](#quick-start) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Options](#options) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [License](#license)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

#### Description (motivation)

This library includes a small amount of code from Go's standard library, which is covered by Go's BSD-style license.  Close #234. 

Update README to add:

- [x]  "Portions (from Go) Copyright © 2009 The Go Authors"
- [x]  "Go is licensed under BSD-style license.  See LICENSE for the full license text."
- [x]  "This library contains a small amount of code from the Go standard library."
- [x]  Remove license badge to avoid potential confusion

Update LICENSE to append:

- [x] "---" separator and line break after the existing MIT license
- [x] "Portions (from Go) " without line break
- [x] full content of Go's BSD-style license

This change will break Github's automatic license detection because the LICENSE file will contain MIT and BSD-style licenses.

### Next Steps After Merging This

I'm not a lawyer so I'm merely speculating you'll need to modify each relevant source code file to add Go's copyright notice prefixed with "Portions ".  Something like this:

```
This file contains some code from the Go standard library.

Portions (from Go) Copyright (c) 2009 The Go Authors.  Use of Go's source code
is governed by a BSD-style license.  See LICENSE for the full text of the license.
```

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->
