### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,8 +1055,8 @@ __This library uses less memory__ for encoding and decoding CBOR Web Token (CWT)
 
 |  | fxamacker/cbor 2.3 | ugorji/go 1.2.6 |
 | :--- | :--- | :--- | 
-| Encode CWT | 0.18 kB/op &nbsp;&nbsp;&nbsp; 2 allocs/op | 1.35 kB/op &nbsp;&nbsp;&nbsp; 4 allocs/op |
-| Decode CWT | 160 bytes/op &nbsp;&nbsp;&nbsp; 6 allocs/op | &nbsp; 744 bytes/op &nbsp;&nbsp;&nbsp; 6 allocs/op |
+| Encode CWT | 0.18 kB/op &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2 allocs/op | 1.35 kB/op &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4 allocs/op |
+| Decode CWT | 160 bytes/op &nbsp;&nbsp;&nbsp; 6 allocs/op | 744 bytes/op &nbsp;&nbsp;&nbsp; 6 allocs/op |
 
 Running your own benchmarks is highly recommended.  Use your most common data structures and data sizes.
 


### PR DESCRIPTION
#### Description

- Update CBOR Security comparison using 10 bytes discussed with @fxamacker 
- Update CBOR Performance comparison with Go 1.17.5
- Add TL;DR below the badges for pkg.go.dev
- Removed some badges
- Removed some text

Closes #285 

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

