### PR TITLE
Bump govulncheck from v1.0.1 to v1.0.4

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -42,6 +42,6 @@ jobs:
         go-version: 1.21.x
         check-latest: true
     - name: Install latest from golang.org
-      run: go install golang.org/x/vuln/cmd/govulncheck@da4b74a5408a0116e9a2dde953659a7b0956dc56 # v1.0.1
+      run: go install golang.org/x/vuln/cmd/govulncheck@5507063454b1b8c930db99818a88b52f1f143418 # v1.0.4
     - name: Run govulncheck      
       run: govulncheck -show=traces ./...


### PR DESCRIPTION
Update govulncheck from 1.0.1 to 1.0.4 in govulncheck.yml.

