### PR TITLE
New options for encoding Go strings to and from CBOR byte strings

### DIFF
--- a/bytestring.go
+++ b/bytestring.go
@@ -57,6 +57,7 @@ func (bs *ByteString) UnmarshalCBOR(data []byte) error {
 		return &UnmarshalTypeError{CBORType: typ.String(), GoType: typeByteString.String()}
 	}
 
-	*bs = ByteString(d.parseByteString())
+	b, _ := d.parseByteString()
+	*bs = ByteString(b)
 	return nil
 }

--- a/diagnose.go
+++ b/diagnose.go
@@ -354,7 +354,7 @@ func (di *diagnose) item() error { //nolint:gocyclo
 		return di.writeString(strconv.FormatInt(nValue, 10))
 
 	case cborTypeByteString:
-		b := di.d.parseByteString()
+		b, _ := di.d.parseByteString()
 		return di.encodeByteString(b)
 
 	case cborTypeTextString:
@@ -418,7 +418,7 @@ func (di *diagnose) item() error { //nolint:gocyclo
 				return errors.New("cbor: tag number 2 must be followed by byte string, got " + nt.String())
 			}
 
-			b := di.d.parseByteString()
+			b, _ := di.d.parseByteString()
 			bi := new(big.Int).SetBytes(b)
 			return di.writeString(bi.String())
 
@@ -427,7 +427,7 @@ func (di *diagnose) item() error { //nolint:gocyclo
 				return errors.New("cbor: tag number 3 must be followed by byte string, got " + nt.String())
 			}
 
-			b := di.d.parseByteString()
+			b, _ := di.d.parseByteString()
 			bi := new(big.Int).SetBytes(b)
 			bi.Add(bi, big.NewInt(1))
 			bi.Neg(bi)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

#### PR Was Proposed and Welcomed in Currently Open Issue

- [x] This PR was proposed and welcomed by maintainer(s) in issue #446
- [x] Closes or Updates Issue #446

#### Checklist (for code PR only, ignore for docs PR)

- [x] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all 18 ci linters (golint, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

