### PR TITLE
Check well-formedness of data from MarshalCBOR

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -790,9 +790,9 @@ func (dm *decMode) Unmarshal(data []byte, v interface{}) error {
 	d := decoder{data: data, dm: dm}
 
 	// Check well-formedness.
-	off := d.off               // Save offset before data validation
-	err := d.wellformed(false) // don't allow any extra data after valid data item.
-	d.off = off                // Restore offset
+	off := d.off                      // Save offset before data validation
+	err := d.wellformed(false, false) // don't allow any extra data after valid data item.
+	d.off = off                       // Restore offset
 	if err != nil {
 		return err
 	}
@@ -810,9 +810,9 @@ func (dm *decMode) UnmarshalFirst(data []byte, v interface{}) (rest []byte, err 
 	d := decoder{data: data, dm: dm}
 
 	// check well-formedness.
-	off := d.off             // Save offset before data validation
-	err = d.wellformed(true) // allow extra data after well-formed data item
-	d.off = off              // Restore offset
+	off := d.off                    // Save offset before data validation
+	err = d.wellformed(true, false) // allow extra data after well-formed data item
+	d.off = off                     // Restore offset
 
 	// If it is well-formed, parse the value. This is structured like this to allow
 	// better test coverage
@@ -853,7 +853,7 @@ func (dm *decMode) Valid(data []byte) error {
 // an ExtraneousDataError is returned.
 func (dm *decMode) Wellformed(data []byte) error {
 	d := decoder{data: data, dm: dm}
-	return d.wellformed(false)
+	return d.wellformed(false, false)
 }
 
 // NewDecoder returns a new decoder that reads from r using dm DecMode.

--- a/decode.go
+++ b/decode.go
@@ -601,69 +601,96 @@ const (
 	defaultMaxMapPairs = 131072
 	minMaxMapPairs     = 16
 	maxMaxMapPairs     = 2147483647
+
+	defaultMaxNestedLevels = 32
+	minMaxNestedLevels     = 4
+	maxMaxNestedLevels     = 65535
 )
 
 func (opts DecOptions) decMode() (*decMode, error) {
 	if !opts.DupMapKey.valid() {
 		return nil, errors.New("cbor: invalid DupMapKey " + strconv.Itoa(int(opts.DupMapKey)))
 	}
+
 	if !opts.TimeTag.valid() {
 		return nil, errors.New("cbor: invalid TimeTag " + strconv.Itoa(int(opts.TimeTag)))
 	}
+
 	if !opts.IndefLength.valid() {
 		return nil, errors.New("cbor: invalid IndefLength " + strconv.Itoa(int(opts.IndefLength)))
 	}
+
 	if !opts.TagsMd.valid() {
 		return nil, errors.New("cbor: invalid TagsMd " + strconv.Itoa(int(opts.TagsMd)))
 	}
+
 	if !opts.IntDec.valid() {
 		return nil, errors.New("cbor: invalid IntDec " + strconv.Itoa(int(opts.IntDec)))
 	}
+
 	if !opts.MapKeyByteString.valid() {
 		return nil, errors.New("cbor: invalid MapKeyByteString " + strconv.Itoa(int(opts.MapKeyByteString)))
 	}
+
 	if opts.MaxNestedLevels == 0 {
-		opts.MaxNestedLevels = 32
-	} else if opts.MaxNestedLevels < 4 || opts.MaxNestedLevels > 65535 {
-		return nil, errors.New("cbor: invalid MaxNestedLevels " + strconv.Itoa(opts.MaxNestedLevels) + " (range is [4, 65535])")
+		opts.MaxNestedLevels = defaultMaxNestedLevels
+	} else if opts.MaxNestedLevels < minMaxNestedLevels || opts.MaxNestedLevels > maxMaxNestedLevels {
+		return nil, errors.New("cbor: invalid MaxNestedLevels " + strconv.Itoa(opts.MaxNestedLevels) +
+			" (range is [" + strconv.Itoa(minMaxNestedLevels) + ", " + strconv.Itoa(maxMaxNestedLevels) + "])")
 	}
+
 	if opts.MaxArrayElements == 0 {
 		opts.MaxArrayElements = defaultMaxArrayElements
 	} else if opts.MaxArrayElements < minMaxArrayElements || opts.MaxArrayElements > maxMaxArrayElements {
-		return nil, errors.New("cbor: invalid MaxArrayElements " + strconv.Itoa(opts.MaxArrayElements) + " (range is [" + strconv.Itoa(minMaxArrayElements) + ", " + strconv.Itoa(maxMaxArrayElements) + "])")
+		return nil, errors.New("cbor: invalid MaxArrayElements " + strconv.Itoa(opts.MaxArrayElements) +
+			" (range is [" + strconv.Itoa(minMaxArrayElements) + ", " + strconv.Itoa(maxMaxArrayElements) + "])")
 	}
+
 	if opts.MaxMapPairs == 0 {
 		opts.MaxMapPairs = defaultMaxMapPairs
 	} else if opts.MaxMapPairs < minMaxMapPairs || opts.MaxMapPairs > maxMaxMapPairs {
-		return nil, errors.New("cbor: invalid MaxMapPairs " + strconv.Itoa(opts.MaxMapPairs) + " (range is [" + strconv.Itoa(minMaxMapPairs) + ", " + strconv.Itoa(maxMaxMapPairs) + "])")
+		return nil, errors.New("cbor: invalid MaxMapPairs " + strconv.Itoa(opts.MaxMapPairs) +
+			" (range is [" + strconv.Itoa(minMaxMapPairs) + ", " + strconv.Itoa(maxMaxMapPairs) + "])")
 	}
+
 	if !opts.ExtraReturnErrors.valid() {
 		return nil, errors.New("cbor: invalid ExtraReturnErrors " + strconv.Itoa(int(opts.ExtraReturnErrors)))
 	}
+
 	if opts.DefaultMapType != nil && opts.DefaultMapType.Kind() != reflect.Map {
 		return nil, fmt.Errorf("cbor: invalid DefaultMapType %s", opts.DefaultMapType)
 	}
+
 	if !opts.UTF8.valid() {
 		return nil, errors.New("cbor: invalid UTF8 " + strconv.Itoa(int(opts.UTF8)))
 	}
+
 	if !opts.FieldNameMatching.valid() {
 		return nil, errors.New("cbor: invalid FieldNameMatching " + strconv.Itoa(int(opts.FieldNameMatching)))
 	}
+
 	if !opts.BigIntDec.valid() {
 		return nil, errors.New("cbor: invalid BigIntDec " + strconv.Itoa(int(opts.BigIntDec)))
 	}
-	if opts.DefaultByteStringType != nil && opts.DefaultByteStringType.Kind() != reflect.String && (opts.DefaultByteStringType.Kind() != reflect.Slice || opts.DefaultByteStringType.Elem().Kind() != reflect.Uint8) {
+
+	if opts.DefaultByteStringType != nil &&
+		opts.DefaultByteStringType.Kind() != reflect.String &&
+		(opts.DefaultByteStringType.Kind() != reflect.Slice || opts.DefaultByteStringType.Elem().Kind() != reflect.Uint8) {
 		return nil, fmt.Errorf("cbor: invalid DefaultByteStringType: %s is not of kind string or []uint8", opts.DefaultByteStringType)
 	}
+
 	if !opts.ByteStringToString.valid() {
 		return nil, errors.New("cbor: invalid ByteStringToString " + strconv.Itoa(int(opts.ByteStringToString)))
 	}
+
 	if !opts.FieldNameByteString.valid() {
 		return nil, errors.New("cbor: invalid FieldNameByteString " + strconv.Itoa(int(opts.FieldNameByteString)))
 	}
+
 	if !opts.UnrecognizedTagToAny.valid() {
 		return nil, errors.New("cbor: invalid UnrecognizedTagToAnyMode " + strconv.Itoa(int(opts.UnrecognizedTagToAny)))
 	}
+
 	dm := decMode{
 		dupMapKey:             opts.DupMapKey,
 		timeTag:               opts.TimeTag,
@@ -684,6 +711,7 @@ func (opts DecOptions) decMode() (*decMode, error) {
 		fieldNameByteString:   opts.FieldNameByteString,
 		unrecognizedTagToAny:  opts.UnrecognizedTagToAny,
 	}
+
 	return &dm, nil
 }
 

--- a/diagnose.go
+++ b/diagnose.go
@@ -235,7 +235,7 @@ func (di *diagnose) diagFirst() (string, []byte, error) {
 
 func (di *diagnose) wellformed(allowExtraData bool) error {
 	off := di.d.off
-	err := di.d.wellformed(allowExtraData)
+	err := di.d.wellformed(allowExtraData, false)
 	di.d.off = off
 	return err
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -4230,11 +4230,11 @@ func TestMarshalRawMessageContainingMalformedCBORData(t *testing.T) {
 	}
 }
 
-type invalidMarshaler struct {
+type marshaler struct {
 	data []byte
 }
 
-func (m invalidMarshaler) MarshalCBOR() (data []byte, err error) {
+func (m marshaler) MarshalCBOR() (data []byte, err error) {
 	return m.data, nil
 }
 
@@ -4247,23 +4247,23 @@ func TestMarshalerReturnsMalformedCBORData(t *testing.T) {
 	}{
 		{
 			name:         "truncated data",
-			value:        invalidMarshaler{data: []byte{0xa6}},
-			wantErrorMsg: "cbor: error calling MarshalCBOR for type cbor.invalidMarshaler: unexpected EOF",
+			value:        marshaler{data: []byte{0xa6}},
+			wantErrorMsg: "cbor: error calling MarshalCBOR for type cbor.marshaler: unexpected EOF",
 		},
 		{
 			name:         "malformed data",
-			value:        invalidMarshaler{data: []byte{0x1f}},
-			wantErrorMsg: "cbor: error calling MarshalCBOR for type cbor.invalidMarshaler: cbor: invalid additional information 31 for type positive integer",
+			value:        marshaler{data: []byte{0x1f}},
+			wantErrorMsg: "cbor: error calling MarshalCBOR for type cbor.marshaler: cbor: invalid additional information 31 for type positive integer",
 		},
 		{
 			name:         "extraneous data",
-			value:        invalidMarshaler{data: []byte{0x01, 0x01}},
-			wantErrorMsg: "cbor: error calling MarshalCBOR for type cbor.invalidMarshaler: cbor: 1 bytes of extraneous data starting at index 1",
+			value:        marshaler{data: []byte{0x01, 0x01}},
+			wantErrorMsg: "cbor: error calling MarshalCBOR for type cbor.marshaler: cbor: 1 bytes of extraneous data starting at index 1",
 		},
 		{
 			name:         "invalid builtin tag",
-			value:        invalidMarshaler{data: []byte{0xc0, 0x01}},
-			wantErrorMsg: "cbor: error calling MarshalCBOR for type cbor.invalidMarshaler: cbor: tag number 0 must be followed by text string, got positive integer",
+			value:        marshaler{data: []byte{0xc0, 0x01}},
+			wantErrorMsg: "cbor: error calling MarshalCBOR for type cbor.marshaler: cbor: tag number 0 must be followed by text string, got positive integer",
 		},
 	}
 
@@ -4279,6 +4279,66 @@ func TestMarshalerReturnsMalformedCBORData(t *testing.T) {
 			}
 			if b != nil {
 				t.Errorf("Marshal(%v) = 0x%x, want nil", tc.value, b)
+			}
+		})
+	}
+}
+
+func TestMarshalerReturnsDisallowedCBORData(t *testing.T) {
+
+	testCases := []struct {
+		name         string
+		encOpts      EncOptions
+		value        interface{}
+		wantErrorMsg string
+	}{
+		{
+			name:         "enc mode forbids indefinite length, data has indefinite length",
+			encOpts:      EncOptions{IndefLength: IndefLengthForbidden},
+			value:        marshaler{data: hexDecode("5f42010243030405ff")},
+			wantErrorMsg: "cbor: error calling MarshalCBOR for type cbor.marshaler: cbor: indefinite-length byte string isn't allowed",
+		},
+		{
+			name:    "enc mode allows indefinite length, data has indefinite length",
+			encOpts: EncOptions{IndefLength: IndefLengthAllowed},
+			value:   marshaler{data: hexDecode("5f42010243030405ff")},
+		},
+		{
+			name:         "enc mode forbids tags, data has tags",
+			encOpts:      EncOptions{TagsMd: TagsForbidden},
+			value:        marshaler{data: hexDecode("c074323031332d30332d32315432303a30343a30305a")},
+			wantErrorMsg: "cbor: error calling MarshalCBOR for type cbor.marshaler: cbor: CBOR tag isn't allowed",
+		},
+		{
+			name:    "enc mode allows tags, data has tags",
+			encOpts: EncOptions{TagsMd: TagsAllowed},
+			value:   marshaler{data: hexDecode("c074323031332d30332d32315432303a30343a30305a")},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			em, err := tc.encOpts.EncMode()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			b, err := em.Marshal(tc.value)
+			if tc.wantErrorMsg == "" {
+				if err != nil {
+					t.Errorf("Marshal(%v) returned error %q", tc.value, err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Marshal(%v) didn't return an error, want error %q", tc.value, tc.wantErrorMsg)
+				} else if _, ok := err.(*MarshalerError); !ok {
+					t.Errorf("Marshal(%v) error type %T, want *MarshalerError", tc.value, err)
+				} else if err.Error() != tc.wantErrorMsg {
+					t.Errorf("Marshal(%v) error %q, want %q", tc.value, err.Error(), tc.wantErrorMsg)
+				}
+				if b != nil {
+					t.Errorf("Marshal(%v) = 0x%x, want nil", tc.value, b)
+				}
 			}
 		})
 	}

--- a/stream.go
+++ b/stream.go
@@ -84,7 +84,7 @@ func (dec *Decoder) readNext() (int, error) {
 		if dec.off < len(dec.buf) {
 			dec.d.reset(dec.buf[dec.off:])
 			off := dec.off // Save offset before data validation
-			validErr = dec.d.wellformed(true)
+			validErr = dec.d.wellformed(true, false)
 			dec.off = off // Restore offset
 
 			if validErr == nil {


### PR DESCRIPTION
Closes #482

`MarshalerError` is returned if CBOR data item returned from `MarshalCBOR()` fails either:
- well-formedness check, or
- tag validation for builtin tags 0-3

Many thanks to @benluddy for reporting this bug!  :+1: 