### PR TITLE
Bump Go to 1.19 in ci-go-cover.yml

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.19
         check-latest: true      
     - name: Go Coverage
       run: |


### PR DESCRIPTION
Bump Go from 1.17 to 1.19.

