### PR TITLE
Retry in decoder if Read() returns 0 bytes read with nil error

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -579,7 +579,7 @@ type decoder struct {
 }
 
 // value decodes CBOR data item into the value pointed to by v.
-// If CBOR data item fails to be decode into v,
+// If CBOR data item fails to be decoded into v,
 // error is returned and offset is moved to the next CBOR data item.
 // Precondition: d.data contains at least one valid CBOR data item.
 func (d *decoder) value(v interface{}) error {

--- a/stream_test.go
+++ b/stream_test.go
@@ -21,37 +21,51 @@ func TestDecoder(t *testing.T) {
 			buf.Write(tc.cborData)
 		}
 	}
-	decoder := NewDecoder(&buf)
-	bytesRead := 0
-	for i := 0; i < 5; i++ {
-		for _, tc := range unmarshalTests {
-			var v interface{}
-			if err := decoder.Decode(&v); err != nil {
-				t.Fatalf("Decode() returned error %v", err)
-			}
-			if tm, ok := tc.emptyInterfaceValue.(time.Time); ok {
-				if vt, ok := v.(time.Time); !ok || !tm.Equal(vt) {
-					t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
-				}
-			} else if !reflect.DeepEqual(v, tc.emptyInterfaceValue) {
-				t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
-			}
-			bytesRead += len(tc.cborData)
-			if decoder.NumBytesRead() != bytesRead {
-				t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
-			}
-		}
+
+	testCases := []struct {
+		name   string
+		reader io.Reader
+	}{
+		{"bytes.Buffer", &buf},
+		{"1 byte reader", newNBytesReader(buf.Bytes(), 1)},
+		{"toggled reader", newToggledReader(buf.Bytes(), 1)},
 	}
-	for i := 0; i < 2; i++ {
-		// no more data
-		var v interface{}
-		err := decoder.Decode(&v)
-		if v != nil {
-			t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
-		}
-		if err != io.EOF {
-			t.Errorf("Decode() returned error %v, want io.EOF (no more data)", err)
-		}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoder := NewDecoder(tc.reader)
+			bytesRead := 0
+			for i := 0; i < 5; i++ {
+				for _, tc := range unmarshalTests {
+					var v interface{}
+					if err := decoder.Decode(&v); err != nil {
+						t.Fatalf("Decode() returned error %v", err)
+					}
+					if tm, ok := tc.emptyInterfaceValue.(time.Time); ok {
+						if vt, ok := v.(time.Time); !ok || !tm.Equal(vt) {
+							t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+						}
+					} else if !reflect.DeepEqual(v, tc.emptyInterfaceValue) {
+						t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+					}
+					bytesRead += len(tc.cborData)
+					if decoder.NumBytesRead() != bytesRead {
+						t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+					}
+				}
+			}
+			for i := 0; i < 2; i++ {
+				// no more data
+				var v interface{}
+				err := decoder.Decode(&v)
+				if v != nil {
+					t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
+				}
+				if err != io.EOF {
+					t.Errorf("Decode() returned error %v, want io.EOF (no more data)", err)
+				}
+			}
+		})
 	}
 }
 
@@ -64,50 +78,64 @@ func TestDecoderUnmarshalTypeError(t *testing.T) {
 			}
 		}
 	}
-	decoder := NewDecoder(&buf)
-	bytesRead := 0
-	for i := 0; i < 5; i++ {
-		for _, tc := range unmarshalTests {
-			for _, typ := range tc.wrongTypes {
-				v := reflect.New(typ)
-				if err := decoder.Decode(v.Interface()); err == nil {
-					t.Errorf("Decode(0x%x) didn't return an error, want UnmarshalTypeError", tc.cborData)
-				} else if _, ok := err.(*UnmarshalTypeError); !ok {
-					t.Errorf("Decode(0x%x) returned wrong error type %T, want UnmarshalTypeError", tc.cborData, err)
-				}
-				bytesRead += len(tc.cborData)
-				if decoder.NumBytesRead() != bytesRead {
-					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
-				}
 
-				var vi interface{}
-				if err := decoder.Decode(&vi); err != nil {
-					t.Errorf("Decode() returned error %v", err)
-				}
-				if tm, ok := tc.emptyInterfaceValue.(time.Time); ok {
-					if vt, ok := vi.(time.Time); !ok || !tm.Equal(vt) {
-						t.Errorf("Decode() = %v (%T), want %v (%T)", vi, vi, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+	testCases := []struct {
+		name   string
+		reader io.Reader
+	}{
+		{"bytes.Buffer", &buf},
+		{"1 byte reader", newNBytesReader(buf.Bytes(), 1)},
+		{"toggled reader", newToggledReader(buf.Bytes(), 1)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoder := NewDecoder(tc.reader)
+			bytesRead := 0
+			for i := 0; i < 5; i++ {
+				for _, tc := range unmarshalTests {
+					for _, typ := range tc.wrongTypes {
+						v := reflect.New(typ)
+						if err := decoder.Decode(v.Interface()); err == nil {
+							t.Errorf("Decode(0x%x) didn't return an error, want UnmarshalTypeError", tc.cborData)
+						} else if _, ok := err.(*UnmarshalTypeError); !ok {
+							t.Errorf("Decode(0x%x) returned wrong error type %T, want UnmarshalTypeError", tc.cborData, err)
+						}
+						bytesRead += len(tc.cborData)
+						if decoder.NumBytesRead() != bytesRead {
+							t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+						}
+
+						var vi interface{}
+						if err := decoder.Decode(&vi); err != nil {
+							t.Errorf("Decode() returned error %v", err)
+						}
+						if tm, ok := tc.emptyInterfaceValue.(time.Time); ok {
+							if vt, ok := vi.(time.Time); !ok || !tm.Equal(vt) {
+								t.Errorf("Decode() = %v (%T), want %v (%T)", vi, vi, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+							}
+						} else if !reflect.DeepEqual(vi, tc.emptyInterfaceValue) {
+							t.Errorf("Decode() = %v (%T), want %v (%T)", vi, vi, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+						}
+						bytesRead += len(tc.cborData)
+						if decoder.NumBytesRead() != bytesRead {
+							t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+						}
 					}
-				} else if !reflect.DeepEqual(vi, tc.emptyInterfaceValue) {
-					t.Errorf("Decode() = %v (%T), want %v (%T)", vi, vi, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
-				}
-				bytesRead += len(tc.cborData)
-				if decoder.NumBytesRead() != bytesRead {
-					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
 				}
 			}
-		}
-	}
-	for i := 0; i < 2; i++ {
-		// no more data
-		var v interface{}
-		err := decoder.Decode(&v)
-		if v != nil {
-			t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
-		}
-		if err != io.EOF {
-			t.Errorf("Decode() returned error %v, want io.EOF (no more data)", err)
-		}
+			for i := 0; i < 2; i++ {
+				// no more data
+				var v interface{}
+				err := decoder.Decode(&v)
+				if v != nil {
+					t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
+				}
+				if err != io.EOF {
+					t.Errorf("Decode() returned error %v, want io.EOF (no more data)", err)
+				}
+			}
+		})
 	}
 }
 
@@ -118,36 +146,50 @@ func TestDecoderUnexpectedEOFError(t *testing.T) {
 	}
 	buf.Truncate(buf.Len() - 1)
 
-	decoder := NewDecoder(&buf)
-	bytesRead := 0
-	for i := 0; i < len(unmarshalTests)-1; i++ {
-		tc := unmarshalTests[i]
-		var v interface{}
-		if err := decoder.Decode(&v); err != nil {
-			t.Fatalf("Decode() returned error %v", err)
-		}
-		if tm, ok := tc.emptyInterfaceValue.(time.Time); ok {
-			if vt, ok := v.(time.Time); !ok || !tm.Equal(vt) {
-				t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
-			}
-		} else if !reflect.DeepEqual(v, tc.emptyInterfaceValue) {
-			t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
-		}
-		bytesRead += len(tc.cborData)
-		if decoder.NumBytesRead() != bytesRead {
-			t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
-		}
+	testCases := []struct {
+		name   string
+		reader io.Reader
+	}{
+		{"bytes.Buffer", &buf},
+		{"1 byte reader", newNBytesReader(buf.Bytes(), 1)},
+		{"toggled reader", newToggledReader(buf.Bytes(), 1)},
 	}
-	for i := 0; i < 2; i++ {
-		// truncated data
-		var v interface{}
-		err := decoder.Decode(&v)
-		if v != nil {
-			t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
-		}
-		if err != io.ErrUnexpectedEOF {
-			t.Errorf("Decode() returned error %v, want io.UnexpectedEOF (truncated data)", err)
-		}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			decoder := NewDecoder(tc.reader)
+			bytesRead := 0
+			for i := 0; i < len(unmarshalTests)-1; i++ {
+				tc := unmarshalTests[i]
+				var v interface{}
+				if err := decoder.Decode(&v); err != nil {
+					t.Fatalf("Decode() returned error %v", err)
+				}
+				if tm, ok := tc.emptyInterfaceValue.(time.Time); ok {
+					if vt, ok := v.(time.Time); !ok || !tm.Equal(vt) {
+						t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+					}
+				} else if !reflect.DeepEqual(v, tc.emptyInterfaceValue) {
+					t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+				}
+				bytesRead += len(tc.cborData)
+				if decoder.NumBytesRead() != bytesRead {
+					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+				}
+			}
+			for i := 0; i < 2; i++ {
+				// truncated data
+				var v interface{}
+				err := decoder.Decode(&v)
+				if v != nil {
+					t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
+				}
+				if err != io.ErrUnexpectedEOF {
+					t.Errorf("Decode() returned error %v, want io.UnexpectedEOF (truncated data)", err)
+				}
+			}
+		})
 	}
 }
 
@@ -160,36 +202,114 @@ func TestDecoderReadError(t *testing.T) {
 
 	readerErr := errors.New("reader error")
 
-	decoder := NewDecoder(NewErrorReader(buf.Bytes(), readerErr))
-	bytesRead := 0
-	for i := 0; i < len(unmarshalTests)-1; i++ {
-		tc := unmarshalTests[i]
-		var v interface{}
-		if err := decoder.Decode(&v); err != nil {
-			t.Fatalf("Decode() returned error %v", err)
-		}
-		if tm, ok := tc.emptyInterfaceValue.(time.Time); ok {
-			if vt, ok := v.(time.Time); !ok || !tm.Equal(vt) {
-				t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
-			}
-		} else if !reflect.DeepEqual(v, tc.emptyInterfaceValue) {
-			t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
-		}
-		bytesRead += len(tc.cborData)
-		if decoder.NumBytesRead() != bytesRead {
-			t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
-		}
+	testCases := []struct {
+		name   string
+		reader io.Reader
+	}{
+		{"byte reader", newNBytesReaderWithError(buf.Bytes(), 512, readerErr)},
+		{"1 byte reader", newNBytesReaderWithError(buf.Bytes(), 1, readerErr)},
+		{"toggled reader", newToggledReaderWithError(buf.Bytes(), 1, readerErr)},
 	}
-	for i := 0; i < 2; i++ {
-		// truncated data because Reader returned error
-		var v interface{}
-		err := decoder.Decode(&v)
-		if v != nil {
-			t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
-		}
-		if err != readerErr {
-			t.Errorf("Decode() returned error %v, want reader error", err)
-		}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoder := NewDecoder(tc.reader)
+			bytesRead := 0
+			for i := 0; i < len(unmarshalTests)-1; i++ {
+				tc := unmarshalTests[i]
+				var v interface{}
+				if err := decoder.Decode(&v); err != nil {
+					t.Fatalf("Decode() returned error %v", err)
+				}
+				if tm, ok := tc.emptyInterfaceValue.(time.Time); ok {
+					if vt, ok := v.(time.Time); !ok || !tm.Equal(vt) {
+						t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+					}
+				} else if !reflect.DeepEqual(v, tc.emptyInterfaceValue) {
+					t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+				}
+				bytesRead += len(tc.cborData)
+				if decoder.NumBytesRead() != bytesRead {
+					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+				}
+			}
+			for i := 0; i < 2; i++ {
+				// truncated data because Reader returned error
+				var v interface{}
+				err := decoder.Decode(&v)
+				if v != nil {
+					t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
+				}
+				if err != readerErr {
+					t.Errorf("Decode() returned error %v, want reader error", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDecoderNoData(t *testing.T) {
+	readerErr := errors.New("reader error")
+
+	testCases := []struct {
+		name    string
+		reader  io.Reader
+		wantErr error
+	}{
+		{"byte.Buffer", new(bytes.Buffer), io.EOF},
+		{"1 byte reader", newNBytesReaderWithError(nil, 0, readerErr), readerErr},
+		{"toggled reader", newToggledReaderWithError(nil, 0, readerErr), readerErr},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoder := NewDecoder(tc.reader)
+			for i := 0; i < 2; i++ {
+				var v interface{}
+				err := decoder.Decode(&v)
+				if v != nil {
+					t.Errorf("Decode() = %v (%T), want nil", v, v)
+				}
+				if err != tc.wantErr {
+					t.Errorf("Decode() returned error %v, want error %v", err, tc.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestDecoderRecoverableReadError(t *testing.T) {
+	cborData := hexDecode("83010203") // [1,2,3]
+	wantValue := []interface{}{uint64(1), uint64(2), uint64(3)}
+	recoverableReaderErr := errors.New("recoverable reader error")
+
+	decoder := NewDecoder(newRecoverableReader(cborData, 1, recoverableReaderErr))
+
+	var v interface{}
+	err := decoder.Decode(&v)
+	if err != recoverableReaderErr {
+		t.Fatalf("Decode() returned error %v, want error %v", err, recoverableReaderErr)
+	}
+
+	err = decoder.Decode(&v)
+	if err != nil {
+		t.Fatalf("Decode() returned error %v", err)
+	}
+	if !reflect.DeepEqual(v, wantValue) {
+		t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, wantValue, wantValue)
+	}
+	if decoder.NumBytesRead() != len(cborData) {
+		t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), len(cborData))
+	}
+
+	// no more data
+	v = interface{}(nil)
+	err = decoder.Decode(&v)
+	if v != nil {
+		t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
+	}
+	if err != io.EOF {
+		t.Errorf("Decode() returned error %v, want io.EOF (no more data)", err)
 	}
 }
 
@@ -219,25 +339,39 @@ func TestDecoderSkip(t *testing.T) {
 			buf.Write(tc.cborData)
 		}
 	}
-	decoder := NewDecoder(&buf)
-	bytesRead := 0
-	for i := 0; i < 5; i++ {
-		for _, tc := range unmarshalTests {
-			if err := decoder.Skip(); err != nil {
-				t.Fatalf("Skip() returned error %v", err)
-			}
-			bytesRead += len(tc.cborData)
-			if decoder.NumBytesRead() != bytesRead {
-				t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
-			}
-		}
+
+	testCases := []struct {
+		name   string
+		reader io.Reader
+	}{
+		{"bytes.Buffer", &buf},
+		{"1 byte reader", newNBytesReader(buf.Bytes(), 1)},
+		{"toggled reader", newToggledReader(buf.Bytes(), 1)},
 	}
-	for i := 0; i < 2; i++ {
-		// no more data
-		err := decoder.Skip()
-		if err != io.EOF {
-			t.Errorf("Skip() returned error %v, want io.EOF (no more data)", err)
-		}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoder := NewDecoder(tc.reader)
+			bytesRead := 0
+			for i := 0; i < 5; i++ {
+				for _, tc := range unmarshalTests {
+					if err := decoder.Skip(); err != nil {
+						t.Fatalf("Skip() returned error %v", err)
+					}
+					bytesRead += len(tc.cborData)
+					if decoder.NumBytesRead() != bytesRead {
+						t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+					}
+				}
+			}
+			for i := 0; i < 2; i++ {
+				// no more data
+				err := decoder.Skip()
+				if err != io.EOF {
+					t.Errorf("Skip() returned error %v, want io.EOF (no more data)", err)
+				}
+			}
+		})
 	}
 }
 
@@ -248,26 +382,39 @@ func TestDecoderSkipInvalidDataError(t *testing.T) {
 	}
 	buf.WriteByte(0x3e)
 
-	decoder := NewDecoder(&buf)
-	bytesRead := 0
-	for i := 0; i < len(unmarshalTests); i++ {
-		tc := unmarshalTests[i]
-		if err := decoder.Skip(); err != nil {
-			t.Fatalf("Skip() returned error %v", err)
-		}
-		bytesRead += len(tc.cborData)
-		if decoder.NumBytesRead() != bytesRead {
-			t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
-		}
+	testCases := []struct {
+		name   string
+		reader io.Reader
+	}{
+		{"bytes.Buffer", &buf},
+		{"1 byte reader", newNBytesReader(buf.Bytes(), 1)},
+		{"toggled reader", newToggledReader(buf.Bytes(), 1)},
 	}
-	for i := 0; i < 2; i++ {
-		// last data item is invalid
-		err := decoder.Skip()
-		if err == nil {
-			t.Fatalf("Skip() didn't return error")
-		} else if !strings.Contains(err.Error(), "cbor: invalid additional information") {
-			t.Errorf("Skip() error %q, want \"cbor: invalid additional information\"", err)
-		}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoder := NewDecoder(tc.reader)
+			bytesRead := 0
+			for i := 0; i < len(unmarshalTests); i++ {
+				tc := unmarshalTests[i]
+				if err := decoder.Skip(); err != nil {
+					t.Fatalf("Skip() returned error %v", err)
+				}
+				bytesRead += len(tc.cborData)
+				if decoder.NumBytesRead() != bytesRead {
+					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+				}
+			}
+			for i := 0; i < 2; i++ {
+				// last data item is invalid
+				err := decoder.Skip()
+				if err == nil {
+					t.Fatalf("Skip() didn't return error")
+				} else if !strings.Contains(err.Error(), "cbor: invalid additional information") {
+					t.Errorf("Skip() error %q, want \"cbor: invalid additional information\"", err)
+				}
+			}
+		})
 	}
 }
 
@@ -278,24 +425,37 @@ func TestDecoderSkipUnexpectedEOFError(t *testing.T) {
 	}
 	buf.Truncate(buf.Len() - 1)
 
-	decoder := NewDecoder(&buf)
-	bytesRead := 0
-	for i := 0; i < len(unmarshalTests)-1; i++ {
-		tc := unmarshalTests[i]
-		if err := decoder.Skip(); err != nil {
-			t.Fatalf("Skip() returned error %v", err)
-		}
-		bytesRead += len(tc.cborData)
-		if decoder.NumBytesRead() != bytesRead {
-			t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
-		}
+	testCases := []struct {
+		name   string
+		reader io.Reader
+	}{
+		{"bytes.Buffer", &buf},
+		{"1 byte reader", newNBytesReader(buf.Bytes(), 1)},
+		{"toggled reader", newToggledReader(buf.Bytes(), 1)},
 	}
-	for i := 0; i < 2; i++ {
-		// last data item is invalid
-		err := decoder.Skip()
-		if err != io.ErrUnexpectedEOF {
-			t.Errorf("Skip() returned error %v, want io.ErrUnexpectedEOF (truncated data)", err)
-		}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoder := NewDecoder(tc.reader)
+			bytesRead := 0
+			for i := 0; i < len(unmarshalTests)-1; i++ {
+				tc := unmarshalTests[i]
+				if err := decoder.Skip(); err != nil {
+					t.Fatalf("Skip() returned error %v", err)
+				}
+				bytesRead += len(tc.cborData)
+				if decoder.NumBytesRead() != bytesRead {
+					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+				}
+			}
+			for i := 0; i < 2; i++ {
+				// last data item is invalid
+				err := decoder.Skip()
+				if err != io.ErrUnexpectedEOF {
+					t.Errorf("Skip() returned error %v, want io.ErrUnexpectedEOF (truncated data)", err)
+				}
+			}
+		})
 	}
 }
 
@@ -308,24 +468,89 @@ func TestDecoderSkipReadError(t *testing.T) {
 
 	readerErr := errors.New("reader error")
 
-	decoder := NewDecoder(NewErrorReader(buf.Bytes(), readerErr))
-	bytesRead := 0
-	for i := 0; i < len(unmarshalTests)-1; i++ {
-		tc := unmarshalTests[i]
-		if err := decoder.Skip(); err != nil {
-			t.Fatalf("Skip() returned error %v", err)
-		}
-		bytesRead += len(tc.cborData)
-		if decoder.NumBytesRead() != bytesRead {
-			t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
-		}
+	testCases := []struct {
+		name   string
+		reader io.Reader
+	}{
+		{"byte reader", newNBytesReaderWithError(buf.Bytes(), 512, readerErr)},
+		{"1 byte reader", newNBytesReaderWithError(buf.Bytes(), 1, readerErr)},
+		{"toggled reader", newToggledReaderWithError(buf.Bytes(), 1, readerErr)},
 	}
-	for i := 0; i < 2; i++ {
-		// truncated data because Reader returned error
-		err := decoder.Skip()
-		if err != readerErr {
-			t.Errorf("Skip() returned error %v, want reader error", err)
-		}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoder := NewDecoder(tc.reader)
+			bytesRead := 0
+			for i := 0; i < len(unmarshalTests)-1; i++ {
+				tc := unmarshalTests[i]
+				if err := decoder.Skip(); err != nil {
+					t.Fatalf("Skip() returned error %v", err)
+				}
+				bytesRead += len(tc.cborData)
+				if decoder.NumBytesRead() != bytesRead {
+					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+				}
+			}
+			for i := 0; i < 2; i++ {
+				// truncated data because Reader returned error
+				err := decoder.Skip()
+				if err != readerErr {
+					t.Errorf("Skip() returned error %v, want reader error", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDecoderSkipNoData(t *testing.T) {
+	readerErr := errors.New("reader error")
+
+	testCases := []struct {
+		name    string
+		reader  io.Reader
+		wantErr error
+	}{
+		{"byte.Buffer", new(bytes.Buffer), io.EOF},
+		{"1 byte reader", newNBytesReaderWithError(nil, 0, readerErr), readerErr},
+		{"toggled reader", newToggledReaderWithError(nil, 0, readerErr), readerErr},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			decoder := NewDecoder(tc.reader)
+			for i := 0; i < 2; i++ {
+				err := decoder.Skip()
+				if err != tc.wantErr {
+					t.Errorf("Decode() returned error %v, want error %v", err, tc.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestDecoderSkipRecoverableReadError(t *testing.T) {
+	cborData := hexDecode("83010203") // [1,2,3]
+	recoverableReaderErr := errors.New("recoverable reader error")
+
+	decoder := NewDecoder(newRecoverableReader(cborData, 1, recoverableReaderErr))
+
+	err := decoder.Skip()
+	if err != recoverableReaderErr {
+		t.Fatalf("Skip() returned error %v, want error %v", err, recoverableReaderErr)
+	}
+
+	err = decoder.Skip()
+	if err != nil {
+		t.Fatalf("Skip() returned error %v", err)
+	}
+	if decoder.NumBytesRead() != len(cborData) {
+		t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), len(cborData))
+	}
+
+	// no more data
+	err = decoder.Skip()
+	if err != io.EOF {
+		t.Errorf("Skip() returned error %v, want io.EOF (no more data)", err)
 	}
 }
 
@@ -663,24 +888,107 @@ func TestNilRawMessageUnmarshalCBORError(t *testing.T) {
 	}
 }
 
-type ErrorReader struct {
-	data []byte
-	off  int
-	err  error
+// nBytesReader reads at most maxBytesPerRead into b.  It also returns error at the last read.
+type nBytesReader struct {
+	data            []byte
+	maxBytesPerRead int
+	off             int
+	err             error
 }
 
-func NewErrorReader(data []byte, err error) *ErrorReader {
-	return &ErrorReader{data: data, err: err}
+func newNBytesReader(data []byte, maxBytesPerRead int) *nBytesReader {
+	return &nBytesReader{
+		data:            append([]byte{}, data...),
+		maxBytesPerRead: maxBytesPerRead,
+		err:             io.EOF,
+	}
 }
 
-func (r *ErrorReader) Read(b []byte) (int, error) {
+func newNBytesReaderWithError(data []byte, maxBytesPerRead int, err error) *nBytesReader {
+	return &nBytesReader{
+		data:            append([]byte{}, data...),
+		maxBytesPerRead: maxBytesPerRead,
+		err:             err,
+	}
+}
+
+func (r *nBytesReader) Read(b []byte) (int, error) {
 	var n int
 	if r.off < len(r.data) {
-		n = copy(b, r.data[r.off:])
+		numOfBytesToRead := len(r.data) - r.off
+		if numOfBytesToRead > r.maxBytesPerRead {
+			numOfBytesToRead = r.maxBytesPerRead
+		}
+		n = copy(b, r.data[r.off:r.off+numOfBytesToRead])
 		r.off += n
 	}
-	if n < len(b) {
+	if r.off == len(r.data) {
 		return n, r.err
 	}
 	return n, nil
+}
+
+// toggledReader returns (0, nil) for every other read to mimic non-blocking read for stream reader.
+type toggledReader struct {
+	nBytesReader
+	toggle bool
+}
+
+func newToggledReader(data []byte, maxBytesPerRead int) *toggledReader {
+	return &toggledReader{
+		nBytesReader: nBytesReader{
+			data:            append([]byte{}, data...),
+			maxBytesPerRead: maxBytesPerRead,
+			err:             io.EOF,
+		},
+		toggle: true, // first read returns (0, nil)
+	}
+}
+
+func newToggledReaderWithError(data []byte, maxBytesPerRead int, err error) *toggledReader {
+	return &toggledReader{
+		nBytesReader: nBytesReader{
+			data:            append([]byte{}, data...),
+			maxBytesPerRead: maxBytesPerRead,
+			err:             err,
+		},
+		toggle: true, // first read returns (0, nil)
+	}
+}
+
+func (r *toggledReader) Read(b []byte) (int, error) {
+	defer func() {
+		r.toggle = !r.toggle
+	}()
+	if r.toggle {
+		return 0, nil
+	}
+	return r.nBytesReader.Read(b)
+}
+
+// recoverableReader returns a recoverable error at first read operation.
+type recoverableReader struct {
+	nBytesReader
+	recoverableErr error
+	first          bool
+}
+
+func newRecoverableReader(data []byte, maxBytesPerRead int, err error) *recoverableReader {
+	return &recoverableReader{
+		nBytesReader: nBytesReader{
+			data:            append([]byte{}, data...),
+			maxBytesPerRead: maxBytesPerRead,
+			err:             io.EOF,
+		},
+		recoverableErr: err,
+		first:          true,
+	}
+}
+
+func (r *recoverableReader) Read(b []byte) (int, error) {
+	if r.first {
+		r.first = false
+		return 0, r.recoverableErr
+	}
+	return r.nBytesReader.Read(b)
 }


### PR DESCRIPTION
Previously, `Decoder` did not properly handle the scenario of `Read` implementations returning 0 bytes read with nil error.

Go [docs](https://pkg.go.dev/io#Reader) for `io.Reader` discourage `Read` implementations from returning 0 bytes with nil error.  And callers should treat this as if nothing happened.

> Implementations of Read are discouraged from returning a zero byte count with a nil error, except when len(p) == 0. Callers should treat a return of 0 and nil as indicating that nothing happened; in particular it does not indicate EOF. 

This PR:
- Retries the call to `Read` if it returns (0, nil).
- Refactors error handling.
- Adds unit tests to reach 100% coverage of stream.go.  :100: :tada: 

Closes #385 - thanks @mixmasala for reporting this issue.