### PR TITLE
Fix Diagnose to return io.EOF error on empty data

### DIFF
--- a/diagnose.go
+++ b/diagnose.go
@@ -210,6 +210,9 @@ func (di *diagnose) diag(cborSequence bool) (string, error) {
 			}
 
 		case io.EOF:
+			if firstItem {
+				return di.w.String(), err
+			}
 			return di.w.String(), nil
 
 		default:


### PR DESCRIPTION
Update `Diagnose()` to return `io.EOF` on empty input, to make it consistent with `DiagnoseFirst()`, `Unmarshal()`, and `UnmarshalFirst()`.

This was detected while updating fuzz tests for v2.5.0-beta3.

Closes #409 