### PR TITLE
Perform no-op when decoding null to cbor.(Raw)Tag

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -742,6 +742,12 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 }
 
 func (d *decoder) parseToTag(v reflect.Value) error {
+	if d.nextCBORNil() {
+		// Decoding CBOR null and undefined to cbor.Tag is no-op.
+		d.skip()
+		return nil
+	}
+
 	t := d.nextCBORType()
 	if t != cborTypeTag {
 		d.skip()

--- a/tag.go
+++ b/tag.go
@@ -26,6 +26,11 @@ func (t *RawTag) UnmarshalCBOR(data []byte) error {
 		return errors.New("cbor.RawTag: UnmarshalCBOR on nil pointer")
 	}
 
+	// Decoding CBOR null and undefined to cbor.RawTag is no-op.
+	if len(data) == 1 && (data[0] == 0xf6 || data[0] == 0xf7) {
+		return nil
+	}
+
 	d := decoder{data: data, dm: defaultDecMode}
 
 	// Unmarshal tag number.


### PR DESCRIPTION
Decoding CBOR null (0xf6) and undefined (0xf7) to cbor.Tag or cbor.RawTag has no effect and returns no error.

See Unmarshal documentation.

Closes #252