### PR TITLE
Fix encoding cbor.RawTag with empty content

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -60,9 +60,14 @@ func (t RawTag) MarshalCBOR() ([]byte, error) {
 
 	encodeHead(e, byte(cborTypeTag), t.Number)
 
-	buf := make([]byte, len(e.Bytes())+len(t.Content))
+	content := t.Content
+	if len(content) == 0 {
+		content = cborNil
+	}
+
+	buf := make([]byte, len(e.Bytes())+len(content))
 	n := copy(buf, e.Bytes())
-	copy(buf[n:], t.Content)
+	copy(buf[n:], content)
 
 	putEncoderBuffer(e)
 	return buf, nil

--- a/tag_test.go
+++ b/tag_test.go
@@ -1215,6 +1215,30 @@ func TestMarshalUninitializedRawTag(t *testing.T) {
 	}
 }
 
+func TestMarshalTagWithEmptyContent(t *testing.T) {
+	v := Tag{Number: 100}       // Tag.Content is empty
+	want := hexDecode("d864f6") // 100(null)
+	b, err := Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", v, err)
+	}
+	if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, want)
+	}
+}
+
+func TestMarshalRawTagWithEmptyContent(t *testing.T) {
+	v := RawTag{Number: 100}    // RawTag.Content is empty
+	want := hexDecode("d864f6") // 100(null)
+	b, err := Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", v, err)
+	}
+	if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, want)
+	}
+}
+
 func TestEncodeTag(t *testing.T) {
 	m := make(map[interface{}]bool)
 	m[10] = true


### PR DESCRIPTION
Encoding cbor.RawTag with empty content returns CBOR representation of tag_number(null).

Closes #258

