### PR TITLE
[stream-mode branch] Enable tinygo 0.23 to compile and use CBOR StreamEncoder and StreamDecoder

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1291,11 +1291,7 @@ func (d *decoder) parseMapToMap(v reflect.Value, tInfo *typeInfo) error { //noli
 	hasSize := (ai != 31)
 	count := int(val)
 	if v.IsNil() {
-		mapsize := count
-		if !hasSize {
-			mapsize = 0
-		}
-		v.Set(reflect.MakeMapWithSize(tInfo.nonPtrType, mapsize))
+		v.Set(reflect.MakeMap(tInfo.nonPtrType))
 	}
 	keyType, eleType := tInfo.keyTypeInfo.typ, tInfo.elemTypeInfo.typ
 	reuseKey, reuseEle := isImmutableKind(tInfo.keyTypeInfo.kind), isImmutableKind(tInfo.elemTypeInfo.kind)


### PR DESCRIPTION
### Description

Replaced `reflect.MakeMapWithSize()` with `reflect.MakeMap()` to allow tinygo 0.23 (amd64) to compile features/stream-mode branch.

Enable tinygo to use `StreamEncoder` and `StreamDecoder`.  Other features may encounter stubs in tinygo that panics due to unimplemented Go features.

Closes #348

For more details, see https://github.com/fxamacker/cbor/issues/295#issuecomment-1140339662

