### PR TITLE
Refactor map encoding to prep for Go version bump

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -7514,7 +7514,7 @@ func TestUnmarshalToInterface(t *testing.T) {
 			if err != nil {
 				t.Errorf("Marshal(%+v) returned error %v", tc.v, err)
 			} else if !bytes.Equal(data, tc.data) {
-				t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.v, data, tc.v)
+				t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.v, data, tc.data)
 			}
 
 			// Unmarshal to empty interface

--- a/encode_map_go117.go
+++ b/encode_map_go117.go
@@ -1,0 +1,49 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"reflect"
+)
+
+type mapKeyValueEncodeFunc struct {
+	kf, ef encodeFunc
+}
+
+func (me *mapKeyValueEncodeFunc) encodeKeyValues(e *encoderBuffer, em *encMode, v reflect.Value, kvs []keyValue) error {
+	trackKeyValueLength := len(kvs) == v.Len()
+
+	iter := v.MapRange()
+	for i := 0; iter.Next(); i++ {
+		off := e.Len()
+
+		if err := me.kf(e, em, iter.Key()); err != nil {
+			return err
+		}
+		if trackKeyValueLength {
+			kvs[i].keyLen = e.Len() - off
+		}
+
+		if err := me.ef(e, em, iter.Value()); err != nil {
+			return err
+		}
+		if trackKeyValueLength {
+			kvs[i].keyValueLen = e.Len() - off
+		}
+	}
+
+	return nil
+}
+
+func getEncodeMapFunc(t reflect.Type) encodeFunc {
+	kf, _ := getEncodeFunc(t.Key())
+	ef, _ := getEncodeFunc(t.Elem())
+	if kf == nil || ef == nil {
+		return nil
+	}
+	mkv := &mapKeyValueEncodeFunc{kf: kf, ef: ef}
+	return mapEncodeFunc{
+		e: mkv.encodeKeyValues,
+	}.encode
+}


### PR DESCRIPTION
Refactor old map encoding code to prep for Go version bump and reduce duplicate code required by upcoming PRs.

@dinhxuanvu opened issue and PR that shows impressive results :tada:  (both speedup & memory reduction!):
- #467
- #468

This PR refactors old code related to map encoding, so new PRs like #468 won't require as much duplicate code.