### PR TITLE
Add a method for marshaling directly into a user-provided buffer.

### DIFF
--- a/bytestring.go
+++ b/bytestring.go
@@ -22,8 +22,8 @@ func (bs ByteString) Bytes() []byte {
 
 // MarshalCBOR encodes ByteString as CBOR byte string (major type 2).
 func (bs ByteString) MarshalCBOR() ([]byte, error) {
-	e := getEncoderBuffer()
-	defer putEncoderBuffer(e)
+	e := getEncodeBuffer()
+	defer putEncodeBuffer(e)
 
 	// Encode length
 	encodeHead(e, byte(cborTypeByteString), uint64(len(bs)))

--- a/cache.go
+++ b/cache.go
@@ -234,7 +234,7 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 	var hasKeyAsInt bool
 	var hasKeyAsStr bool
 	var omitEmptyIdx []int
-	e := getEncoderBuffer()
+	e := getEncodeBuffer()
 	for i := 0; i < len(flds); i++ {
 		// Get field's encodeFunc
 		flds[i].ef, flds[i].ief = getEncodeFunc(flds[i].typ)
@@ -286,7 +286,7 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 			omitEmptyIdx = append(omitEmptyIdx, i)
 		}
 	}
-	putEncoderBuffer(e)
+	putEncodeBuffer(e)
 
 	if err != nil {
 		structType := &encodingStructType{err: err}

--- a/encode.go
+++ b/encode.go
@@ -854,6 +854,10 @@ func (em *encMode) Marshal(v interface{}) ([]byte, error) {
 	return buf, nil
 }
 
+func (em *encMode) MarshalToBuffer(v interface{}, buf *bytes.Buffer) error {
+	return encode(buf, em, reflect.ValueOf(v))
+}
+
 // NewEncoder returns a new encoder that writes to w using em EncMode.
 func (em *encMode) NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{w: w, em: em}

--- a/encode_map.go
+++ b/encode_map.go
@@ -6,6 +6,7 @@
 package cbor
 
 import (
+	"bytes"
 	"reflect"
 	"sync"
 )
@@ -15,7 +16,7 @@ type mapKeyValueEncodeFunc struct {
 	kpool, vpool sync.Pool
 }
 
-func (me *mapKeyValueEncodeFunc) encodeKeyValues(e *encoderBuffer, em *encMode, v reflect.Value, kvs []keyValue) error {
+func (me *mapKeyValueEncodeFunc) encodeKeyValues(e *bytes.Buffer, em *encMode, v reflect.Value, kvs []keyValue) error {
 	trackKeyValueLength := len(kvs) == v.Len()
 	iterk := me.kpool.Get().(*reflect.Value)
 	defer func() {

--- a/encode_map_go117.go
+++ b/encode_map_go117.go
@@ -6,6 +6,7 @@
 package cbor
 
 import (
+	"bytes"
 	"reflect"
 )
 
@@ -13,7 +14,7 @@ type mapKeyValueEncodeFunc struct {
 	kf, ef encodeFunc
 }
 
-func (me *mapKeyValueEncodeFunc) encodeKeyValues(e *encoderBuffer, em *encMode, v reflect.Value, kvs []keyValue) error {
+func (me *mapKeyValueEncodeFunc) encodeKeyValues(e *bytes.Buffer, em *encMode, v reflect.Value, kvs []keyValue) error {
 	trackKeyValueLength := len(kvs) == v.Len()
 
 	iter := v.MapRange()

--- a/stream.go
+++ b/stream.go
@@ -187,14 +187,14 @@ func (enc *Encoder) Encode(v interface{}) error {
 		}
 	}
 
-	buf := getEncoderBuffer()
+	buf := getEncodeBuffer()
 
 	err := encode(buf, enc.em, reflect.ValueOf(v))
 	if err == nil {
 		_, err = enc.w.Write(buf.Bytes())
 	}
 
-	putEncoderBuffer(buf)
+	putEncodeBuffer(buf)
 	return err
 }
 

--- a/tag.go
+++ b/tag.go
@@ -56,7 +56,7 @@ func (t RawTag) MarshalCBOR() ([]byte, error) {
 		return b, nil
 	}
 
-	e := getEncoderBuffer()
+	e := getEncodeBuffer()
 
 	encodeHead(e, byte(cborTypeTag), t.Number)
 
@@ -69,7 +69,7 @@ func (t RawTag) MarshalCBOR() ([]byte, error) {
 	n := copy(buf, e.Bytes())
 	copy(buf[n:], content)
 
-	putEncoderBuffer(e)
+	putEncodeBuffer(e)
 	return buf, nil
 }
 
@@ -269,13 +269,13 @@ func newTagItem(opts TagOptions, contentType reflect.Type, num uint64, nestedNum
 	te.num = append(te.num, nestedNum...)
 
 	// Cache encoded tag numbers
-	e := getEncoderBuffer()
+	e := getEncodeBuffer()
 	for _, n := range te.num {
 		encodeHead(e, byte(cborTypeTag), n)
 	}
 	te.cborTagNum = make([]byte, e.Len())
 	copy(te.cborTagNum, e.Bytes())
-	putEncoderBuffer(e)
+	putEncodeBuffer(e)
 
 	return &te, nil
 }


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description

This is an implementation of the proposal in https://github.com/fxamacker/cbor/issues/520.

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

#### PR Was Proposed and Welcomed in Currently Open Issue

- [ ] This PR was proposed and welcomed by maintainer(s) in issue #___
- [x] Closes or Updates Issue #520

#### Checklist (for code PR only, ignore for docs PR)

- [ ] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all lint checks in CI (goimports, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

