### PR TITLE
Use io.WriterTo interface when provided by the type

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -3699,3 +3699,26 @@ func TestMapWithSimpleValueKey(t *testing.T) {
 		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, encodedData, data)
 	}
 }
+
+func TestOmitEmptyForReaderWriter(t *testing.T) {
+	type T struct {
+		rw streamReaderWriter `cbor:"rw,omitempty"`
+	}
+
+	testCases := []roundTripTest{
+		{
+			"empty ReaderWriter",
+			streamReaderWriter{},
+			[]byte{0x40},
+		},
+		{
+			"empty struct containing empty streamReaderWriter",
+			T{rw: streamReaderWriter{}},
+			[]byte{0xa0},
+		},
+	}
+
+	em, _ := EncOptions{}.EncMode()
+	dm, _ := DecOptions{}.DecMode()
+	testRoundTrip(t, testCases, em, dm)
+}


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description

`MarshalBinary` and `MarshalCBOR` interfaces result in heap memory allocations. `io.WriterTo` & `io.ReadFrom` eliminates the need for temporary heap buffers.  

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

#### Checklist (for code PR only, ignore for docs PR)

- [X] Include unit tests that cover the new code
- [X] Pass all unit tests 
- [X] Pass all 18 ci linters (golint, gosec, staticcheck, etc.)
- [X] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [X] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [X] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

