### PR TITLE
Remove ignored UTF8 setting in diagMode()

### DIFF
--- a/diagnose.go
+++ b/diagnose.go
@@ -111,8 +111,6 @@ func (opts DiagOptions) diagMode() (*diagMode, error) {
 		MaxNestedLevels:  opts.MaxNestedLevels,
 		MaxArrayElements: opts.MaxArrayElements,
 		MaxMapPairs:      opts.MaxMapPairs,
-		// loosest decode options for diagnostic purpose.
-		UTF8: UTF8DecodeInvalid,
 	}.decMode()
 	if err != nil {
 		return nil, err

--- a/diagnose_test.go
+++ b/diagnose_test.go
@@ -583,14 +583,6 @@ func TestDiagnoseTextString(t *testing.T) {
 				ByteStringText: true,
 			},
 		},
-		// {
-		// 	"invalid UTF-8 text in text string",
-		// 	hexDecode("6d68656c6c6fffeee4bda0e5a5bd"),
-		// 	`"hello\u00ff\u00ee\u4f60\u597d"`,
-		// 	&DiagOptions{
-		// 		ByteStringText: true,
-		// 	},
-		// },
 		{
 			"valid grapheme cluster text in byte string",
 			hexDecode("583448656c6c6f2c2027e29da4efb88fe2808df09f94a5270ae4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122"),
@@ -615,14 +607,6 @@ func TestDiagnoseTextString(t *testing.T) {
 				ByteStringText: true,
 			},
 		},
-		// {
-		// 	"invalid grapheme cluster text in text string",
-		// 	hexDecode("783448656c6c6feeff27e29da4efb88fe2808df09f94a5270de4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122"),
-		// 	`"Hello\u00ee\u00ff'\u2764\ufe0f\u200d\ud83d\udd25'\r\u4f60\u597d\uff0c\"\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\""`,
-		// 	&DiagOptions{
-		// 		ByteStringText: true,
-		// 	},
-		// },
 		{
 			"indefinite length text string with no chunks",
 			hexDecode("7fff"),


### PR DESCRIPTION
Closes #416 

Unreleased functions `Diagnose()` and `DiagnoseFirst()` added in v2.5.0-beta3 were ignoring the setting of DecOptions.UTF8 = DecodeInvalidUTF8 (to allow decoding invalid UTF-8) in the underlying decoder.

This PR is a NOP which simply removes the ignored code (instead of making it work) because:

- Diagnostic functions rejecting invalid UTF-8 matches the default behavior of CBOR decoder.

- It currently doesn't make sense to display invalid UTF-8 text.   Diagnostic Notation described by RFC 8949 and the Extended Diagnostic Notation in Appendix G of RFC 8610 don't specify how to represent invalid UTF-8.