### PR TITLE
Create optional byte string wrapper for map keys

### DIFF
--- a/bytestring.go
+++ b/bytestring.go
@@ -1,0 +1,34 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"encoding/hex"
+	"reflect"
+)
+
+var (
+	typeByteString = reflect.TypeOf(NewByteString(nil))
+)
+
+type ByteString struct {
+	// XXX: replace with interface{} storing fixed-length byte array?
+	// We use a string because []byte isn't comparable
+	data string
+}
+
+func NewByteString(data []byte) ByteString {
+	bs := ByteString{
+		data: string(data),
+	}
+	return bs
+}
+
+func (bs ByteString) Bytes() []byte {
+	return []byte(bs.data)
+}
+
+func (bs ByteString) String() string {
+	return hex.EncodeToString([]byte(bs.data))
+}

--- a/decode.go
+++ b/decode.go
@@ -239,6 +239,26 @@ func (idm IntDecMode) valid() bool {
 	return idm < maxIntDec
 }
 
+// MapKeyByteStringMode specifies whether to use a wrapper object for byte strings.
+type MapKeyByteStringMode int
+
+const (
+	// MapKeyByteStringFail affects how a CBOR byte string as a map key is decoded.
+	// It makes the parsing fail as Go cannot use []byte as a map key.
+	MapKeyByteStringFail MapKeyByteStringMode = iota
+
+	// MapKeyByteStringWrap affects how a CBOR byte string as a map key is decoded.
+	// It allows the parsing to succeed by wrapping the byte string in a wrapper object
+	// that can be used as a map key in Go.
+	MapKeyByteStringWrap
+
+	maxMapKeyByteString
+)
+
+func (bsm MapKeyByteStringMode) valid() bool {
+	return bsm < maxMapKeyByteString
+}
+
 // ExtraDecErrorCond specifies extra conditions that should be treated as errors.
 type ExtraDecErrorCond uint
 
@@ -287,6 +307,9 @@ type DecOptions struct {
 	// IntDec specifies which Go integer type (int64 or uint64) to use
 	// when decoding CBOR int (major type 0 and 1) to Go interface{}.
 	IntDec IntDecMode
+
+	// MapKeyByteString specifies whether to use a wrapper object for byte strings.
+	MapKeyByteString MapKeyByteStringMode
 
 	// ExtraReturnErrors specifies extra conditions that should be treated as errors.
 	ExtraReturnErrors ExtraDecErrorCond
@@ -376,6 +399,9 @@ func (opts DecOptions) decMode() (*decMode, error) {
 	if !opts.IntDec.valid() {
 		return nil, errors.New("cbor: invalid IntDec " + strconv.Itoa(int(opts.IntDec)))
 	}
+	if !opts.MapKeyByteString.valid() {
+		return nil, errors.New("cbor: invalid MapKeyByteString " + strconv.Itoa(int(opts.MapKeyByteString)))
+	}
 	if opts.MaxNestedLevels == 0 {
 		opts.MaxNestedLevels = 32
 	} else if opts.MaxNestedLevels < 4 || opts.MaxNestedLevels > 256 {
@@ -406,6 +432,7 @@ func (opts DecOptions) decMode() (*decMode, error) {
 		indefLength:       opts.IndefLength,
 		tagsMd:            opts.TagsMd,
 		intDec:            opts.IntDec,
+		mapKeyByteString:  opts.MapKeyByteString,
 		extraReturnErrors: opts.ExtraReturnErrors,
 		defaultMapType:    opts.DefaultMapType,
 	}
@@ -438,6 +465,7 @@ type decMode struct {
 	indefLength       IndefLengthMode
 	tagsMd            TagsMode
 	intDec            IntDecMode
+	mapKeyByteString  MapKeyByteStringMode
 	extraReturnErrors ExtraDecErrorCond
 	defaultMapType    reflect.Type
 }
@@ -455,6 +483,7 @@ func (dm *decMode) DecOptions() DecOptions {
 		IndefLength:       dm.indefLength,
 		TagsMd:            dm.tagsMd,
 		IntDec:            dm.intDec,
+		MapKeyByteString:  dm.mapKeyByteString,
 		ExtraReturnErrors: dm.extraReturnErrors,
 	}
 }
@@ -1168,6 +1197,7 @@ func (d *decoder) parseMap() (interface{}, error) {
 	var k, e interface{}
 	var err, lastErr error
 	keyCount := 0
+	typeByteSlice := reflect.TypeOf([]byte{})
 	for i := 0; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
 		// Parse CBOR map key.
 		if k, lastErr = d.parse(true); lastErr != nil {
@@ -1180,6 +1210,11 @@ func (d *decoder) parseMap() (interface{}, error) {
 
 		// Detect if CBOR map key can be used as Go map key.
 		rv := reflect.ValueOf(k)
+		// Wrap byte string if enabled
+		if rv.IsValid() && rv.Type() == typeByteSlice && d.dm.mapKeyByteString == MapKeyByteStringWrap {
+			k = NewByteString(rv.Bytes())
+			rv = reflect.ValueOf(k)
+		}
 		if !isHashableValue(rv) {
 			if err == nil {
 				err = errors.New("cbor: invalid map key type: " + rv.Type().String())
@@ -1236,6 +1271,7 @@ func (d *decoder) parseMapToMap(v reflect.Value, tInfo *typeInfo) error { //noli
 	keyIsInterfaceType := keyType == typeIntf // If key type is interface{}, need to check if key value is hashable.
 	var err, lastErr error
 	keyCount := v.Len()
+	typeByteSlice := reflect.TypeOf([]byte{})
 	var existingKeys map[interface{}]bool // Store existing map keys, used for detecting duplicate map key.
 	if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
 		existingKeys = make(map[interface{}]bool, keyCount)
@@ -1262,6 +1298,11 @@ func (d *decoder) parseMapToMap(v reflect.Value, tInfo *typeInfo) error { //noli
 			}
 			d.skip()
 			continue
+		}
+		// Wrap byte string if enabled
+		if keyType == typeByteSlice && d.dm.mapKeyByteString == MapKeyByteStringWrap {
+			keyValue = reflect.ValueOf(NewByteString(keyValue.Bytes()))
+			keyType = keyValue.Type()
 		}
 
 		// Detect if CBOR map key can be used as Go map key.

--- a/encode.go
+++ b/encode.go
@@ -786,6 +786,10 @@ func encodeFloat64(e *encoderBuffer, f64 float64) error {
 }
 
 func encodeByteString(e *encoderBuffer, em *encMode, v reflect.Value) error {
+	// Unwrap byte string
+	if v.Type() == typeByteString {
+		v = reflect.ValueOf(v.Interface().(ByteString).Bytes())
+	}
 	vk := v.Kind()
 	if vk == reflect.Slice && v.IsNil() {
 		e.Write(cborNil)
@@ -1298,6 +1302,8 @@ func getEncodeFuncInternal(t reflect.Type) (encodeFunc, isEmptyFunc) {
 		return encodeBigInt, alwaysNotEmpty
 	case typeRawMessage:
 		return encodeMarshalerType, isEmptySlice
+	case typeByteString:
+		return encodeByteString, isEmptyByteString
 	}
 	if reflect.PtrTo(t).Implements(typeMarshaler) {
 		return encodeMarshalerType, alwaysNotEmpty
@@ -1395,6 +1401,10 @@ func isEmptyString(v reflect.Value) (bool, error) {
 
 func isEmptySlice(v reflect.Value) (bool, error) {
 	return v.Len() == 0, nil
+}
+
+func isEmptyByteString(v reflect.Value) (bool, error) {
+	return len(v.Interface().(ByteString).Bytes()) == 0, nil
 }
 
 func isEmptyMap(v reflect.Value) (bool, error) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -3590,3 +3590,34 @@ func TestMarshalNegBigInt(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalByteStringUnwrap(t *testing.T) {
+	testCases := []struct {
+		name         string
+		value        interface{}
+		wantCborData []byte
+	}{
+		{
+			name: "map with ByteString keys",
+			value: map[interface{}]interface{}{
+				NewByteString(hexDecode("abcdef")): uint64(123),
+			},
+			wantCborData: hexDecode("A143ABCDEF187B"),
+		},
+	}
+	dm, err := EncOptions{}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fmt.Printf("tc.value = %#v\n", tc.value)
+			if b, err := dm.Marshal(tc.value); err != nil {
+				t.Errorf("Marshal(%v) returned error %v", tc.value, err)
+			} else if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", tc.value, b, tc.wantCborData)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Description (motivation)

This allows the parsing of CBOR data containing maps with byte string
keys, which is commonly seen in Cardano blockchain data. The default
behavior remains the legacy behavior (throw an error) for backward
compatibility.

This is related to #312 

#### PR Was Proposed and Welcomed in Currently Open Issue
This PR was proposed and welcomed by maintainer(s) in issue #

Closes #

NOTE: I'm leaving this section blank, since this fix was not necessarily "welcomed" by the maintainer :)

#### Checklist (for code PR only, ignore for docs PR)

- [x] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all 18 ci linters (golint, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

