### PR TITLE
Enable more linters in .golangci.yml

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ Thank you for your interest in contributing to fxamacker/cbor!
 
 - [ ] Include unit tests that cover the new code
 - [ ] Pass all unit tests 
-- [ ] Pass all 18 ci linters (golint, gosec, staticcheck, etc.)
+- [ ] Pass all lint checks in CI (goimports, gosec, staticcheck, etc.)
 - [ ] Sign each commit with your real name and email.  
       Last line of each commit message should be in this format:  
       Signed-off-by: Firstname Lastname <firstname.lastname@example.com>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: [1.17, 1.19, '1.20', 1.21]
+        go-version: [1.17, 1.19, '1.20', 1.22]
     steps:
     - name: Install Go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,26 @@
 # Do not delete linter settings. Linters like gocritic can be enabled on the command line.
 
 linters-settings:
+  depguard:
+    rules:
+      prevent_unmaintained_packages:
+        list-mode: strict
+        files:
+          - $all
+          - "!$test"
+        allow:
+          - $gostd
+          - github.com/x448/float16
+        deny:
+          - pkg: io/ioutil
+            desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
   dupl:
     threshold: 100
   funlen:
     lines: 100
     statements: 50
   goconst:
+    ignore-tests: true
     min-len: 2
     min-occurrences: 3
   gocritic:
@@ -17,12 +31,12 @@ linters-settings:
       - performance
       - style
     disabled-checks:
+      - commentedOutCode
       - dupImport # https://github.com/go-critic/go-critic/issues/845
       - ifElseChain
       - octalLiteral
       - paramTypeCombine
       - whyNoLint
-      - wrapperFunc
   gofmt:
     simplify: false
   goimports:
@@ -37,22 +51,31 @@ linters-settings:
     suggest-new: true
   misspell:
     locale: US
+  staticcheck:
+    checks: ["all"]
 
 linters:
   disable-all: true
   enable:
+    - asciicheck
     - bidichk
+    - depguard
     - errcheck
+    - exportloopref
     - goconst
     - gocyclo
     - gofmt
     - goimports
+    - goprintffuncname
     - gosec
+    - gosimple
     - govet
     - ineffassign
     - misspell
+    - nilerr
     - revive
     - staticcheck
+    - stylecheck
     - typecheck
     - unconvert
     - unused
@@ -62,16 +85,19 @@ issues:
   max-issues-per-linter: 0
   # max-same-issues default is 3.  Set to 0 to disable limit.
   max-same-issues: 0
-  # Excluding configuration per-path, per-linter, per-text and per-source
+
   exclude-rules:
-    - path: _test\.go
-      linters:
-        - goconst
-        - dupl
-        - gomnd
-        - lll
-    - path: doc\.go
-      linters:
-        - goimports
-        - gomnd
-        - lll
+    - path: decode.go
+      text: "string ` overflows ` has (\\d+) occurrences, make it a constant"
+    - path: decode.go
+      text: "string ` \\(range is \\[` has (\\d+) occurrences, make it a constant"
+    - path: decode.go
+      text: "string `, ` has (\\d+) occurrences, make it a constant"
+    - path: decode.go
+      text: "string ` overflows Go's int64` has (\\d+) occurrences, make it a constant"
+    - path: decode.go
+      text: "string `\\]\\)` has (\\d+) occurrences, make it a constant"
+    - path: valid.go
+      text: "string ` for type ` has (\\d+) occurrences, make it a constant"
+    - path: valid.go
+      text: "string `cbor: ` has (\\d+) occurrences, make it a constant"


### PR DESCRIPTION
Added 7 more linters in .golangci.yml.  While at it, updated some linter settings and use go1.22 in ci.yml.

I can remove goconst, etc. or relax settings if a linter gets too noisy.