### PR TITLE
Add options to support byte string map keys as struct field names

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -224,6 +224,15 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 			copy(flds[i].cborName[n:], flds[i].name)
 			e.Reset()
 
+			// If cborName contains a text string, then cborNameByteString contains a
+			// string that has the byte string major type but is otherwise identical to
+			// cborName.
+			flds[i].cborNameByteString = make([]byte, len(flds[i].cborName))
+			copy(flds[i].cborNameByteString, flds[i].cborName)
+			// Reset encoded CBOR type to byte string, preserving the "additional
+			// information" bits:
+			flds[i].cborNameByteString[0] = byte(cborTypeByteString) | (flds[i].cborNameByteString[0] & 0x1f)
+
 			hasKeyAsStr = true
 		}
 

--- a/structfields.go
+++ b/structfields.go
@@ -10,17 +10,18 @@ import (
 )
 
 type field struct {
-	name      string
-	nameAsInt int64 // used to decoder to match field name with CBOR int
-	cborName  []byte
-	idx       []int
-	typ       reflect.Type
-	ef        encodeFunc
-	ief       isEmptyFunc
-	typInfo   *typeInfo // used to decoder to reuse type info
-	tagged    bool      // used to choose dominant field (at the same level tagged fields dominate untagged fields)
-	omitEmpty bool      // used to skip empty field
-	keyAsInt  bool      // used to encode/decode field name as int
+	name               string
+	nameAsInt          int64 // used to decoder to match field name with CBOR int
+	cborName           []byte
+	cborNameByteString []byte // major type 2 name encoding iff cborName has major type 3
+	idx                []int
+	typ                reflect.Type
+	ef                 encodeFunc
+	ief                isEmptyFunc
+	typInfo            *typeInfo // used to decoder to reuse type info
+	tagged             bool      // used to choose dominant field (at the same level tagged fields dominate untagged fields)
+	omitEmpty          bool      // used to skip empty field
+	keyAsInt           bool      // used to encode/decode field name as int
 }
 
 type fields []*field


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description

Introduces one encode option and one decode option to control the CBOR major type of struct field names.

The current behavior on encode is to produce text strings for field names, unless a field has the `keyasint` tag option, in which case it will serialize as either a positive or negative CBOR int. That remains the default encode behavior, with the new option to produce byte strings instead of text strings for fields that do not have the `keyasint` tag option.

Decoding a CBOR map containing a byte string key into a Go struct value currently produces an error. By overriding the default value of the new decode option, byte string map keys can also be recognized as struct field names.

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

#### PR Was Proposed and Welcomed in Currently Open Issue

- [x] This PR was proposed and welcomed by maintainer(s) in issue #471
- [x] Closes or Updates Issue #471 

#### Checklist (for code PR only, ignore for docs PR)

- [x] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all 18 ci linters (golint, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

