### PR TITLE
godoc.org link in Readme should point to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ type RawTag struct {
 }
 ```
 
-See [API docs (godoc.org)](https://godoc.org/github.com/fxamacker/cbor) for more details and more functions.  See [Usage section](#usage) for usage and code examples.
+See [API docs (godoc.org)](https://godoc.org/github.com/fxamacker/cbor/v2) for more details and more functions.  See [Usage section](#usage) for usage and code examples.
 
 <hr>
 


### PR DESCRIPTION

<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description
This change updates the readme to point to the v2 docs instead of the v1.x docs on godoc.org.

It's possible there's some reason for this link to not point to the v2 docs, but I'm guessing this was just never updated.  I keep clicking this link to bring up documentation and then having to realize I'm looking at an old version :)


<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->