### PR TITLE
Fix handling of extra data in Unmarshal() & Valid()

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -549,13 +549,13 @@ func (dm *decMode) DecOptions() DecOptions {
 // See the documentation for Unmarshal for details.
 func (dm *decMode) Unmarshal(data []byte, v interface{}) error {
 	d := decoder{data: data, dm: dm}
-	return d.value(v)
+	return d.value(v, false)
 }
 
 // Valid checks whether the CBOR data is complete and well-formed.
 func (dm *decMode) Valid(data []byte) error {
 	d := decoder{data: data, dm: dm}
-	return d.valid()
+	return d.valid(false)
 }
 
 // NewDecoder returns a new decoder that reads from r using dm DecMode.
@@ -573,7 +573,7 @@ type decoder struct {
 // If CBOR data item is invalid, error is returned and offset isn't changed.
 // If CBOR data item is valid but fails to be decode into v for other reasons,
 // error is returned and offset is moved to the next CBOR data item.
-func (d *decoder) value(v interface{}) error {
+func (d *decoder) value(v interface{}, allowExtraData bool) error {
 	// v can't be nil, non-pointer, or nil pointer value.
 	if v == nil {
 		return &InvalidUnmarshalError{"cbor: Unmarshal(nil)"}
@@ -586,7 +586,7 @@ func (d *decoder) value(v interface{}) error {
 	}
 
 	off := d.off // Save offset before data validation
-	err := d.valid()
+	err := d.valid(allowExtraData)
 	d.off = off // Restore offset
 	if err != nil {
 		return err

--- a/decode_test.go
+++ b/decode_test.go
@@ -1369,6 +1369,10 @@ var invalidCBORUnmarshalTests = []struct {
 	{"Major type 0 with additional information 31", hexDecode("1f"), "cbor: invalid additional information 31 for type positive integer", true},
 	{"Major type 1 with additional information 31", hexDecode("3f"), "cbor: invalid additional information 31 for type negative integer", true},
 	{"Major type 6 with additional information 31", hexDecode("df"), "cbor: invalid additional information 31 for type tag", true},
+	// Extraneous data
+	{"two ints", hexDecode("0001"), "cbor: 1 bytes of extraneous data starting at index 1", false},
+	{"two arrays", hexDecode("830102038104"), "cbor: 2 bytes of extraneous data starting at index 4", false},
+	{"int and partial array", hexDecode("00830102"), "cbor: 3 bytes of extraneous data starting at index 1", false},
 }
 
 func TestInvalidCBORUnmarshal(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -34,7 +34,7 @@ func (dec *Decoder) Decode(v interface{}) error {
 	}
 	for {
 		dec.d.reset(dec.buf[dec.off:])
-		err := dec.d.value(v)
+		err := dec.d.value(v, true)
 		// Increment dec.off even if err is not nil because
 		// dec.d.off points to the next CBOR data item if current
 		// CBOR data item is valid but failed to be decoded into v.

--- a/stream_test.go
+++ b/stream_test.go
@@ -192,6 +192,25 @@ func TestDecoderReadError(t *testing.T) {
 	}
 }
 
+func TestDecoderInvalidData(t *testing.T) {
+	data := []byte{0x01, 0x83, 0x01, 0x02}
+	decoder := NewDecoder(bytes.NewReader(data))
+
+	var v1 interface{}
+	err := decoder.Decode(&v1)
+	if err != nil {
+		t.Errorf("Decode() returned error %v when decoding valid data item", err)
+	}
+
+	var v2 interface{}
+	err = decoder.Decode(&v2)
+	if err == nil {
+		t.Errorf("Decode() didn't return error when decoding invalid data item")
+	} else if err != io.ErrUnexpectedEOF {
+		t.Errorf("Decode() error %q, want %q", err, io.ErrUnexpectedEOF)
+	}
+}
+
 func TestDecoderStructTag(t *testing.T) {
 	type strc struct {
 		A string `json:"x" cbor:"a"`


### PR DESCRIPTION
Previously, Unmarshal() and Valid() ignored extra data (if any) after the current CBOR data item. This matched the behavior of Decoder.Decode().

However, Unmarshal() and Valid() are typically used for single CBOR data item, so extra data (if present) should return ExtraneousDataError.

This is a bug fix because the previous behavior of ignoring extra data didn't exactly match RFC 8949 regarding this and was also different from how encoding/json handles this.

The behavior for Decoder.Decode() is unchanged because extra data after reading a single CBOR data item is expected for Decoder with io.Reader.

Special thanks to @zensh for reporting this issue and proposing a solution.

Closes #359
 