### PR TITLE
Add stream encoding for CBOR array and tag

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -86,6 +86,7 @@ type Encoder struct {
 	em         *encMode
 	e          *encoderBuffer
 	indefTypes []cborType
+	stream     bool
 }
 
 // NewEncoder returns a new encoder that writes to w using the default encoding options.
@@ -112,10 +113,10 @@ func (enc *Encoder) Encode(v interface{}) error {
 	}
 
 	err := encode(enc.e, enc.em, reflect.ValueOf(v))
-	if err == nil {
+	if err == nil && !enc.stream {
 		_, err = enc.e.WriteTo(enc.w)
+		enc.e.Reset()
 	}
-	enc.e.Reset()
 	return err
 }
 

--- a/stream_encode.go
+++ b/stream_encode.go
@@ -1,0 +1,40 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import "io"
+
+// StreamEncoder provides low-level API for sequential encoding.
+//
+// Users of StreamEncoder should be familiar with CBOR data models.
+// When in doubt, please use Encoder instead.
+//
+// IMPORTANT: Use Valid() to check whether generated CBOR data is
+// complete and well-formed.
+type StreamEncoder struct {
+	*Encoder
+}
+
+// NewStreamEncoder returns a new StreamEncoder for sequential encoding.
+func NewStreamEncoder(w io.Writer) *StreamEncoder {
+	enc := defaultEncMode.NewEncoder(w)
+	enc.stream = true
+	return &StreamEncoder{enc}
+}
+
+// Flush writes streamed data to underlying io.Writer.
+func (se *StreamEncoder) Flush() error {
+	_, err := se.Encoder.e.WriteTo(se.Encoder.w)
+	return err
+}
+
+// EncodeArrayHead encodes CBOR array head of specified size.
+func (se *StreamEncoder) EncodeArrayHead(size uint64) {
+	encodeHead(se.Encoder.e, byte(cborTypeArray), size)
+}
+
+// EncodeTagHead encodes CBOR tag head with num as tag number.
+func (se *StreamEncoder) EncodeTagHead(num uint64) {
+	encodeHead(se.Encoder.e, byte(cborTypeTag), num)
+}

--- a/stream_encode_test.go
+++ b/stream_encode_test.go
@@ -25,16 +25,27 @@ func TestStreamEncodeArray(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-
 		se := NewStreamEncoder(&buf)
+
 		se.EncodeArrayHead(2)
-		se.Encode("hello")
+
+		err := se.Encode("hello")
+		if err != nil {
+			t.Errorf("StreamEncoder.Encode() returned error %v", err)
+		}
+
 		se.EncodeArrayHead(1)
-		se.Encode(big.NewInt(1))
-		err := se.Flush()
+
+		err = se.Encode(big.NewInt(1))
+		if err != nil {
+			t.Errorf("StreamEncoder.Encode() returned error %v", err)
+		}
+
+		err = se.Flush()
 		if err != nil {
 			t.Errorf("StreamEncoder.Flush() returned error %v", err)
 		}
+
 		if !bytes.Equal(buf.Bytes(), expected) {
 			t.Errorf("StreamEncoder encoded 0x%x, want 0x%x", buf.Bytes(), expected)
 		}
@@ -57,23 +68,34 @@ func TestStreamEncodeArray(t *testing.T) {
 			0x01,
 		}
 
-		var buf bytes.Buffer
-
 		opts := EncOptions{BigIntConvert: BigIntConvertNone}
 		em, err := opts.encMode()
 		if err != nil {
 			panic(err)
 		}
 
+		var buf bytes.Buffer
 		se := em.NewStreamEncoder(&buf)
+
 		se.EncodeArrayHead(2)
-		se.Encode("hello")
+
+		err = se.Encode("hello")
+		if err != nil {
+			t.Errorf("StreamEncoder.Encode() returned error %v", err)
+		}
+
 		se.EncodeArrayHead(1)
-		se.Encode(big.NewInt(1))
+
+		err = se.Encode(big.NewInt(1))
+		if err != nil {
+			t.Errorf("StreamEncoder.Encode() returned error %v", err)
+		}
+
 		err = se.Flush()
 		if err != nil {
 			t.Errorf("StreamEncoder.Flush() returned error %v", err)
 		}
+
 		if !bytes.Equal(buf.Bytes(), expected) {
 			t.Errorf("StreamEncoder encoded 0x%x, want 0x%x", buf.Bytes(), expected)
 		}
@@ -96,16 +118,27 @@ func TestStreamEncodeTag(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-
 		se := NewStreamEncoder(&buf)
+
 		se.EncodeTagHead(128)
+
 		se.EncodeArrayHead(2)
-		se.Encode("hello")
-		se.Encode(big.NewInt(1))
-		err := se.Flush()
+
+		err := se.Encode("hello")
+		if err != nil {
+			t.Errorf("StreamEncoder.Encode() returned error %v", err)
+		}
+
+		err = se.Encode(big.NewInt(1))
+		if err != nil {
+			t.Errorf("StreamEncoder.Encode() returned error %v", err)
+		}
+
+		err = se.Flush()
 		if err != nil {
 			t.Errorf("StreamEncoder.Flush() returned error %v", err)
 		}
+
 		if !bytes.Equal(buf.Bytes(), expected) {
 			t.Errorf("StreamEncoder encoded 0x%x, want 0x%x", buf.Bytes(), expected)
 		}
@@ -135,16 +168,27 @@ func TestStreamEncodeTag(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-
 		se := em.NewStreamEncoder(&buf)
+
 		se.EncodeTagHead(128)
+
 		se.EncodeArrayHead(2)
-		se.Encode("hello")
-		se.Encode(big.NewInt(1))
+
+		err = se.Encode("hello")
+		if err != nil {
+			t.Errorf("StreamEncoder.Encode() returned error %v", err)
+		}
+
+		err = se.Encode(big.NewInt(1))
+		if err != nil {
+			t.Errorf("StreamEncoder.Encode() returned error %v", err)
+		}
+
 		err = se.Flush()
 		if err != nil {
 			t.Errorf("StreamEncoder.Flush() returned error %v", err)
 		}
+
 		if !bytes.Equal(buf.Bytes(), expected) {
 			t.Errorf("StreamEncoder encoded 0x%x, want 0x%x", buf.Bytes(), expected)
 		}

--- a/stream_encode_test.go
+++ b/stream_encode_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+)
+
+func TestStreamEncodeArray(t *testing.T) {
+	t.Run("default mode", func(t *testing.T) {
+		expected := []byte{
+			// array, 2 items follow
+			0x82,
+			// UTF-8 string, length 5
+			0x65,
+			// h, e, l, l, o
+			0x68, 0x65, 0x6c, 0x6c, 0x6f,
+			// array, 1 items follow
+			0x81,
+			// 1
+			0x01,
+		}
+
+		var buf bytes.Buffer
+
+		se := NewStreamEncoder(&buf)
+		se.EncodeArrayHead(2)
+		se.Encode("hello")
+		se.EncodeArrayHead(1)
+		se.Encode(big.NewInt(1))
+		err := se.Flush()
+		if err != nil {
+			t.Errorf("StreamEncoder.Flush() returned error %v", err)
+		}
+		if !bytes.Equal(buf.Bytes(), expected) {
+			t.Errorf("StreamEncoder encoded 0x%x, want 0x%x", buf.Bytes(), expected)
+		}
+	})
+
+	t.Run("BigIntConvertNone mode", func(t *testing.T) {
+		expected := []byte{
+			// array, 2 items follow
+			0x82,
+			// UTF-8 string, length 5
+			0x65,
+			// h, e, l, l, o
+			0x68, 0x65, 0x6c, 0x6c, 0x6f,
+			// array, 1 items follow
+			0x81,
+			// positive bignum
+			0xc2,
+			// byte string, length 1
+			0x41,
+			0x01,
+		}
+
+		var buf bytes.Buffer
+
+		opts := EncOptions{BigIntConvert: BigIntConvertNone}
+		em, err := opts.encMode()
+		if err != nil {
+			panic(err)
+		}
+
+		se := em.NewStreamEncoder(&buf)
+		se.EncodeArrayHead(2)
+		se.Encode("hello")
+		se.EncodeArrayHead(1)
+		se.Encode(big.NewInt(1))
+		err = se.Flush()
+		if err != nil {
+			t.Errorf("StreamEncoder.Flush() returned error %v", err)
+		}
+		if !bytes.Equal(buf.Bytes(), expected) {
+			t.Errorf("StreamEncoder encoded 0x%x, want 0x%x", buf.Bytes(), expected)
+		}
+	})
+}
+
+func TestStreamEncodeTag(t *testing.T) {
+	t.Run("default mode", func(t *testing.T) {
+		expected := []byte{
+			// tag 128
+			0xd8, 0x80,
+			// array, 2 items follow
+			0x82,
+			// UTF-8 string, length 5
+			0x65,
+			// h, e, l, l, o
+			0x68, 0x65, 0x6c, 0x6c, 0x6f,
+			// 1
+			0x01,
+		}
+
+		var buf bytes.Buffer
+
+		se := NewStreamEncoder(&buf)
+		se.EncodeTagHead(128)
+		se.EncodeArrayHead(2)
+		se.Encode("hello")
+		se.Encode(big.NewInt(1))
+		err := se.Flush()
+		if err != nil {
+			t.Errorf("StreamEncoder.Flush() returned error %v", err)
+		}
+		if !bytes.Equal(buf.Bytes(), expected) {
+			t.Errorf("StreamEncoder encoded 0x%x, want 0x%x", buf.Bytes(), expected)
+		}
+	})
+
+	t.Run("BigIntConvertNone", func(t *testing.T) {
+		expected := []byte{
+			// tag 128
+			0xd8, 0x80,
+			// array, 2 items follow
+			0x82,
+			// UTF-8 string, length 5
+			0x65,
+			// h, e, l, l, o
+			0x68, 0x65, 0x6c, 0x6c, 0x6f,
+			// positive bignum
+			0xc2,
+			// byte string, length 1
+			0x41,
+			0x01,
+		}
+
+		opts := EncOptions{BigIntConvert: BigIntConvertNone}
+		em, err := opts.encMode()
+		if err != nil {
+			panic(err)
+		}
+
+		var buf bytes.Buffer
+
+		se := em.NewStreamEncoder(&buf)
+		se.EncodeTagHead(128)
+		se.EncodeArrayHead(2)
+		se.Encode("hello")
+		se.Encode(big.NewInt(1))
+		err = se.Flush()
+		if err != nil {
+			t.Errorf("StreamEncoder.Flush() returned error %v", err)
+		}
+		if !bytes.Equal(buf.Bytes(), expected) {
+			t.Errorf("StreamEncoder encoded 0x%x, want 0x%x", buf.Bytes(), expected)
+		}
+	})
+}


### PR DESCRIPTION
StreamEncoder provides low-level API for sequential encoding.
    
It can be used to avoid creating large collection objects.
    
Users of StreamEncoder should be familiar with CBOR data models.  When in doubt, please use Encoder instead.
    
Users should use Valid() to check whether generated CBOR data is complete and well-formed.