### PR TITLE
Improve speed & memory use for Diagnose() and DiagnoseFirst()

### DIFF
--- a/diagnose.go
+++ b/diagnose.go
@@ -466,10 +466,14 @@ func (di *diagnose) item() error { //nolint:gocyclo
 // writeU16 format a rune as "\uxxxx"
 func (di *diagnose) writeU16(val rune) {
 	di.w.WriteString("\\u")
-	b := make([]byte, 2)
-	b[0] = byte(val >> 8)
-	b[1] = byte(val)
-	di.w.WriteString(hex.EncodeToString(b))
+	var in [2]byte
+	in[0] = byte(val >> 8)
+	in[1] = byte(val)
+	sz := hex.EncodedLen(len(in))
+	di.w.Grow(sz)
+	dst := di.w.Bytes()[di.w.Len() : di.w.Len()+sz]
+	hex.Encode(dst, in[:])
+	di.w.Write(dst)
 }
 
 var rawBase32Encoding = base32.StdEncoding.WithPadding(base32.NoPadding)

--- a/diagnose_test.go
+++ b/diagnose_test.go
@@ -1102,3 +1102,49 @@ func TestDiagnoseEmptyData(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkDiagnose(b *testing.B) {
+	for _, tc := range []struct {
+		name  string
+		opts  DiagOptions
+		input []byte
+	}{
+		{
+			name:  "escaped character in text string",
+			opts:  DiagOptions{},
+			input: hexDecode("62c3bc"), // "\u00fc"
+		},
+		{
+			name:  "byte string base16 encoding",
+			opts:  DiagOptions{ByteStringEncoding: ByteStringBase16Encoding},
+			input: []byte("\x45hello"),
+		},
+		{
+			name:  "byte string base32 encoding",
+			opts:  DiagOptions{ByteStringEncoding: ByteStringBase32Encoding},
+			input: []byte("\x45hello"),
+		},
+		{
+			name:  "byte string base32hex encoding",
+			opts:  DiagOptions{ByteStringEncoding: ByteStringBase32HexEncoding},
+			input: []byte("\x45hello"),
+		},
+		{
+			name:  "byte string base64url encoding",
+			opts:  DiagOptions{ByteStringEncoding: ByteStringBase64Encoding},
+			input: []byte("\x45hello"),
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			dm, err := tc.opts.DiagMode()
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = dm.Diagnose(tc.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

This PR improves efficiency of functions in `diagnose.go` used by `Diagnose()` and `DiagnoseFirst()`, especially related to use of `encoding/hex`, `encoding/base32`, and `encoding/base64`.

The "Encoder" types for the various byte string diagnostic encodings (encoding/hex, encoding/base32,
and encoding/base64) include sizable internal buffers (1KiB at time of writing), and a new encoder
is created to produce the diagnostic encoding of every byte string in the input. This results in a
lot of extra allocations, especially for inputs containing many small byte strings.

```
                                        │  before.txt  │              after.txt              │
                                        │    sec/op    │   sec/op     vs base                │
Diagnose/byte_string_base16_encoding      315.90n ± 0%   95.03n ± 1%  -69.92% (p=0.000 n=10)
Diagnose/byte_string_base32_encoding      325.55n ± 0%   99.27n ± 1%  -69.51% (p=0.000 n=10)
Diagnose/byte_string_base32hex_encoding    325.4n ± 0%   100.2n ± 1%  -69.21% (p=0.000 n=10)
Diagnose/byte_string_base64url_encoding    336.5n ± 0%   100.7n ± 2%  -70.07% (p=0.000 n=10)
geomean                                    325.8n        98.78n       -69.68%

                                        │  before.txt  │             after.txt              │
                                        │     B/op     │    B/op     vs base                │
Diagnose/byte_string_base16_encoding      1344.00 ± 0%   80.00 ± 0%  -94.05% (p=0.000 n=10)
Diagnose/byte_string_base32_encoding      1344.00 ± 0%   80.00 ± 0%  -94.05% (p=0.000 n=10)
Diagnose/byte_string_base32hex_encoding   1344.00 ± 0%   80.00 ± 0%  -94.05% (p=0.000 n=10)
Diagnose/byte_string_base64url_encoding   1344.00 ± 0%   80.00 ± 0%  -94.05% (p=0.000 n=10)
geomean                                   1.313Ki        80.00       -94.05%

                                        │ before.txt │             after.txt              │
                                        │ allocs/op  │ allocs/op   vs base                │
Diagnose/byte_string_base16_encoding      5.000 ± 0%   2.000 ± 0%  -60.00% (p=0.000 n=10)
Diagnose/byte_string_base32_encoding      5.000 ± 0%   2.000 ± 0%  -60.00% (p=0.000 n=10)
Diagnose/byte_string_base32hex_encoding   5.000 ± 0%   2.000 ± 0%  -60.00% (p=0.000 n=10)
Diagnose/byte_string_base64url_encoding   5.000 ± 0%   2.000 ± 0%  -60.00% (p=0.000 n=10)
geomean                                   5.000        2.000       -60.00%
```

Producing the \uxxxx escape sequences also made a few more allocations than necessary.

```
                                          │ before.txt  │              after.txt              │
                                          │   sec/op    │   sec/op     vs base                │
Diagnose/escaped_character_in_text_string   180.3n ± 0%   109.2n ± 2%  -39.41% (p=0.000 n=10)

                                          │ before.txt  │             after.txt              │
                                          │    B/op     │    B/op     vs base                │
Diagnose/escaped_character_in_text_string   192.00 ± 0%   72.00 ± 0%  -62.50% (p=0.000 n=10)

                                          │ before.txt │             after.txt              │
                                          │ allocs/op  │ allocs/op   vs base                │
Diagnose/escaped_character_in_text_string   5.000 ± 0%   2.000 ± 0%  -60.00% (p=0.000 n=10)
```

#### PR Was Proposed and Welcomed in Currently Open Issue

- [ ] This PR was proposed and welcomed by maintainer(s) in issue #___
- [ ] Closes or Updates Issue #___

#### Checklist (for code PR only, ignore for docs PR)

- [x] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all lint checks in CI (goimports, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

