### PR TITLE
Add support for unassigned/reserved CBOR simple values

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -431,31 +431,31 @@ var unmarshalTests = []unmarshalTest{
 	{
 		hexDecode("f4"),
 		false,
-		[]interface{}{false},
+		[]interface{}{false, SimpleValue(20)},
 		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteArray, typeByteSlice, typeString, typeIntSlice, typeMapStringInt, typeTag, typeRawTag, typeBigInt},
 	},
 	{
 		hexDecode("f5"),
 		true,
-		[]interface{}{true},
+		[]interface{}{true, SimpleValue(21)},
 		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteArray, typeByteSlice, typeString, typeIntSlice, typeMapStringInt, typeTag, typeRawTag, typeBigInt},
 	},
 	{
 		hexDecode("f6"),
 		nil,
-		[]interface{}{false, uint(0), uint8(0), uint16(0), uint32(0), uint64(0), int(0), int8(0), int16(0), int32(0), int64(0), float32(0.0), float64(0.0), "", []byte(nil), []int(nil), []string(nil), map[string]int(nil), time.Time{}, bigIntOrPanic("0"), Tag{}, RawTag{}},
+		[]interface{}{SimpleValue(22), false, uint(0), uint8(0), uint16(0), uint32(0), uint64(0), int(0), int8(0), int16(0), int32(0), int64(0), float32(0.0), float64(0.0), "", []byte(nil), []int(nil), []string(nil), map[string]int(nil), time.Time{}, bigIntOrPanic("0"), Tag{}, RawTag{}},
 		nil,
 	},
 	{
 		hexDecode("f7"),
 		nil,
-		[]interface{}{false, uint(0), uint8(0), uint16(0), uint32(0), uint64(0), int(0), int8(0), int16(0), int32(0), int64(0), float32(0.0), float64(0.0), "", []byte(nil), []int(nil), []string(nil), map[string]int(nil), time.Time{}, bigIntOrPanic("0"), Tag{}, RawTag{}},
+		[]interface{}{SimpleValue(23), false, uint(0), uint8(0), uint16(0), uint32(0), uint64(0), int(0), int8(0), int16(0), int32(0), int64(0), float32(0.0), float64(0.0), "", []byte(nil), []int(nil), []string(nil), map[string]int(nil), time.Time{}, bigIntOrPanic("0"), Tag{}, RawTag{}},
 		nil,
 	},
 	{
 		hexDecode("f0"),
-		uint64(16),
-		[]interface{}{uint8(16), uint16(16), uint32(16), uint64(16), uint(16), int8(16), int16(16), int32(16), int64(16), int(16), float32(16), float64(16), bigIntOrPanic("16")},
+		SimpleValue(16),
+		[]interface{}{SimpleValue(16), uint8(16), uint16(16), uint32(16), uint64(16), uint(16), int8(16), int16(16), int32(16), int64(16), int(16), float32(16), float64(16), bigIntOrPanic("16")},
 		[]reflect.Type{typeByteSlice, typeString, typeBool, typeByteArray, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
 	},
 	// This example is not well-formed because Simple value (with 5-bit value 24) must be >= 32.
@@ -471,14 +471,14 @@ var unmarshalTests = []unmarshalTest{
 	*/
 	{
 		hexDecode("f820"),
-		uint64(32),
-		[]interface{}{uint8(32), uint16(32), uint32(32), uint64(32), uint(32), int8(32), int16(32), int32(32), int64(32), int(32), float32(32), float64(32), bigIntOrPanic("32")},
+		SimpleValue(32),
+		[]interface{}{SimpleValue(32), uint8(32), uint16(32), uint32(32), uint64(32), uint(32), int8(32), int16(32), int32(32), int64(32), int(32), float32(32), float64(32), bigIntOrPanic("32")},
 		[]reflect.Type{typeByteSlice, typeString, typeBool, typeByteArray, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
 	},
 	{
 		hexDecode("f8ff"),
-		uint64(255),
-		[]interface{}{uint8(255), uint16(255), uint32(255), uint64(255), uint(255), int16(255), int32(255), int64(255), int(255), float32(255), float64(255), bigIntOrPanic("255")},
+		SimpleValue(255),
+		[]interface{}{SimpleValue(255), uint8(255), uint16(255), uint32(255), uint64(255), uint(255), int16(255), int32(255), int64(255), int(255), float32(255), float64(255), bigIntOrPanic("255")},
 		[]reflect.Type{typeByteSlice, typeString, typeBool, typeByteArray, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
 	},
 	// More testcases not covered by https://tools.ietf.org/html/rfc7049#appendix-A.

--- a/encode.go
+++ b/encode.go
@@ -1250,6 +1250,14 @@ func encodeTag(e *encoderBuffer, em *encMode, v reflect.Value) error {
 	return nil
 }
 
+func encodeSimpleValue(e *encoderBuffer, em *encMode, v reflect.Value) error {
+	if b := em.encTagBytes(v.Type()); b != nil {
+		e.Write(b)
+	}
+	encodeHead(e, byte(cborTypePrimitives), v.Uint())
+	return nil
+}
+
 func encodeHead(e *encoderBuffer, t byte, n uint64) {
 	if n <= 23 {
 		e.WriteByte(t | byte(n))
@@ -1290,6 +1298,8 @@ func getEncodeFuncInternal(t reflect.Type) (encodeFunc, isEmptyFunc) {
 		return getEncodeIndirectValueFunc(t), isEmptyPtr
 	}
 	switch t {
+	case typeSimpleValue:
+		return encodeSimpleValue, isEmptyUint
 	case typeTag:
 		return encodeTag, alwaysNotEmpty
 	case typeTime:

--- a/simplevalue.go
+++ b/simplevalue.go
@@ -2,7 +2,14 @@ package cbor
 
 import "reflect"
 
-// SimpleValue represents CBOR simple value [0, 255].
+// SimpleValue represents CBOR simple value.
+// CBOR simple value is:
+// * an extension point like CBOR tag.
+// * a subset of CBOR major type 7 that isn't floating-point.
+// * "identified by a number between 0 and 255, but distinct from that number itself".
+//   For example, "a simple value 2 is not equivalent to an integer 2" as a CBOR map key.
+// CBOR simple values identified by 20..23 are: "false", "true" , "null", and "undefined".
+// Other CBOR simple values are currently unassigned/reserved by IANA.
 type SimpleValue uint8
 
 var (

--- a/simplevalue.go
+++ b/simplevalue.go
@@ -1,0 +1,10 @@
+package cbor
+
+import "reflect"
+
+// SimpleValue represents CBOR simple value [0, 255].
+type SimpleValue uint8
+
+var (
+	typeSimpleValue = reflect.TypeOf(SimpleValue(0))
+)


### PR DESCRIPTION
### Description

This PR adds proper support for all CBOR simple values, including simple values [unassigned/reserved by IANA](https://www.iana.org/assignments/cbor-simple-values/cbor-simple-values.xhtml).

- Add a SimpleValue type which is distinct from Go's numeric types.
- Add support for properly encoding and decoding all simple values, including 251 unassigned/reserved simple values.
- Improve support for simple values as map keys by making them distinct from uint64 values.

Closes #372 

### Background

CBOR simple values are a subset of major type 7 that is not floating-point.

Only 4 simple values were previously supported by this CBOR codec:
- false
- true
- null
- undefined

The other 251 simple values are [unassigned or reserved by IANA](https://www.iana.org/assignments/cbor-simple-values/cbor-simple-values.xhtml).

#### TODO
- [ ] update comments and godoc
- [ ] update README
- [ ] fuzz test changes
- [ ] code reviews