### PR TITLE
Add UnmarshalFirst to DecMode interface

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -536,6 +536,14 @@ type DecMode interface {
 	// See the documentation for Unmarshal for details.
 	Unmarshal(data []byte, v interface{}) error
 
+	// UnmarshalFirst parses the first CBOR data item into the value pointed to by v
+	// using the decoding mode.  Any remaining bytes are returned in rest.
+	//
+	// If v is nil, not a pointer, or a nil pointer, UnmarshalFirst returns an error.
+	//
+	// See the documentation for Unmarshal for details.
+	UnmarshalFirst(data []byte, v interface{}) (rest []byte, err error)
+
 	// Valid checks whether data is a well-formed encoded CBOR data item and
 	// that it complies with configurable restrictions such as MaxNestedLevels,
 	// MaxArrayElements, MaxMapPairs, etc.

--- a/decode_test.go
+++ b/decode_test.go
@@ -6034,7 +6034,7 @@ func TestUnmarshalFirstInvalidItem(t *testing.T) {
 	invalidCBOR := hexDecode("83FF20030102")
 	var v interface{}
 	rest, err := UnmarshalFirst(invalidCBOR, &v)
-	if rest != nil {
+	if rest != nil || err == nil {
 		t.Errorf("UnmarshalFirst(0x%x) = (%x, %v), want (nil, err)", invalidCBOR, rest, err)
 	}
 }


### PR DESCRIPTION
`UnmarshalFirst()` was added in PR #398, so make it available in DecMode interface, too.

Closes #401 