### PR TITLE
Include Go's copyright notice to 2 files

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -1,6 +1,11 @@
 // Copyright (c) Faye Amacker. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+// This file contains some code from the Go standard library.
+
+// Portions (from Go) Copyright (c) 2009 The Go Authors.  Use of Go's source code
+// is governed by a BSD-style license.  See LICENSE for the full text of the license.
+
 package cbor
 
 import (
@@ -1326,6 +1331,8 @@ func getEncodeIndirectValueFunc(t reflect.Type) encodeFunc {
 	}
 }
 
+// isEmptyValue returns true if v has zero value for its type.
+// isEmptyValue was copied from stdlib's encoding/json/encode.go.
 func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:

--- a/structfields.go
+++ b/structfields.go
@@ -1,6 +1,11 @@
 // Copyright (c) Faye Amacker. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+// This file contains some code from the Go standard library.
+
+// Portions (from Go) Copyright (c) 2009 The Go Authors.  Use of Go's source code
+// is governed by a BSD-style license.  See LICENSE for the full text of the license.
+
 package cbor
 
 import (


### PR DESCRIPTION
Two files contain a small amount of code from the Go standard library.

Add Go's copyright notice to 2 files:
- encode.go
- structfileds.go

Updates issue #233, #234

