### PR TITLE
Return buffer to pool when using Encoder

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -577,7 +577,7 @@ func (em *encMode) Marshal(v interface{}) ([]byte, error) {
 
 // NewEncoder returns a new encoder that writes to w using em EncMode.
 func (em *encMode) NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{w: w, em: em, e: getEncoderBuffer()}
+	return &Encoder{w: w, em: em}
 }
 
 type encoderBuffer struct {

--- a/stream.go
+++ b/stream.go
@@ -130,7 +130,6 @@ func (dec *Decoder) overwriteBuf(newBuf []byte) {
 type Encoder struct {
 	w          io.Writer
 	em         *encMode
-	e          *encoderBuffer
 	indefTypes []cborType
 }
 
@@ -157,11 +156,14 @@ func (enc *Encoder) Encode(v interface{}) error {
 		}
 	}
 
-	err := encode(enc.e, enc.em, reflect.ValueOf(v))
+	buf := getEncoderBuffer()
+
+	err := encode(buf, enc.em, reflect.ValueOf(v))
 	if err == nil {
-		_, err = enc.e.WriteTo(enc.w)
+		_, err = enc.w.Write(buf.Bytes())
 	}
-	enc.e.Reset()
+
+	putEncoderBuffer(buf)
 	return err
 }
 


### PR DESCRIPTION
This PR makes `Encoder.Encode()` reuse and return the buffer from a pool by default.

Benchmarks that create a new `Encoder` inside a loop for each call to `Encoder.Encode()` will show improved speed and less memory use.  However, benchmarks that reuse same `Encoder` in each call to `Encoder.Encode()` will show some reduced speed from the overhead of returning the buffer to the pool.

Closes #332