### PR TITLE
Update README for changes in cbor v2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ JSON: {"Foo":{"Qux":{}}}
 
 </details>
 
+Example using different struct tags together:
+
 ![alt text](https://github.com/fxamacker/images/raw/master/cbor/v2.3.0/cbor_struct_tags_api.svg?sanitize=1 "CBOR API and Go Struct Tags")
 
 API is mostly same as `encoding/json`, plus interfaces that simplify concurrency for CBOR options.


### PR DESCRIPTION
Changes:
- Add example decoding 181 bytes with encoding/gob and getting fatal "out of memory" error.
- Add example encoding 3-level nested Go struct with fxamacker/cbor to just 1 byte CBOR.
- Status:  mention extended beta period v2.5.0-beta (Dec 2022) -> v2.5.0 (Aug 2023)
- Reorder intro section.
- Quick Start:  add "NOTE: Unmarshal returns ExtraneousDataError if there are remaining bytes, but new funcs UnmarshalFirst and DiagnoseFirst do not."
- Versions and API Changes:  mention extended beta period for non-API changes to behavior of existing functions.
- Versions and API Changes: add "This project avoids breaking changes to behavior of encoding and decoding functions unless required to improve conformance with supported RFCs (e.g. RFC 8949, RFC 8742, etc.) Visible changes that don't improve conformance to standards are typically made available as new opt-in settings or new functions."