### PR TITLE
docs: fix EncMode example in the package comment

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -39,9 +39,9 @@ creating modes from options at runtime.
 
 EncMode and DecMode interfaces are created from EncOptions or DecOptions structs.
 
-    em := cbor.EncOptions{...}.EncMode()
-    em := cbor.CanonicalEncOptions().EncMode()
-    em := cbor.CTAP2EncOptions().EncMode()
+    em, err := cbor.EncOptions{...}.EncMode()
+    em, err := cbor.CanonicalEncOptions().EncMode()
+    em, err := cbor.CTAP2EncOptions().EncMode()
 
 Modes use immutable options to avoid side-effects and simplify concurrency. Behavior of
 modes won't accidentally change at runtime after they're created.


### PR DESCRIPTION
A few of the examples show calling the EncMode method with only one result (the mode) rather than a mode and an error.

Fixes #374.

N.B.: This PR is morally a documentation fix, although it does change a source file. I verified that all the tests still pass, but omitted the checklist on that basis. If you'd prefer to have it anyway, I'm happy to update the PR.