### PR TITLE
Refactor and remove Go's copyright notice in 1 file

### DIFF
--- a/structfields.go
+++ b/structfields.go
@@ -1,11 +1,6 @@
 // Copyright (c) Faye Amacker. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-// This file contains some code from the Go standard library.
-
-// Portions (from Go) Copyright (c) 2009 The Go Authors.  Use of Go's source code
-// is governed by a BSD-style license.  See LICENSE for the full text of the license.
-
 package cbor
 
 import (
@@ -43,15 +38,8 @@ func (x *indexFieldSorter) Swap(i, j int) {
 }
 
 func (x *indexFieldSorter) Less(i, j int) bool {
-	iIdx := x.fields[i].idx
-	jIdx := x.fields[j].idx
-
-	minLen := len(iIdx)
-	if len(jIdx) < minLen {
-		minLen = len(jIdx)
-	}
-
-	for k := 0; k < minLen; k++ {
+	iIdx, jIdx := x.fields[i].idx, x.fields[j].idx
+	for k := 0; k < len(iIdx) && k < len(jIdx); k++ {
 		if iIdx[k] != jIdx[k] {
 			return iIdx[k] < jIdx[k]
 		}
@@ -73,99 +61,54 @@ func (x *nameLevelAndTagFieldSorter) Swap(i, j int) {
 }
 
 func (x *nameLevelAndTagFieldSorter) Less(i, j int) bool {
-	if x.fields[i].name != x.fields[j].name {
-		return x.fields[i].name < x.fields[j].name
+	fi, fj := x.fields[i], x.fields[j]
+	if fi.name != fj.name {
+		return fi.name < fj.name
 	}
-	if len(x.fields[i].idx) != len(x.fields[j].idx) {
-		return len(x.fields[i].idx) < len(x.fields[j].idx)
+	if len(fi.idx) != len(fj.idx) {
+		return len(fi.idx) < len(fj.idx)
 	}
-	if x.fields[i].tagged != x.fields[j].tagged {
-		return x.fields[i].tagged
+	if fi.tagged != fj.tagged {
+		return fi.tagged
 	}
 	return i < j // Field i and j have the same name, depth, and tagged status. Nothing else matters.
 }
 
-// getFields returns a list of visible fields of struct type typ following Go
-// visibility rules for struct fields.
-func getFields(typ reflect.Type) (flds fields, structOptions string) {
-	// Inspired by typeFields() in stdlib's encoding/json/encode.go.
+// getFields returns visible fields of struct type t following visibility rules for JSON encoding.
+func getFields(t reflect.Type) (flds fields, structOptions string) {
+	// Get special field "_" tag options
+	if f, ok := t.FieldByName("_"); ok {
+		tag := f.Tag.Get("cbor")
+		if tag != "-" {
+			structOptions = tag
+		}
+	}
 
-	var current map[reflect.Type][][]int // key: struct type, value: field index of this struct type at the same level
-	next := map[reflect.Type][][]int{typ: nil}
-	visited := map[reflect.Type]bool{} // Inspected struct type at less nested levels.
+	// nTypes contains next level anonymous fields' types and indexes
+	// (there can be multiple fields of the same type at the same level)
+	flds, nTypes := appendFields(t, nil, nil, nil)
 
-	for len(next) > 0 {
-		current, next = next, map[reflect.Type][][]int{}
+	if len(nTypes) > 0 {
 
-		for structType, structIdx := range current {
-			if len(structIdx) > 1 {
-				continue // Fields of the same embedded struct type at the same level are ignored.
-			}
+		var cTypes map[reflect.Type][][]int      // current level anonymous fields' types and indexes
+		vTypes := map[reflect.Type]bool{t: true} // visited field types at less nested levels
 
-			if visited[structType] {
-				continue
-			}
-			visited[structType] = true
+		for len(nTypes) > 0 {
+			cTypes, nTypes = nTypes, nil
 
-			var fieldIdx []int
-			if len(structIdx) > 0 {
-				fieldIdx = structIdx[0]
-			}
-
-			for i := 0; i < structType.NumField(); i++ {
-				f := structType.Field(i)
-				ft := f.Type
-
-				if ft.Kind() == reflect.Ptr {
-					ft = ft.Elem()
-				}
-
-				exportable := f.PkgPath == ""
-				if f.Anonymous {
-					if !exportable && ft.Kind() != reflect.Struct {
-						// Nonexportable anonymous fields of non-struct type are ignored.
-						continue
-					}
-					// Nonexportable anonymous field of struct type can contain exportable fields for serialization.
-				} else if !exportable {
-					// Get special field "_" struct options
-					if f.Name == "_" {
-						tag := f.Tag.Get("cbor")
-						if tag != "-" {
-							structOptions = tag
-						}
-					}
-					// Nonexportable fields are ignored.
+			for t, idx := range cTypes {
+				// If there are multiple anonymous fields of the same struct type at the same level, all are ignored.
+				if len(idx) > 1 {
 					continue
 				}
 
-				tag := f.Tag.Get("cbor")
-				if tag == "" {
-					tag = f.Tag.Get("json")
-				}
-				if tag == "-" {
+				// Anonymous field of the same type at deeper nested level is ignored.
+				if vTypes[t] {
 					continue
 				}
+				vTypes[t] = true
 
-				idx := make([]int, len(fieldIdx)+1)
-				copy(idx, fieldIdx)
-				idx[len(fieldIdx)] = i
-
-				tagged := len(tag) > 0
-				tagFieldName, omitempty, keyasint := getFieldNameAndOptionsFromTag(tag)
-
-				fieldName := tagFieldName
-				if tagFieldName == "" {
-					fieldName = f.Name
-				}
-
-				if !f.Anonymous || ft.Kind() != reflect.Struct || len(tagFieldName) > 0 {
-					flds = append(flds, &field{name: fieldName, idx: idx, typ: f.Type, tagged: tagged, omitEmpty: omitempty, keyAsInt: keyasint})
-					continue
-				}
-
-				// f is anonymous struct of type ft.
-				next[ft] = append(next[ft], idx)
+				flds, nTypes = appendFields(t, idx[0], flds, nTypes)
 			}
 		}
 	}
@@ -173,45 +116,112 @@ func getFields(typ reflect.Type) (flds fields, structOptions string) {
 	sort.Sort(&nameLevelAndTagFieldSorter{flds})
 
 	// Keep visible fields.
-	visibleFields := flds[:0]
-	for i, j := 0, 0; i < len(flds); i = j {
+	j := 0 // index of next unique field
+	for i := 0; i < len(flds); {
 		name := flds[i].name
-		for j = i + 1; j < len(flds) && flds[j].name == name; j++ {
+		if i == len(flds)-1 || // last field
+			name != flds[i+1].name || // field i has unique field name
+			len(flds[i].idx) < len(flds[i+1].idx) || // field i is at a less nested level than field i+1
+			(flds[i].tagged && !flds[i+1].tagged) { // field i is tagged while field i+1 is not
+			flds[j] = flds[i]
+			j++
 		}
-		if j-i == 1 || len(flds[i].idx) < len(flds[i+1].idx) || (flds[i].tagged && !flds[i+1].tagged) {
-			// Keep the field if the field name is unique, or if the first field
-			// is at a less nested level, or if the first field is tagged and
-			// the second field is not.
-			visibleFields = append(visibleFields, flds[i])
+
+		// Skip fields with the same field name.
+		for i++; i < len(flds) && name == flds[i].name; i++ {
 		}
 	}
+	if j != len(flds) {
+		flds = flds[:j]
+	}
 
-	sort.Sort(&indexFieldSorter{visibleFields})
+	// Sort fields by field index
+	sort.Sort(&indexFieldSorter{flds})
 
-	return visibleFields, structOptions
+	return flds, structOptions
 }
 
-func getFieldNameAndOptionsFromTag(tag string) (name string, omitEmpty bool, keyAsInt bool) {
-	if tag == "" {
-		return
+// appendFields appends type t's exportable fields to flds and anonymous struct fields to nTypes .
+func appendFields(t reflect.Type, idx []int, flds fields, nTypes map[reflect.Type][][]int) (fields, map[reflect.Type][][]int) {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+
+		ft := f.Type
+		for ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+
+		if !isFieldExportable(f, ft.Kind()) {
+			continue
+		}
+
+		tag := f.Tag.Get("cbor")
+		if tag == "" {
+			tag = f.Tag.Get("json")
+		}
+		if tag == "-" {
+			continue
+		}
+
+		tagged := len(tag) > 0
+
+		// Parse field tag options
+		var tagFieldName string
+		var omitempty, keyasint bool
+		for i := 0; len(tag) > 0; i++ {
+			var token string
+			idx := strings.IndexByte(tag, ',')
+			if idx == -1 {
+				token, tag = tag, ""
+			} else {
+				token, tag = tag[:idx], tag[idx+1:]
+			}
+			if i == 0 {
+				tagFieldName = token
+			} else {
+				switch token {
+				case "omitempty":
+					omitempty = true
+				case "keyasint":
+					keyasint = true
+				}
+			}
+		}
+
+		fieldName := tagFieldName
+		if tagFieldName == "" {
+			fieldName = f.Name
+		}
+
+		fIdx := make([]int, len(idx)+1)
+		copy(fIdx, idx)
+		fIdx[len(fIdx)-1] = i
+
+		if !f.Anonymous || ft.Kind() != reflect.Struct || len(tagFieldName) > 0 {
+			flds = append(flds, &field{
+				name:      fieldName,
+				idx:       fIdx,
+				typ:       f.Type,
+				omitEmpty: omitempty,
+				keyAsInt:  keyasint,
+				tagged:    tagged})
+		} else {
+			if nTypes == nil {
+				nTypes = make(map[reflect.Type][][]int)
+			}
+			nTypes[ft] = append(nTypes[ft], fIdx)
+		}
 	}
-	idx := strings.Index(tag, ",")
-	if idx == -1 {
-		return tag, false, false
-	}
-	if idx > 0 {
-		name = tag[:idx]
-		tag = tag[idx:]
-	}
-	s := ",omitempty"
-	if idx = strings.Index(tag, s); idx >= 0 && (len(tag) == idx+len(s) || tag[idx+len(s)] == ',') {
-		omitEmpty = true
-	}
-	s = ",keyasint"
-	if idx = strings.Index(tag, s); idx >= 0 && (len(tag) == idx+len(s) || tag[idx+len(s)] == ',') {
-		keyAsInt = true
-	}
-	return
+
+	return flds, nTypes
+}
+
+// isFieldExportable returns true if f is an exportable (regular or anonymous) field or
+// a nonexportable anonymous field of struct type.
+// Nonexportable anonymous field of struct type can contain exportable fields.
+func isFieldExportable(f reflect.StructField, fk reflect.Kind) bool {
+	exportable := f.PkgPath == ""
+	return exportable || (f.Anonymous && fk == reflect.Struct)
 }
 
 type embeddedFieldNullPtrFunc func(reflect.Value) (reflect.Value, error)

--- a/structfields.go
+++ b/structfields.go
@@ -168,7 +168,7 @@ func appendFields(t reflect.Type, idx []int, flds fields, nTypes map[reflect.Typ
 		// Parse field tag options
 		var tagFieldName string
 		var omitempty, keyasint bool
-		for i := 0; len(tag) > 0; i++ {
+		for j := 0; len(tag) > 0; j++ {
 			var token string
 			idx := strings.IndexByte(tag, ',')
 			if idx == -1 {
@@ -176,7 +176,7 @@ func appendFields(t reflect.Type, idx []int, flds fields, nTypes map[reflect.Typ
 			} else {
 				token, tag = tag[:idx], tag[idx+1:]
 			}
-			if i == 0 {
+			if j == 0 {
 				tagFieldName = token
 			} else {
 				switch token {


### PR DESCRIPTION
Refactored getFields and other functions.

Removed Go's copyright notice in structfields.go.