### PR TITLE
Bump safer-golangci-lint.yml to 1.49.0.1

### DIFF
--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -51,7 +51,7 @@ on:
     branches: [main, master]
 
 env:
-  GO_VERSION: 1.19
+  GO_VERSION: 1.18
   GOLINTERS_VERSION: 1.49.0
   GOLINTERS_ARCH: linux-amd64
   GOLINTERS_TGZ_DGST: 5badc6e9fee2003621efa07e385910d9a88c89b38f6c35aded153193c5125178

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -26,8 +26,9 @@
 #   1. GOLINTERS_VERSION
 #   2. GOLINTERS_TGZ_DGST
 #
-# Customize for fxamacker/cbor (October 2, 2022)
-#   - Use Go 1.17 for now because gofmt changed in Go 1.19 and other PRs are pending.
+# Release v1.49.0.1 (October 2, 2022) for github.com/fxamacker/cbor
+#   - Allow goimports/gofmt version to use different Go version
+#   - Add GOFMT_VERSION, GOTOOLS_VERSION, etc.
 #
 # Release v1.49.0 (September 18, 2022)
 #   - Bump golangci-lint to 1.49.0
@@ -54,17 +55,71 @@ on:
     branches: [main, master]
 
 env:
-  GO_VERSION: 1.17
-  GOLINTERS_VERSION: 1.49.0
+  GO_VERSION: 1.19
+  GOFMT_VERSION: 1.18        # version of Go for gofmt and for building goimports
+  GOLINTERS_VERSION: 1.49.0  # version of golangci-lint
+    
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: 5badc6e9fee2003621efa07e385910d9a88c89b38f6c35aded153193c5125178
+  GOLINTERS_TGZ_DGST: 5badc6e9fee2003621efa07e385910d9a88c89b38f6c35aded153193c5125178 # golangci-lint 1.49.0
   GOLINTERS_TIMEOUT: 15m
+  
+  # go tools v0.1.12 (Jan 27, 2022) is commit b3b5c13b291f9653da6f31b95db100a2e26bd186
+  # https://github.com/golang/tools/releases/tag/v0.1.12
+  GOTOOLS_VERSION: b3b5c13b291f9653da6f31b95db100a2e26bd186 # v0.1.12  
+  GOIMPORTS_DGST: 82a00939e3555d5dd7ca7b53bd3e413c4d3de5c32698f05e17f1d62fdc81c07e # go 1.18.6 + go tools v0.1.12
+  GOIMPORTS_FLAGS: -l # -l (filenames) is recommended.  -d (diffs) can be useful.
+  
   OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
 
 jobs:
-  main:
-    name: Lint
+  gofmt:
+    name: goimports
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          # Use GOFMT_VERSION (not GO_VERSION) for job goimports
+          go-version: ${{ env.GOFMT_VERSION }}
+          check-latest: true
+          
+      # Run goimports and print file names that didn't pass
+      - name: Run goimports
+        run: |
+          go install golang.org/x/tools/cmd/goimports@${GOTOOLS_VERSION}
+          GOIMPORTS_FULLPATH=$(go env GOPATH)/bin/goimports
+          GOIMPORTS_EXPECTED_DGST="${GOIMPORTS_DGST} *${GOIMPORTS_FULLPATH}"
+          DGST_CMD="${OPENSSL_DGST_CMD} ${GOIMPORTS_FULLPATH}"
+          
+          GOIMPORTS_GOT_DGST=$(${DGST_CMD})
+          echo "${GOIMPORTS_GOT_DGST}"
+               
+          if [ "${GOIMPORTS_GOT_DGST}" != "${GOIMPORTS_EXPECTED_DGST}" ]
+          then
+            echo "Digest of goimports is not equal to expected digest."
+            echo "Expected digest: " "${GOIMPORTS_EXPECTED_DGST}"
+            echo "Got digest:      " "${GOIMPORTS_GOT_DGST}"
+            # exit 1
+          fi
+          
+          GOIMPORTS_OUTPUT=$(${GOIMPORTS_FULLPATH} ${GOIMPORTS_FLAGS} .)
+          if [[ "${GOIMPORTS_OUTPUT}" ]]; then
+            echo "${GOIMPORTS_OUTPUT}"
+            exit 1
+          fi
+
+        shell: bash
+        
+  linters:
+    name: linters
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,6 +156,11 @@ jobs:
 
           tar --no-same-owner -xzf "${GOLINTERS_TGZ}" --strip-components 1
           install golangci-lint $(go env GOPATH)/bin
+          go version
+          golangci-lint --version
+          which go
+          which gofmt
+          which golangci-lint
         shell: bash
 
       # Run required linters enabled in .golangci.yml (or default linters if yml doesn't exist)     

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -27,7 +27,7 @@
 #   2. GOLINTERS_TGZ_DGST
 #
 # Customize for fxamacker/cbor (October 2, 2022)
-#   - Use Go 1.18 for now because gofmt changed in Go 1.19 and other PRs are pending.
+#   - Use Go 1.17 for now because gofmt changed in Go 1.19 and other PRs are pending.
 #
 # Release v1.49.0 (September 18, 2022)
 #   - Bump golangci-lint to 1.49.0
@@ -54,7 +54,7 @@ on:
     branches: [main, master]
 
 env:
-  GO_VERSION: 1.18
+  GO_VERSION: 1.17
   GOLINTERS_VERSION: 1.49.0
   GOLINTERS_ARCH: linux-amd64
   GOLINTERS_TGZ_DGST: 5badc6e9fee2003621efa07e385910d9a88c89b38f6c35aded153193c5125178

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -26,6 +26,9 @@
 #   1. GOLINTERS_VERSION
 #   2. GOLINTERS_TGZ_DGST
 #
+# Customize for fxamacker/cbor (October 2, 2022)
+#   - Use Go 1.18 for now because gofmt changed in Go 1.19 and other PRs are pending.
+#
 # Release v1.49.0 (September 18, 2022)
 #   - Bump golangci-lint to 1.49.0
 #   - Bump Go to 1.19 (latest version of 1.19.x because check-latest: true).

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -56,8 +56,8 @@ on:
 
 env:
   GO_VERSION: 1.19
-  GOFMT_VERSION: 1.18        # version of Go for gofmt and for building goimports
-  GOLINTERS_VERSION: 1.49.0  # version of golangci-lint
+  GOFMT_VERSION: 1.18.6        # version of Go for gofmt and for building goimports
+  GOLINTERS_VERSION: 1.49.0    # version of golangci-lint
     
   GOLINTERS_ARCH: linux-amd64
   GOLINTERS_TGZ_DGST: 5badc6e9fee2003621efa07e385910d9a88c89b38f6c35aded153193c5125178 # golangci-lint 1.49.0
@@ -89,7 +89,7 @@ jobs:
         with:
           # Use GOFMT_VERSION (not GO_VERSION) for job goimports
           go-version: ${{ env.GOFMT_VERSION }}
-          check-latest: true
+          check-latest: false  # false to prevent compiled goimports digest from changing
           
       # Run goimports and print file names that didn't pass
       - name: Run goimports

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -6,9 +6,15 @@
 #
 # safer-golangci-lint.yml
 #
+# This workflow downloads, verifies, and runs golangci-lint in a
+# deterministic, reviewable, and safe manner.
+#
 # 100% of the script for downloading, installing, and running golangci-lint
-# is embedded in this file.  The embedded SHA384 digest is used to verify the 
-# downloaded golangci-lint tarball (golangci-lint-1.46.2-linux-amd64.tar.gz). 
+# is embedded in this file. The embedded SHA-256 digest is used to verify the
+# downloaded golangci-lint tarball (golangci-lint-1.49.0-linux-amd64.tar.gz).
+#
+# The embedded SHA-256 digest matches golangci-lint-1.49.0-checksums.txt at
+# https://github.com/golangci/golangci-lint/releases
 #
 # To use:
 #   Step 1. Copy this file into [github_repo]/.github/workflows/
@@ -20,15 +26,17 @@
 #   1. GOLINTERS_VERSION
 #   2. GOLINTERS_TGZ_DGST
 #
-# Release v1.46.2 (May 19, 2022)
-#   - actions/setup-go uses check-latest: true
-#   - Remove default permissions at top level and grant only read permission in the job.
-#   - Add workflow_dispatch.
-#   - Tidy some comments.
-#   - Bump golangci-lint to 1.46.2.
-#   - Checksum for golangci-lint-1.46.2-linux-amd64.tar.gz
-#     - SHA-256 is 242cd4f2d6ac0556e315192e8555784d13da5d1874e51304711570769c4f2b9b
-#     - SHA-384 is 60ade95e447f8c9a2dfc507c271c2ff41a0e0856f077bf2f734bcd80dd8268addf8cf1625c3e47a6516eb14f23423315
+# Release v1.49.0 (September 18, 2022)
+#   - Bump golangci-lint to 1.49.0
+#   - Bump Go to 1.19 (latest version of 1.19.x because check-latest: true).
+#   - Put Go version in environment variable GO_VERSION.
+#   - Increase timeout to 15m for big projects enabling more linters.
+#   - Use SHA-256 to verify (instead of SHA-384) and mention checksums file.
+#   - Hash of golangci-lint-1.49.0-linux-amd64.tar.gz
+#     - SHA-384: df59267a11317d2763fb6cb454a9b3a6a6d428f4750fcbb8604fb0d289b18a1b3b6cd2bfbf2a2fe976979e97a71fcc36
+#     - SHA-256: 5badc6e9fee2003621efa07e385910d9a88c89b38f6c35aded153193c5125178
+#                This SHA-256 digest matches golangci-lint-1.49.0-checksums.txt at
+#                https://github.com/golangci/golangci-lint/releases
 #
 name: linters
 
@@ -43,11 +51,12 @@ on:
     branches: [main, master]
 
 env:
-  GOLINTERS_VERSION: 1.46.2
+  GO_VERSION: 1.19
+  GOLINTERS_VERSION: 1.49.0
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: 60ade95e447f8c9a2dfc507c271c2ff41a0e0856f077bf2f734bcd80dd8268addf8cf1625c3e47a6516eb14f23423315
-  GOLINTERS_TIMEOUT: 5m
-  OPENSSL_DGST_CMD: openssl dgst -sha384 -r
+  GOLINTERS_TGZ_DGST: 5badc6e9fee2003621efa07e385910d9a88c89b38f6c35aded153193c5125178
+  GOLINTERS_TIMEOUT: 15m
+  OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
 
 jobs:
@@ -65,7 +74,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
 
       - name: Install golangci-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,8 +45,8 @@ linters:
     - errcheck
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
+    # - gofmt       # handled by safer-golangci-lint.yml
+    # - goimports   # handled by safer-golangci-lint.yml
     - gosec
     - govet
     - ineffassign


### PR DESCRIPTION
Bump from 1.46.2 to 1.49.0.1.  

1.49.0.1 (October 2, 2022) allows different version of goimports (gofmt) to be used than Go version for golangci-lint.
- GOFMT_VERSION - version of Go for gofmt and for building goimports
- GOTOOLS_VERSION - version of go tools
- GOIMPORTS_DGST - SHA-256 of goimports command built with Go 1.8.6 and go tools v0.1.12.

1.49.0 (September 18, 2022) is identical to latest at [github.com/x448/safer-golangci-lint](https://github.com/x448/safer-golangci-lint).
```
# Release v1.49.0 (September 18, 2022)
#   - Bump golangci-lint to 1.49.0
#   - Bump Go to 1.19 (latest version of 1.19.x because check-latest: true).
#   - Put Go version in environment variable GO_VERSION.
#   - Increase timeout to 15m for big projects enabling more linters.
#   - Use SHA-256 to verify (instead of SHA-384) and mention checksums file.
#   - Hash of golangci-lint-1.49.0-linux-amd64.tar.gz
#     - SHA-384: df59267a11317d2763fb6cb454a9b3a6a6d428f4750fcbb8604fb0d289b18a1b3b6cd2bfbf2a2fe976979e97a71fcc36
#     - SHA-256: 5badc6e9fee2003621efa07e385910d9a88c89b38f6c35aded153193c5125178
#                This SHA-256 digest matches golangci-lint-1.49.0-checksums.txt at
#                https://github.com/golangci/golangci-lint/releases
```
