### PR TITLE
Allow rejection of NaN and Inf float values on encode and decode.

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -4919,6 +4919,8 @@ func TestDecOptions(t *testing.T) {
 		UnrecognizedTagToAny:  UnrecognizedTagContentToAny,
 		TimeTagToAny:          TimeTagToRFC3339,
 		SimpleValues:          simpleValues,
+		NaN:                   NaNDecodeForbidden,
+		Inf:                   InfDecodeForbidden,
 	}
 	ov := reflect.ValueOf(opts1)
 	for i := 0; i < ov.NumField(); i++ {
@@ -8905,6 +8907,522 @@ func TestDecModeTimeTagToAny(t *testing.T) {
 
 			compareNonFloats(t, tc.in, got, tc.want)
 
+		})
+	}
+}
+
+func TestDecModeInvalidNaNDec(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		opts         DecOptions
+		wantErrorMsg string
+	}{
+		{
+			name:         "below range of valid modes",
+			opts:         DecOptions{NaN: -1},
+			wantErrorMsg: "cbor: invalid NaNDec -1",
+		},
+		{
+			name:         "above range of valid modes",
+			opts:         DecOptions{NaN: 101},
+			wantErrorMsg: "cbor: invalid NaNDec 101",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.opts.DecMode()
+			if err == nil {
+				t.Errorf("DecMode() didn't return an error")
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("DecMode() returned error %q, want %q", err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestNaNDecMode(t *testing.T) {
+	for _, tc := range []struct {
+		opt    NaNMode
+		src    []byte
+		dst    interface{}
+		reject bool
+	}{
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("197e00"),
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("1a7fc00000"),
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("1b7ff8000000000000"),
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("f90000"), // 0.0
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("f90000"), // 0.0
+			dst:    new(float32),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("f90000"), // 0.0
+			dst:    new(float64),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("f90000"), // 0.0
+			dst:    new(time.Time),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fa47c35000"), // 100000.0
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fa47c35000"), // 100000.0
+			dst:    new(float32),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fa47c35000"), // 100000.0
+			dst:    new(float64),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fa47c35000"), // 100000.0
+			dst:    new(time.Time),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fb3ff199999999999a"), // 1.1
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fb3ff199999999999a"), // 1.1
+			dst:    new(float32),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fb3ff199999999999a"), // 1.1
+			dst:    new(float64),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fb3ff199999999999a"), // 1.1
+			dst:    new(time.Time),
+			reject: false,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("f97e00"),
+			dst:    new(interface{}),
+			reject: true,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("f97e00"),
+			dst:    new(float32),
+			reject: true,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("f97e00"),
+			dst:    new(float64),
+			reject: true,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("f97e00"),
+			dst:    new(time.Time),
+			reject: true,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fa7fc00000"),
+			dst:    new(interface{}),
+			reject: true,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fa7fc00000"),
+			dst:    new(float32),
+			reject: true,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fa7fc00000"),
+			dst:    new(float64),
+			reject: true,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fa7fc00000"),
+			dst:    new(time.Time),
+			reject: true,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fb7ff8000000000000"),
+			dst:    new(interface{}),
+			reject: true,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fb7ff8000000000000"),
+			dst:    new(float32),
+			reject: true,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fb7ff8000000000000"),
+			dst:    new(float64),
+			reject: true,
+		},
+		{
+			opt:    NaNDecodeForbidden,
+			src:    hexDecode("fb7ff8000000000000"),
+			dst:    new(time.Time),
+			reject: true,
+		},
+	} {
+		t.Run(fmt.Sprintf("mode=%d/0x%x into %s", tc.opt, tc.src, reflect.TypeOf(tc.dst).String()), func(t *testing.T) {
+			dm, err := DecOptions{NaN: tc.opt}.DecMode()
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := &UnacceptableDataItemError{
+				CBORType: cborTypePrimitives.String(),
+				Message:  "floating-point NaN",
+			}
+			if got := dm.Unmarshal(tc.src, tc.dst); got != nil {
+				if tc.reject {
+					if !reflect.DeepEqual(want, got) {
+						t.Errorf("want error: %v, got error: %v", want, got)
+					}
+				} else {
+					t.Errorf("unexpected error: %v", got)
+				}
+			} else if tc.reject {
+				t.Error("unexpected nil error")
+			}
+		})
+	}
+}
+
+func TestDecModeInvalidInfDec(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		opts         DecOptions
+		wantErrorMsg string
+	}{
+		{
+			name:         "below range of valid modes",
+			opts:         DecOptions{Inf: -1},
+			wantErrorMsg: "cbor: invalid InfDec -1",
+		},
+		{
+			name:         "above range of valid modes",
+			opts:         DecOptions{Inf: 101},
+			wantErrorMsg: "cbor: invalid InfDec 101",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.opts.DecMode()
+			if err == nil {
+				t.Errorf("DecMode() didn't return an error")
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("DecMode() returned error %q, want %q", err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestInfDecMode(t *testing.T) {
+	for _, tc := range []struct {
+		opt    InfMode
+		src    []byte
+		dst    interface{}
+		reject bool
+	}{
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("197c00"),
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("1a7f800000"), // Infinity
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("1b7ff0000000000000"), // Infinity
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f90000"), // 0.0
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f90000"), // 0.0
+			dst:    new(float32),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f90000"), // 0.0
+			dst:    new(float64),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f90000"), // 0.0
+			dst:    new(time.Time),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fa47c35000"), // 100000.0
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fa47c35000"), // 100000.0
+			dst:    new(float32),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fa47c35000"), // 100000.0
+			dst:    new(float64),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fa47c35000"), // 100000.0
+			dst:    new(time.Time),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fb3ff199999999999a"), // 1.1
+			dst:    new(interface{}),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fb3ff199999999999a"), // 1.1
+			dst:    new(float32),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fb3ff199999999999a"), // 1.1
+			dst:    new(float64),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fb3ff199999999999a"), // 1.1
+			dst:    new(time.Time),
+			reject: false,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f97c00"), // Infinity
+			dst:    new(interface{}),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f97c00"), // Infinity
+			dst:    new(float32),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f97c00"), // Infinity
+			dst:    new(float64),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f97c00"), // Infinity
+			dst:    new(time.Time),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f9fc00"), // -Infinity
+			dst:    new(interface{}),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f9fc00"), // -Infinity
+			dst:    new(float32),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f9fc00"), // -Infinity
+			dst:    new(float64),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("f9fc00"), // -Infinity
+			dst:    new(time.Time),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fa7f800000"), // Infinity
+			dst:    new(interface{}),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fa7f800000"), // Infinity
+			dst:    new(float32),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fa7f800000"), // Infinity
+			dst:    new(float64),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fa7f800000"), // Infinity
+			dst:    new(time.Time),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("faff800000"), // -Infinity
+			dst:    new(interface{}),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("faff800000"), // -Infinity
+			dst:    new(float32),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("faff800000"), // -Infinity
+			dst:    new(float64),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("faff800000"), // -Infinity
+			dst:    new(time.Time),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fb7ff0000000000000"), // Infinity
+			dst:    new(interface{}),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fb7ff0000000000000"), // Infinity
+			dst:    new(float32),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fb7ff0000000000000"), // Infinity
+			dst:    new(float64),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fb7ff0000000000000"), // Infinity
+			dst:    new(time.Time),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fbfff0000000000000"), // -Infinity
+			dst:    new(interface{}),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fbfff0000000000000"), // -Infinity
+			dst:    new(float32),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fbfff0000000000000"), // -Infinity
+			dst:    new(float64),
+			reject: true,
+		},
+		{
+			opt:    InfDecodeForbidden,
+			src:    hexDecode("fbfff0000000000000"), // -Infinity
+			dst:    new(time.Time),
+			reject: true,
+		},
+	} {
+		t.Run(fmt.Sprintf("mode=%d/0x%x into %s", tc.opt, tc.src, tc.dst), func(t *testing.T) {
+			dm, err := DecOptions{Inf: tc.opt}.DecMode()
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := &UnacceptableDataItemError{
+				CBORType: cborTypePrimitives.String(),
+				Message:  "floating-point infinity",
+			}
+			if got := dm.Unmarshal(tc.src, tc.dst); got != nil {
+				if tc.reject {
+					if !reflect.DeepEqual(want, got) {
+						t.Errorf("want error: %v, got error: %v", want, got)
+					}
+				} else {
+					t.Errorf("unexpected error: %v", got)
+				}
+			} else if tc.reject {
+				t.Error("unexpected nil error")
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description

Implements #512 to allow users to error rather than encode or decode NaN and Inf floating-point values.

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

#### PR Was Proposed and Welcomed in Currently Open Issue

- [ ] This PR was proposed and welcomed by maintainer(s) in issue #___
- [x] Closes or Updates Issue #512

#### Checklist (for code PR only, ignore for docs PR)

- [x] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all lint checks in CI (goimports, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

