### PR TITLE
Refactor to reuse functions and improve code coverage

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -170,7 +170,6 @@ type encodingStructType struct {
 	omitEmptyFieldsIdx []int
 	err                error
 	toArray            bool
-	fixedLength        bool // Struct type doesn't have any omitempty or anonymous fields.
 	maxHeadLen         int
 }
 
@@ -238,7 +237,6 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 	var hasKeyAsInt bool
 	var hasKeyAsStr bool
 	var omitEmptyIdx []int
-	fixedLength := true
 	e := getEncoderBuffer()
 	for i := 0; i < len(flds); i++ {
 		// Get field's encodeFunc
@@ -286,14 +284,8 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 			hasKeyAsStr = true
 		}
 
-		// Check if field is from embedded struct
-		if len(flds[i].idx) > 1 {
-			fixedLength = false
-		}
-
 		// Check if field can be omitted when empty
 		if flds[i].omitEmpty {
-			fixedLength = false
 			omitEmptyIdx = append(omitEmptyIdx, i)
 		}
 
@@ -326,7 +318,6 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 		bytewiseFields:     bytewiseFields,
 		lengthFirstFields:  lengthFirstFields,
 		omitEmptyFieldsIdx: omitEmptyIdx,
-		fixedLength:        fixedLength,
 		maxHeadLen:         encodedHeadLen(uint64(len(flds))),
 	}
 
@@ -346,9 +337,8 @@ func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructT
 	}
 
 	structType := &encodingStructType{
-		fields:      flds,
-		toArray:     true,
-		fixedLength: true,
+		fields:  flds,
+		toArray: true,
 	}
 	encodingStructTypeCache.Store(t, structType)
 	return structType, structType.err

--- a/cache.go
+++ b/cache.go
@@ -170,7 +170,6 @@ type encodingStructType struct {
 	omitEmptyFieldsIdx []int
 	err                error
 	toArray            bool
-	maxHeadLen         int
 }
 
 func (st *encodingStructType) getFields(em *encMode) fields {
@@ -231,8 +230,6 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 		return getEncodingStructToArrayType(t, flds)
 	}
 
-	nOptional := 0
-
 	var err error
 	var hasKeyAsInt bool
 	var hasKeyAsStr bool
@@ -288,10 +285,6 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 		if flds[i].omitEmpty {
 			omitEmptyIdx = append(omitEmptyIdx, i)
 		}
-
-		if len(flds[i].idx) > 1 || flds[i].omitEmpty {
-			nOptional++
-		}
 	}
 	putEncoderBuffer(e)
 
@@ -318,7 +311,6 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 		bytewiseFields:     bytewiseFields,
 		lengthFirstFields:  lengthFirstFields,
 		omitEmptyFieldsIdx: omitEmptyIdx,
-		maxHeadLen:         encodedHeadLen(uint64(len(flds))),
 	}
 
 	encodingStructTypeCache.Store(t, structType)

--- a/encode.go
+++ b/encode.go
@@ -1267,8 +1267,9 @@ func encodeStruct(e *encoderBuffer, em *encMode, v reflect.Value) (err error) {
 		e.Write(b)
 	}
 
-	// Reserve space in the output buffer for the head if its encoded size is fixed.
-	encodeHead(e, byte(cborTypeMap), uint64(len(flds)))
+	// Encode head with struct field count.
+	// Head is rewritten later if actual encoded field count is different from struct field count.
+	encodedHeadLen := encodeHead(e, byte(cborTypeMap), uint64(len(flds)))
 
 	kvbegin := e.Len()
 	kvcount := 0
@@ -1317,13 +1318,13 @@ func encodeStruct(e *encoderBuffer, em *encMode, v reflect.Value) (err error) {
 	}
 
 	// Overwrite the bytes that were reserved for the head before encoding the map entries.
+	var actualHeadLen int
 	{
-		headbuf := encoderBuffer{Buffer: *bytes.NewBuffer(e.Bytes()[kvbegin-structType.maxHeadLen : kvbegin-structType.maxHeadLen : kvbegin])}
-		encodeHead(&headbuf, byte(cborTypeMap), uint64(kvcount))
+		headbuf := encoderBuffer{Buffer: *bytes.NewBuffer(e.Bytes()[kvbegin-encodedHeadLen : kvbegin-encodedHeadLen : kvbegin])}
+		actualHeadLen = encodeHead(&headbuf, byte(cborTypeMap), uint64(kvcount))
 	}
 
-	actualHeadLen := encodedHeadLen(uint64(kvcount))
-	if actualHeadLen == structType.maxHeadLen {
+	if actualHeadLen == encodedHeadLen {
 		// The bytes reserved for the encoded head were exactly the right size, so the
 		// encoded entries are already in their final positions.
 		return nil
@@ -1332,7 +1333,7 @@ func encodeStruct(e *encoderBuffer, em *encMode, v reflect.Value) (err error) {
 	// We reserved more bytes than needed for the encoded head, based on the number of fields
 	// encoded. The encoded entries are offset to the right by the number of excess reserved
 	// bytes. Shift the entries left to remove the gap.
-	excessReservedBytes := structType.maxHeadLen - actualHeadLen
+	excessReservedBytes := encodedHeadLen - actualHeadLen
 	dst := e.Bytes()[kvbegin-excessReservedBytes : e.Len()-excessReservedBytes]
 	src := e.Bytes()[kvbegin:e.Len()]
 	copy(dst, src)
@@ -1490,47 +1491,33 @@ func encodeTag(e *encoderBuffer, em *encMode, v reflect.Value) error {
 	return encode(e, em, reflect.ValueOf(t.Content))
 }
 
-func encodeHead(e *encoderBuffer, t byte, n uint64) {
+// encodeHead writes CBOR head of specified type t and returns number of bytes written.
+func encodeHead(e *encoderBuffer, t byte, n uint64) int {
 	if n <= 23 {
 		e.WriteByte(t | byte(n))
-		return
+		return 1
 	}
 	if n <= math.MaxUint8 {
 		e.scratch[0] = t | byte(24)
 		e.scratch[1] = byte(n)
 		e.Write(e.scratch[:2])
-		return
+		return 2
 	}
 	if n <= math.MaxUint16 {
 		e.scratch[0] = t | byte(25)
 		binary.BigEndian.PutUint16(e.scratch[1:], uint16(n))
 		e.Write(e.scratch[:3])
-		return
+		return 3
 	}
 	if n <= math.MaxUint32 {
 		e.scratch[0] = t | byte(26)
 		binary.BigEndian.PutUint32(e.scratch[1:], uint32(n))
 		e.Write(e.scratch[:5])
-		return
+		return 5
 	}
 	e.scratch[0] = t | byte(27)
 	binary.BigEndian.PutUint64(e.scratch[1:], n)
 	e.Write(e.scratch[:9])
-}
-
-// encodedHeadLen returns the number of bytes that will be written by a call to encodeHead with the
-// given argument. This must be kept in sync with encodeHead.
-func encodedHeadLen(arg uint64) int {
-	switch {
-	case arg <= 23:
-		return 1
-	case arg <= math.MaxUint8:
-		return 2
-	case arg <= math.MaxUint16:
-		return 3
-	case arg <= math.MaxUint32:
-		return 5
-	}
 	return 9
 }
 


### PR DESCRIPTION
This PR refactors code to reuse functions and improve code coverage:

- Remove `encodeFixedLengthStruct()` and reuse `encodeStruct()`
  
  Previously, `encodeStruct()` used extra buffer to encode elements to get actual encoded element count.  To avoid this overhead, `encodeFixedLengthStruct()` was created to encode fixed length struct (struct without any "omitempty" fields) since encoded element count is always known in this use case.

  Since @benluddy's PR #519, `encodeStruct()` doesn't use extra buffer any more, and `encodeFixedLengthStruct()` isn't necessary.  Thanks Ben!  :+1: 

- Combine `encodeHead()` and `encodedHeadLen()` to avoid these two functions out of sync.

  `encodeHead()` is modified to return encoded head length so caller doesn't need to call `encodedHeadLen()` separately.