### PR TITLE
Allow user to specify buffer by adding `cbor.MarshalToBuffer()`, `UserBufferEncMode` interface, etc.

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -498,15 +498,36 @@ func testMarshal(t *testing.T, testCases []marshalTest) {
 	if err != nil {
 		t.Errorf("EncMode() returned an error %v", err)
 	}
+	bem, err := EncOptions{Sort: SortCanonical}.UserBufferEncMode()
+	if err != nil {
+		t.Errorf("UserBufferEncMode() returned an error %v", err)
+	}
 	for _, tc := range testCases {
 		for _, value := range tc.values {
+			// Encode value using default options
 			if _, err := Marshal(value); err != nil {
 				t.Errorf("Marshal(%v) returned error %v", value, err)
 			}
+
+			// Encode value to provided buffer using default options
+			var buf1 bytes.Buffer
+			if err := MarshalToBuffer(value, &buf1); err != nil {
+				t.Errorf("MarshalToBuffer(%v) returned error %v", value, err)
+			}
+
+			// Encode value using specified options
 			if b, err := em.Marshal(value); err != nil {
 				t.Errorf("Marshal(%v) returned error %v", value, err)
 			} else if !bytes.Equal(b, tc.wantData) {
 				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", value, b, tc.wantData)
+			}
+
+			// Encode value to provided buffer using specified options
+			var buf2 bytes.Buffer
+			if err := bem.MarshalToBuffer(value, &buf2); err != nil {
+				t.Errorf("MarshalToBuffer(%v) returned error %v", value, err)
+			} else if !bytes.Equal(buf2.Bytes(), tc.wantData) {
+				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", value, buf2.Bytes(), tc.wantData)
 			}
 		}
 		r := RawMessage(tc.wantData)


### PR DESCRIPTION
Currently, the encoder uses a built-in buffer pool.  This PR allows encoding to a user specified buffer rather than using the built-in buffer pool.

This PR wraps and uses a function implemented in PR #521 by @benluddy.  Thanks Ben! :+1: 

This PR adds:

- `cbor.MarshalToBuffer()` uses codec's default options to encode to user provided buffer instead of using built-in buffer pool.

- `UserBufferEncMode` interface extends `EncMode` interface with `MarshalToBuffer()` so user can provide buffer for encoding instead of using built-in buffer pool.

- `EncOptions.UserBufferEncMode()` returns `UserBufferEncMode`

- `EncOptions.UserBufferEncModeWithTags()` returns `UserBufferEncMode`

- `EncOptions.UserBufferEncModeWithSharedTags()` returns `UserBufferEncMode`

This PR added a check to return error if user provided buffer `*bytes.Buffer` is nil.