### PR TITLE
Reuse underlying array if RawMessage has sufficient capacity

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -193,7 +193,6 @@ func (m *RawMessage) UnmarshalCBOR(data []byte) error {
 	if m == nil {
 		return errors.New("cbor.RawMessage: UnmarshalCBOR on nil pointer")
 	}
-	*m = make([]byte, len(data))
-	copy(*m, data)
+	*m = append((*m)[0:0], data...)
 	return nil
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -5,6 +5,7 @@ package cbor
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"reflect"
 	"testing"
@@ -386,6 +387,20 @@ func TestRawMessage(t *testing.T) {
 	}
 	if !bytes.Equal(b, cborData) {
 		t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", v, b, cborData)
+	}
+
+	address := fmt.Sprintf("%p", *v.B)
+	if err := Unmarshal(v.A, v.B); err != nil {
+		t.Fatalf("Unmarshal(0x%x) returned error %v", v.A, err)
+	}
+	if address != fmt.Sprintf("%p", *v.B) {
+		t.Fatalf("Unmarshal RawMessage should reuse underlying array if it has sufficient capacity")
+	}
+	if err := Unmarshal(cborData, v.B); err != nil {
+		t.Fatalf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if address == fmt.Sprintf("%p", *v.B) {
+		t.Fatalf("Unmarshal RawMessage should allocate a new underlying array if it does not have sufficient capacity")
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

#### Description (motivation)
This is a performance optimization for implementing cbor-patch.

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

#### PR Was Proposed and Welcomed in Currently Open Issue
This PR was proposed and welcomed by maintainer(s) in issue #

Closes #

#### Checklist (for code PR only, ignore for docs PR)

- [x] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all 18 ci linters (golint, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

