### PR TITLE
Add option to reject decoding bignum tags and encoding big.Int.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1005,7 +1005,7 @@ func (opts DecOptions) decMode() (*decMode, error) {
 	if !opts.BignumTag.valid() {
 		return nil, errors.New("cbor: invalid BignumTag " + strconv.Itoa(int(opts.BignumTag)))
 	}
-  
+
 	if !opts.BinaryUnmarshaler.valid() {
 		return nil, errors.New("cbor: invalid BinaryUnmarshaler " + strconv.Itoa(int(opts.BinaryUnmarshaler)))
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -4923,6 +4923,7 @@ func TestDecOptions(t *testing.T) {
 		Inf:                       InfDecodeForbidden,
 		ByteStringToTime:          ByteStringToTimeAllowed,
 		ByteSliceExpectedEncoding: ByteSliceToByteStringWithExpectedConversionToBase64,
+		BignumTag:                 BignumTagForbidden,
 	}
 	ov := reflect.ValueOf(opts1)
 	for i := 0; i < ov.NumField(); i++ {
@@ -9922,6 +9923,98 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 
 			if dst := dstVal.Elem().Interface(); !reflect.DeepEqual(dst, tc.want) {
 				t.Errorf("got: %#v, want %#v", dst, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecModeInvalidBignumTag(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		opts         DecOptions
+		wantErrorMsg string
+	}{
+		{
+			name:         "below range of valid modes",
+			opts:         DecOptions{BignumTag: -1},
+			wantErrorMsg: "cbor: invalid BignumTag -1",
+		},
+		{
+			name:         "above range of valid modes",
+			opts:         DecOptions{BignumTag: 101},
+			wantErrorMsg: "cbor: invalid BignumTag 101",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.opts.DecMode()
+			if err == nil {
+				t.Errorf("Expected non nil error from DecMode()")
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("Expected error: %q, want: %q \n", tc.wantErrorMsg, err.Error())
+			}
+		})
+	}
+}
+
+func TestBignumTagMode(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		opt            DecOptions
+		input          []byte
+		wantErrMessage string // if "" then expect nil error
+	}{
+		{
+			name:  "default options decode unsigned bignum without error",
+			opt:   DecOptions{},
+			input: hexDecode("c240"), // 2(0) i.e. unsigned bignum 0
+		},
+		{
+			name:  "default options decode negative bignum without error",
+			opt:   DecOptions{},
+			input: hexDecode("c340"), // 3(0) i.e. negative bignum -1
+		},
+		{
+			name:           "BignumTagForbidden returns UnacceptableDataItemError on unsigned bignum",
+			opt:            DecOptions{BignumTag: BignumTagForbidden},
+			input:          hexDecode("c240"), // 2(0) i.e. unsigned bignum 0
+			wantErrMessage: "cbor: data item of cbor type tag is not accepted by protocol: bignum",
+		},
+		{
+			name:           "BignumTagForbidden returns UnacceptableDataItemError on negative bignum",
+			opt:            DecOptions{BignumTag: BignumTagForbidden},
+			input:          hexDecode("c340"), // 3(0) i.e. negative bignum -1
+			wantErrMessage: "cbor: data item of cbor type tag is not accepted by protocol: bignum",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dm, err := tc.opt.DecMode()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, dstType := range []reflect.Type{
+				typeInt64,
+				typeFloat64,
+				typeByteArray,
+				typeByteSlice,
+				typeBigInt,
+				typeIntf,
+			} {
+				t.Run(dstType.String(), func(t *testing.T) {
+					dstv := reflect.New(dstType)
+					err = dm.Unmarshal(tc.input, dstv.Interface())
+					if err != nil {
+						if tc.wantErrMessage == "" {
+							t.Errorf("want nil error, got: %v", err)
+						} else if gotErrMessage := err.Error(); gotErrMessage != tc.wantErrMessage {
+							t.Errorf("want error: %q, got error: %q", tc.wantErrMessage, gotErrMessage)
+						}
+					} else {
+						if tc.wantErrMessage != "" {
+							t.Errorf("got nil error, want: %s", tc.wantErrMessage)
+						}
+					}
+				})
 			}
 		})
 	}

--- a/encode.go
+++ b/encode.go
@@ -318,6 +318,9 @@ const (
 	// converting it to another CBOR type.
 	BigIntConvertNone
 
+	// BigIntConvertReject returns an UnsupportedTypeError instead of marshaling a big.Int.
+	BigIntConvertReject
+
 	maxBigIntConvert
 )
 
@@ -1474,6 +1477,10 @@ func encodeTime(e *encoderBuffer, em *encMode, v reflect.Value) error {
 }
 
 func encodeBigInt(e *encoderBuffer, em *encMode, v reflect.Value) error {
+	if em.bigIntConvert == BigIntConvertReject {
+		return &UnsupportedTypeError{Type: typeBigInt}
+	}
+
 	vbi := v.Interface().(big.Int)
 	sign := vbi.Sign()
 	bi := new(big.Int).SetBytes(vbi.Bytes()) // bi is absolute value of v

--- a/encode_test.go
+++ b/encode_test.go
@@ -4690,7 +4690,7 @@ func TestBigIntConvertReject(t *testing.T) {
 
 	if _, err := em.Marshal(&big.Int{}); !reflect.DeepEqual(want, err) {
 		t.Errorf("want: %v, got: %v", want, err)
-  }
+	}
 }
 
 func TestEncModeInvalidBinaryMarshalerMode(t *testing.T) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -4674,3 +4674,20 @@ func TestMarshalByteSliceMode(t *testing.T) {
 		})
 	}
 }
+
+func TestBigIntConvertReject(t *testing.T) {
+	em, err := EncOptions{BigIntConvert: BigIntConvertReject}.EncMode()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &UnsupportedTypeError{Type: typeBigInt}
+
+	if _, err := em.Marshal(big.Int{}); !reflect.DeepEqual(want, err) {
+		t.Errorf("want: %v, got: %v", want, err)
+	}
+
+	if _, err := em.Marshal(&big.Int{}); !reflect.DeepEqual(want, err) {
+		t.Errorf("want: %v, got: %v", want, err)
+	}
+}

--- a/valid.go
+++ b/valid.go
@@ -99,7 +99,7 @@ func (d *decoder) wellformed(allowExtraData bool, checkBuiltinTags bool) error {
 }
 
 // wellformedInternal checks data's well-formedness and returns max depth and error.
-func (d *decoder) wellformedInternal(depth int, checkBuiltinTags bool) (int, error) {
+func (d *decoder) wellformedInternal(depth int, checkBuiltinTags bool) (int, error) { // nolint:gocyclo
 	t, ai, val, err := d.wellformedHead()
 	if err != nil {
 		return 0, err
@@ -186,6 +186,12 @@ func (d *decoder) wellformedInternal(depth int, checkBuiltinTags bool) (int, err
 				err = validBuiltinTag(tagNum, d.data[d.off])
 				if err != nil {
 					return 0, err
+				}
+			}
+			if d.dm.bignumTag == BignumTagForbidden && (tagNum == 2 || tagNum == 3) {
+				return 0, &UnacceptableDataItemError{
+					CBORType: cborTypeTag.String(),
+					Message:  "bignum",
 				}
 			}
 			if cborType(d.data[d.off]&0xe0) != cborTypeTag {


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

This allows encode and decode modes to be configured for applications whose CBOR-based protocols do not allow the bignum tags (https://www.rfc-editor.org/rfc/rfc8949.html#section-5-3).

#### PR Was Proposed and Welcomed in Currently Open Issue

- [ ] This PR was proposed and welcomed by maintainer(s) in issue #___
- [x] Closes or Updates Issue #528

#### Checklist (for code PR only, ignore for docs PR)

- [x] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all lint checks in CI (goimports, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

