### PR TITLE
Update CI and README

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -36,11 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: 1.21
         check-latest: true
     - name: Install x448/float16
       run: go get github.com/x448/float16@v0.8.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: [1.17, 1.19, 1.20, 1.21]
+        go-version: [1.17, 1.19, '1.20', 1.21]
     steps:
     - name: Install Go
       uses: actions/setup-go@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: [1.17, 1.18, 1.19]
+        go-version: [1.17, 1.19, 1.20, 1.21]
     steps:
     - name: Install Go
       uses: actions/setup-go@v4
@@ -35,7 +35,7 @@ jobs:
         check-latest: true
         
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
         check-latest: true
     - name: Install latest from golang.org
       run: go install golang.org/x/vuln/cmd/govulncheck@da4b74a5408a0116e9a2dde953659a7b0956dc56 # v1.0.1

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - name: Set up Go
@@ -42,6 +42,6 @@ jobs:
         go-version: 1.20.x
         check-latest: true
     - name: Install latest from golang.org
-      run: go install golang.org/x/vuln/cmd/govulncheck@f69de671333b611ab6b6f21f8ff0ab53f6d96c61 # v1.0.0
+      run: go install golang.org/x/vuln/cmd/govulncheck@da4b74a5408a0116e9a2dde953659a7b0956dc56 # v1.0.1
     - name: Run govulncheck      
       run: govulncheck -show=traces ./...

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -27,13 +27,11 @@
 #   1. GOLINTERS_VERSION
 #   2. GOLINTERS_TGZ_DGST
 #
-# Release v1.52.2 (May 14, 2023)
-#   - Bump Go to 1.20
-#   - Bump actions/setup-go to v4
-#   - Bump golangci-lint to 1.52.2
-#   - Hash of golangci-lint-1.52.2-linux-amd64.tar.gz
-#     - SHA-256: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501
-#                This SHA-256 digest matches golangci-lint-1.52.2-checksums.txt at
+# Release v1.53.3 (June 25, 2023)
+#   - Bump golangci-lint to 1.53.3
+#   - Hash of golangci-lint-1.53.3-linux-amd64.tar.gz
+#     - SHA-256: 4f62007ca96372ccba54760e2ed39c2446b40ec24d9a90c21aad9f2fdf6cf0da
+#                This SHA-256 digest matches golangci-lint-1.53.3-checksums.txt at
 #                https://github.com/golangci/golangci-lint/releases
 #
 name: linters
@@ -49,9 +47,9 @@ on:
 
 env:
   GO_VERSION: '1.20'
-  GOLINTERS_VERSION: 1.52.2
+  GOLINTERS_VERSION: 1.53.3
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501
+  GOLINTERS_TGZ_DGST: 4f62007ca96372ccba54760e2ed39c2446b40ec24d9a90c21aad9f2fdf6cf0da
   GOLINTERS_TIMEOUT: 15m
   OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -62,7 +62,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/README.md
+++ b/README.md
@@ -523,10 +523,6 @@ geomean                                                      2.782              
 
 `fxamacker/cbor` is used in projects by Arm Ltd., Berlin Institute of Health at Charité, Chainlink, Cisco, Confidential Computing Consortium, ConsenSys, Dapper&nbsp;Labs, EdgeX&nbsp;Foundry, F5, Fraunhofer&#8209;AISEC, Linux&nbsp;Foundation, Microsoft, Mozilla, National&nbsp;Cybersecurity&nbsp;Agency&nbsp;of&nbsp;France (govt), Netherlands (govt), Oasis Protocol, Smallstep, Tailscale, Taurus SA, Teleport, TIBCO, and others.
 
-GitHub reports `fxamacker/cbor` is "Used by":
-- &nbsp;&nbsp; 220+ [repositories that depend on v1.x](https://github.com/fxamacker/cbor/network/dependents) (old version). Shown by default.
-- 2,450+ [repositories that depend on v2.x](https://github.com/fxamacker/cbor/network/dependents?package_id=UGFja2FnZS0yMjcwNDY1OTQ4) (current version).
-
 `fxamacker/cbor` passed multiple confidential security assessments.  A [nonconfidential security assessment](https://github.com/veraison/go-cose/blob/v1.0.0-rc.1/reports/NCC_Microsoft-go-cose-Report_2022-05-26_v1.0.pdf) (prepared by NCC Group for Microsoft Corporation) includes a subset of fxamacker/cbor v2.4.0 in its scope.
 
 ## Standards


### PR DESCRIPTION
Changes:
- Bump latest go-version to 1.21.
- Bump safer-golangci-lint.yml to 1.53.3
- Bump govulncheck to 1.0.1
- Bump actions/checkout to v4
- Update README to remove text about "Used by" count for v2 vs v1.