### PR TITLE
Support automatic conversion between text and binary string representations

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -387,6 +387,62 @@ func (fnm FieldNameMode) valid() bool {
 	return fnm >= 0 && fnm < maxFieldNameMode
 }
 
+// ByteSliceMode specifies how to encode slices of bytes.
+type ByteSliceMode int
+
+const (
+	// ByteSliceToByteString encodes slices of bytes to CBOR byte string (major type 2).
+	ByteSliceToByteString = iota
+
+	// ByteSliceToByteStringWithExpectedConversionToBase64URL encodes slices of bytes to CBOR
+	// byte string (major type 2) inside tag 21 (expected conversion to base64url encoding, see
+	// RFC 8949 Section 3.4.5.2).
+	ByteSliceToByteStringWithExpectedConversionToBase64URL
+
+	// ByteSliceToByteStringWithExpectedConversionToBase64 encodes slices of bytes to CBOR byte
+	// string (major type 2) inside tag 22 (expected conversion to base64 encoding, see RFC 8949
+	// Section 3.4.5.2).
+	ByteSliceToByteStringWithExpectedConversionToBase64
+
+	// ByteSliceToByteStringWithExpectedConversionToBase16 encodes slices of bytes to CBOR byte
+	// string (major type 2) inside tag 23 (expected conversion to base16 encoding, see RFC 8949
+	// Section 3.4.5.2).
+	ByteSliceToByteStringWithExpectedConversionToBase16
+)
+
+func (bsm ByteSliceMode) encodingTag() (uint64, error) {
+	switch bsm {
+	case ByteSliceToByteString:
+		return 0, nil
+	case ByteSliceToByteStringWithExpectedConversionToBase64URL:
+		return expectedLaterEncodingBase64URLTagNum, nil
+	case ByteSliceToByteStringWithExpectedConversionToBase64:
+		return expectedLaterEncodingBase64TagNum, nil
+	case ByteSliceToByteStringWithExpectedConversionToBase16:
+		return expectedLaterEncodingBase16TagNum, nil
+	}
+	return 0, errors.New("cbor: invalid ByteSlice " + strconv.Itoa(int(bsm)))
+}
+
+// ByteArrayMode specifies how to encode byte arrays.
+type ByteArrayMode int
+
+const (
+	// ByteArrayToByteSlice encodes byte arrays the same way that a byte slice with identical
+	// length and contents is encoded.
+	ByteArrayToByteSlice = iota
+
+	// ByteArrayToArray encodes byte arrays to the CBOR array type with one unsigned integer
+	// item for each byte in the array.
+	ByteArrayToArray
+
+	maxByteArrayMode
+)
+
+func (bam ByteArrayMode) valid() bool {
+	return bam >= 0 && bam < maxByteArrayMode
+}
+
 // EncOptions specifies encoding options.
 type EncOptions struct {
 	// Sort specifies sorting order.
@@ -431,6 +487,12 @@ type EncOptions struct {
 
 	// FieldName specifies the CBOR type to use when encoding struct field names.
 	FieldName FieldNameMode
+
+	// ByteSlice specifies how to encode byte slices.
+	ByteSlice ByteSliceMode
+
+	// ByteArray specifies how to encode byte arrays.
+	ByteArray ByteArrayMode
 }
 
 // CanonicalEncOptions returns EncOptions for "Canonical CBOR" encoding,
@@ -616,21 +678,31 @@ func (opts EncOptions) encMode() (*encMode, error) {
 	if !opts.FieldName.valid() {
 		return nil, errors.New("cbor: invalid FieldName " + strconv.Itoa(int(opts.FieldName)))
 	}
+	byteSliceEncodingTag, err := opts.ByteSlice.encodingTag()
+	if err != nil {
+		return nil, err
+	}
+	if !opts.ByteArray.valid() {
+		return nil, errors.New("cbor: invalid ByteArray " + strconv.Itoa(int(opts.ByteArray)))
+	}
 	em := encMode{
-		sort:            opts.Sort,
-		shortestFloat:   opts.ShortestFloat,
-		nanConvert:      opts.NaNConvert,
-		infConvert:      opts.InfConvert,
-		bigIntConvert:   opts.BigIntConvert,
-		time:            opts.Time,
-		timeTag:         opts.TimeTag,
-		indefLength:     opts.IndefLength,
-		nilContainers:   opts.NilContainers,
-		tagsMd:          opts.TagsMd,
-		omitEmpty:       opts.OmitEmpty,
-		stringType:      opts.String,
-		stringMajorType: stringMajorType,
-		fieldName:       opts.FieldName,
+		sort:                 opts.Sort,
+		shortestFloat:        opts.ShortestFloat,
+		nanConvert:           opts.NaNConvert,
+		infConvert:           opts.InfConvert,
+		bigIntConvert:        opts.BigIntConvert,
+		time:                 opts.Time,
+		timeTag:              opts.TimeTag,
+		indefLength:          opts.IndefLength,
+		nilContainers:        opts.NilContainers,
+		tagsMd:               opts.TagsMd,
+		omitEmpty:            opts.OmitEmpty,
+		stringType:           opts.String,
+		stringMajorType:      stringMajorType,
+		fieldName:            opts.FieldName,
+		byteSlice:            opts.ByteSlice,
+		byteSliceEncodingTag: byteSliceEncodingTag,
+		byteArray:            opts.ByteArray,
 	}
 	return &em, nil
 }
@@ -643,21 +715,24 @@ type EncMode interface {
 }
 
 type encMode struct {
-	tags            tagProvider
-	sort            SortMode
-	shortestFloat   ShortestFloatMode
-	nanConvert      NaNConvertMode
-	infConvert      InfConvertMode
-	bigIntConvert   BigIntConvertMode
-	time            TimeMode
-	timeTag         EncTagMode
-	indefLength     IndefLengthMode
-	nilContainers   NilContainersMode
-	tagsMd          TagsMode
-	omitEmpty       OmitEmptyMode
-	stringType      StringMode
-	stringMajorType cborType
-	fieldName       FieldNameMode
+	tags                 tagProvider
+	sort                 SortMode
+	shortestFloat        ShortestFloatMode
+	nanConvert           NaNConvertMode
+	infConvert           InfConvertMode
+	bigIntConvert        BigIntConvertMode
+	time                 TimeMode
+	timeTag              EncTagMode
+	indefLength          IndefLengthMode
+	nilContainers        NilContainersMode
+	tagsMd               TagsMode
+	omitEmpty            OmitEmptyMode
+	stringType           StringMode
+	stringMajorType      cborType
+	fieldName            FieldNameMode
+	byteSlice            ByteSliceMode
+	byteSliceEncodingTag uint64
+	byteArray            ByteArrayMode
 }
 
 var defaultEncMode, _ = EncOptions{}.encMode()
@@ -747,6 +822,8 @@ func (em *encMode) EncOptions() EncOptions {
 		OmitEmpty:     em.omitEmpty,
 		String:        em.stringType,
 		FieldName:     em.fieldName,
+		ByteSlice:     em.byteSlice,
+		ByteArray:     em.byteArray,
 	}
 }
 
@@ -1026,6 +1103,9 @@ func encodeByteString(e *encoderBuffer, em *encMode, v reflect.Value) error {
 		e.Write(cborNil)
 		return nil
 	}
+	if vk == reflect.Slice && v.Type().Elem().Kind() == reflect.Uint8 && em.byteSliceEncodingTag != 0 {
+		encodeHead(e, byte(cborTypeTag), em.byteSliceEncodingTag)
+	}
 	if b := em.encTagBytes(v.Type()); b != nil {
 		e.Write(b)
 	}
@@ -1059,6 +1139,9 @@ type arrayEncodeFunc struct {
 }
 
 func (ae arrayEncodeFunc) encode(e *encoderBuffer, em *encMode, v reflect.Value) error {
+	if em.byteArray == ByteArrayToByteSlice && v.Type().Elem().Kind() == reflect.Uint8 {
+		return encodeByteString(e, em, v)
+	}
 	if v.Kind() == reflect.Slice && v.IsNil() && em.nilContainers == NilContainerAsNull {
 		e.Write(cborNil)
 		return nil
@@ -1570,10 +1653,12 @@ func getEncodeFuncInternal(t reflect.Type) (encodeFunc, isEmptyFunc) {
 		return encodeFloat, isEmptyFloat
 	case reflect.String:
 		return encodeString, isEmptyString
-	case reflect.Slice, reflect.Array:
+	case reflect.Slice:
 		if t.Elem().Kind() == reflect.Uint8 {
 			return encodeByteString, isEmptySlice
 		}
+		fallthrough
+	case reflect.Array:
 		f, _ := getEncodeFunc(t.Elem())
 		if f == nil {
 			return nil, nil

--- a/encode_test.go
+++ b/encode_test.go
@@ -3683,6 +3683,8 @@ func TestEncOptions(t *testing.T) {
 		OmitEmpty:     OmitEmptyGoValue,
 		String:        StringToByteString,
 		FieldName:     FieldNameToByteString,
+		ByteSlice:     ByteSliceToByteStringWithExpectedConversionToBase16,
+		ByteArray:     ByteArrayToArray,
 	}
 	ov := reflect.ValueOf(opts1)
 	for i := 0; i < ov.NumField(); i++ {
@@ -4418,6 +4420,205 @@ func TestSortModeFastShuffle(t *testing.T) {
 			}
 
 			t.Errorf("object encoded identically in %d consecutive trials using SortFastShuffle", tc.trials)
+		})
+	}
+}
+
+func TestInvalidByteSlice(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		opts         EncOptions
+		wantErrorMsg string
+	}{
+		{
+			name:         "below range of valid modes",
+			opts:         EncOptions{ByteSlice: -1},
+			wantErrorMsg: "cbor: invalid ByteSlice -1",
+		},
+		{
+			name:         "above range of valid modes",
+			opts:         EncOptions{ByteSlice: 101},
+			wantErrorMsg: "cbor: invalid ByteSlice 101",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.opts.EncMode()
+			if err == nil {
+				t.Errorf("EncMode() didn't return an error")
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("EncMode() returned error %q, want %q", err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestInvalidByteArray(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		opts         EncOptions
+		wantErrorMsg string
+	}{
+		{
+			name:         "below range of valid modes",
+			opts:         EncOptions{ByteArray: -1},
+			wantErrorMsg: "cbor: invalid ByteArray -1",
+		},
+		{
+			name:         "above range of valid modes",
+			opts:         EncOptions{ByteArray: 101},
+			wantErrorMsg: "cbor: invalid ByteArray 101",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.opts.EncMode()
+			if err == nil {
+				t.Errorf("EncMode() didn't return an error")
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("EncMode() returned error %q, want %q", err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestMarshalByteArrayMode(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		opts     EncOptions
+		in       interface{}
+		expected []byte
+	}{
+		{
+			name:     "byte array treated as byte slice by default",
+			opts:     EncOptions{},
+			in:       [1]byte{},
+			expected: []byte{0x41, 0x00},
+		},
+		{
+			name:     "byte array treated as byte slice with ByteArrayAsByteSlice",
+			opts:     EncOptions{ByteArray: ByteArrayToByteSlice},
+			in:       [1]byte{},
+			expected: []byte{0x41, 0x00},
+		},
+		{
+			name:     "byte array treated as array of integers with ByteArrayToArray",
+			opts:     EncOptions{ByteArray: ByteArrayToArray},
+			in:       [1]byte{},
+			expected: []byte{0x81, 0x00},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			em, err := tc.opts.EncMode()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			out, err := em.Marshal(tc.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(out) != string(tc.expected) {
+				t.Errorf("unexpected output, got 0x%x want 0x%x", out, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMarshalByteSliceMode(t *testing.T) {
+	type namedByteSlice []byte
+	ts := NewTagSet()
+	if err := ts.Add(TagOptions{EncTag: EncTagRequired}, reflect.TypeOf(namedByteSlice{}), 0xcc); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		tags     TagSet
+		opts     EncOptions
+		in       interface{}
+		expected []byte
+	}{
+		{
+			name:     "byte slice marshals to byte string by default",
+			opts:     EncOptions{},
+			in:       []byte{0xbb},
+			expected: []byte{0x41, 0xbb},
+		},
+		{
+			name:     "byte slice marshals to byte string by with ByteSliceToByteString",
+			opts:     EncOptions{ByteSlice: ByteSliceToByteString},
+			in:       []byte{0xbb},
+			expected: []byte{0x41, 0xbb},
+		},
+		{
+			name:     "byte slice marshaled to byte string enclosed in base64url expected encoding tag",
+			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase64URL},
+			in:       []byte{0xbb},
+			expected: []byte{0xd5, 0x41, 0xbb},
+		},
+		{
+			name:     "byte slice marshaled to byte string enclosed in base64 expected encoding tag",
+			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase64},
+			in:       []byte{0xbb},
+			expected: []byte{0xd6, 0x41, 0xbb},
+		},
+		{
+			name:     "byte slice marshaled to byte string enclosed in base16 expected encoding tag",
+			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase16},
+			in:       []byte{0xbb},
+			expected: []byte{0xd7, 0x41, 0xbb},
+		},
+		{
+			name:     "user-registered tag numbers are encoded with no expected encoding tag",
+			tags:     ts,
+			opts:     EncOptions{ByteSlice: ByteSliceToByteString},
+			in:       namedByteSlice{0xbb},
+			expected: []byte{0xd8, 0xcc, 0x41, 0xbb},
+		},
+		{
+			name:     "user-registered tag numbers are encoded after base64url expected encoding tag",
+			tags:     ts,
+			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase64URL},
+			in:       namedByteSlice{0xbb},
+			expected: []byte{0xd5, 0xd8, 0xcc, 0x41, 0xbb},
+		},
+		{
+			name:     "user-registered tag numbers are encoded after base64 expected encoding tag",
+			tags:     ts,
+			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase64},
+			in:       namedByteSlice{0xbb},
+			expected: []byte{0xd6, 0xd8, 0xcc, 0x41, 0xbb},
+		},
+		{
+			name:     "user-registered tag numbers are encoded after base16 expected encoding tag",
+			tags:     ts,
+			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase16},
+			in:       namedByteSlice{0xbb},
+			expected: []byte{0xd7, 0xd8, 0xcc, 0x41, 0xbb},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var em EncMode
+			if tc.tags != nil {
+				var err error
+				if em, err = tc.opts.EncModeWithTags(tc.tags); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				var err error
+				if em, err = tc.opts.EncMode(); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			out, err := em.Marshal(tc.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(out) != string(tc.expected) {
+				t.Errorf("unexpected output, got 0x%x want 0x%x", out, tc.expected)
+			}
 		})
 	}
 }

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,132 @@
+package cbor_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+// TestStdlibJSONCompatibility tests compatibility as a drop-in replacement for the standard library
+// encoding/json package on a round trip encoding from Go object to interface{}.
+func TestStdlibJSONCompatibility(t *testing.T) {
+	// TODO: With better coverage and compatibility, it could be useful to expose these option
+	// configurations to users.
+
+	enc, err := cbor.EncOptions{
+		ByteSlice: cbor.ByteSliceToByteStringWithExpectedConversionToBase64,
+		String:    cbor.StringToByteString,
+		ByteArray: cbor.ByteArrayToArray,
+	}.EncMode()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec, err := cbor.DecOptions{
+		DefaultByteStringType:     reflect.TypeOf(""),
+		ByteStringToString:        cbor.ByteStringToStringAllowedWithExpectedLaterEncoding,
+		ByteSliceExpectedEncoding: cbor.ByteSliceExpectedEncodingBase64,
+	}.DecMode()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name       string
+		original   interface{}
+		ifaceEqual bool // require equal intermediate interface{} values from both protocols
+	}{
+		{
+			name:       "byte slice to base64-encoded string",
+			original:   []byte("hello world"),
+			ifaceEqual: true,
+		},
+		{
+			name:       "byte array to array of integers",
+			original:   [11]byte{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'},
+			ifaceEqual: false, // encoding/json decodes the array elements to float64
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("original: %#v", tc.original)
+
+			j1, err := json.Marshal(tc.original)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("original to json: %s", string(j1))
+
+			c1, err := enc.Marshal(tc.original)
+			if err != nil {
+				t.Fatal(err)
+			}
+			diag1, err := cbor.Diagnose(c1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("original to cbor: %s", diag1)
+
+			var jintf interface{}
+			err = json.Unmarshal(j1, &jintf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("json to interface{} (%T): %#v", jintf, jintf)
+
+			var cintf interface{}
+			err = dec.Unmarshal(c1, &cintf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("cbor to interface{} (%T): %#v", cintf, cintf)
+
+			j2, err := json.Marshal(jintf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("interface{} to json: %s", string(j2))
+
+			c2, err := enc.Marshal(cintf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			diag2, err := cbor.Diagnose(c2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("interface{} to cbor: %s", diag2)
+
+			if !reflect.DeepEqual(jintf, cintf) {
+				if tc.ifaceEqual {
+					t.Errorf("native-to-interface{} via cbor differed from native-to-interface{} via json")
+				} else {
+					t.Logf("native-to-interface{} via cbor differed from native-to-interface{} via json")
+				}
+			}
+
+			jfinalValue := reflect.New(reflect.TypeOf(tc.original))
+			err = json.Unmarshal(j2, jfinalValue.Interface())
+			if err != nil {
+				t.Fatal(err)
+			}
+			jfinal := jfinalValue.Elem().Interface()
+			t.Logf("json to native: %#v", jfinal)
+			if !reflect.DeepEqual(tc.original, jfinal) {
+				t.Error("diff in json roundtrip")
+			}
+
+			cfinalValue := reflect.New(reflect.TypeOf(tc.original))
+			err = dec.Unmarshal(c2, cfinalValue.Interface())
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfinal := cfinalValue.Elem().Interface()
+			t.Logf("cbor to native: %#v", cfinal)
+			if !reflect.DeepEqual(tc.original, cfinal) {
+				t.Error("diff in cbor roundtrip")
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description

This is a proof-of-concept solution for https://github.com/fxamacker/cbor/issues/449. It includes a test that roundtrips a struct value with fields of types `[]byte` and `[5]byte` to `interface{}` and back to the original struct type, via both CBOR (using the features here) and via encoding/json.

```
    json_test.go:58: original: cbor_test.S{Bytes:[]uint8{0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64}, Arr:[5]uint8{0x68, 0x65, 0x6c, 0x6c, 0x6f}}
    json_test.go:64: original to json: {"bytes":"aGVsbG8gd29ybGQ=","arr":[104,101,108,108,111]}
    json_test.go:74: original to cbor: {'bytes': 22('hello world'), 'arr': [104, 101, 108, 108, 111]}
    json_test.go:81: json to interface{}: map[string]interface {}{"arr":[]interface {}{104, 101, 108, 108, 111}, "bytes":"aGVsbG8gd29ybGQ="}
    json_test.go:88: cbor to interface{}: map[string]interface {}{"arr":[]interface {}{0x68, 0x65, 0x6c, 0x6c, 0x6f}, "bytes":"aGVsbG8gd29ybGQ="}
    json_test.go:94: interface{} to json: {"arr":[104,101,108,108,111],"bytes":"aGVsbG8gd29ybGQ="}
    json_test.go:104: interface{} to cbor: {'bytes': 'aGVsbG8gd29ybGQ=', 'arr': [104, 101, 108, 108, 111]}
    json_test.go:108: native-to-interface{} via cbor differed from native-to-interface{} via json
    json_test.go:116: json to native: cbor_test.S{Bytes:[]uint8{0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64}, Arr:[5]uint8{0x68, 0x65, 0x6c, 0x6c, 0x6f}}
    json_test.go:126: cbor to native: cbor_test.S{Bytes:[]uint8{0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64}, Arr:[5]uint8{0x68, 0x65, 0x6c, 0x6c, 0x6f}}

```

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

#### PR Was Proposed and Welcomed in Currently Open Issue

- [ ] This PR was proposed and welcomed by maintainer(s) in issue #___
- [x] Closes or Updates Issue #449

#### Checklist (for code PR only, ignore for docs PR)

- [x] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all 18 ci linters (golint, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

