### PR TITLE
Rename ByteSliceMode to ByteSliceLaterFormatMode, etc

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -4922,7 +4922,7 @@ func TestDecOptions(t *testing.T) {
 		NaN:                      NaNDecodeForbidden,
 		Inf:                      InfDecodeForbidden,
 		ByteStringToTime:         ByteStringToTimeAllowed,
-		ByteStringExpectedFormat: ByteSliceToByteStringWithExpectedConversionToBase64,
+		ByteStringExpectedFormat: ByteStringExpectedBase64URL,
 		BignumTag:                BignumTagForbidden,
 		BinaryUnmarshaler:        BinaryUnmarshalerNone,
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -3764,22 +3764,22 @@ func TestEncOptionsTagsForbidden(t *testing.T) {
 
 func TestEncOptions(t *testing.T) {
 	opts1 := EncOptions{
-		Sort:            SortBytewiseLexical,
-		ShortestFloat:   ShortestFloat16,
-		NaNConvert:      NaNConvertPreserveSignal,
-		InfConvert:      InfConvertNone,
-		BigIntConvert:   BigIntConvertNone,
-		Time:            TimeRFC3339Nano,
-		TimeTag:         EncTagRequired,
-		IndefLength:     IndefLengthForbidden,
-		NilContainers:   NilContainerAsEmpty,
-		TagsMd:          TagsAllowed,
-		OmitEmpty:       OmitEmptyGoValue,
-		String:          StringToByteString,
-		FieldName:       FieldNameToByteString,
-		ByteSlice:       ByteSliceToByteStringWithExpectedConversionToBase16,
-		ByteArray:       ByteArrayToArray,
-		BinaryMarshaler: BinaryMarshalerNone,
+		Sort:                 SortBytewiseLexical,
+		ShortestFloat:        ShortestFloat16,
+		NaNConvert:           NaNConvertPreserveSignal,
+		InfConvert:           InfConvertNone,
+		BigIntConvert:        BigIntConvertNone,
+		Time:                 TimeRFC3339Nano,
+		TimeTag:              EncTagRequired,
+		IndefLength:          IndefLengthForbidden,
+		NilContainers:        NilContainerAsEmpty,
+		TagsMd:               TagsAllowed,
+		OmitEmpty:            OmitEmptyGoValue,
+		String:               StringToByteString,
+		FieldName:            FieldNameToByteString,
+		ByteSliceLaterFormat: ByteSliceLaterFormatBase16,
+		ByteArray:            ByteArrayToArray,
+		BinaryMarshaler:      BinaryMarshalerNone,
 	}
 	ov := reflect.ValueOf(opts1)
 	for i := 0; i < ov.NumField(); i++ {
@@ -4519,7 +4519,7 @@ func TestSortModeFastShuffle(t *testing.T) {
 	}
 }
 
-func TestInvalidByteSlice(t *testing.T) {
+func TestInvalidByteSliceExpectedFormat(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		opts         EncOptions
@@ -4527,13 +4527,13 @@ func TestInvalidByteSlice(t *testing.T) {
 	}{
 		{
 			name:         "below range of valid modes",
-			opts:         EncOptions{ByteSlice: -1},
-			wantErrorMsg: "cbor: invalid ByteSlice -1",
+			opts:         EncOptions{ByteSliceLaterFormat: -1},
+			wantErrorMsg: "cbor: invalid ByteSliceLaterFormat -1",
 		},
 		{
 			name:         "above range of valid modes",
-			opts:         EncOptions{ByteSlice: 101},
-			wantErrorMsg: "cbor: invalid ByteSlice 101",
+			opts:         EncOptions{ByteSliceLaterFormat: 101},
+			wantErrorMsg: "cbor: invalid ByteSliceLaterFormat 101",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -4641,53 +4641,53 @@ func TestMarshalByteSliceMode(t *testing.T) {
 		},
 		{
 			name:     "byte slice marshals to byte string by with ByteSliceToByteString",
-			opts:     EncOptions{ByteSlice: ByteSliceToByteString},
+			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatNone},
 			in:       []byte{0xbb},
 			expected: []byte{0x41, 0xbb},
 		},
 		{
 			name:     "byte slice marshaled to byte string enclosed in base64url expected encoding tag",
-			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase64URL},
+			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64URL},
 			in:       []byte{0xbb},
 			expected: []byte{0xd5, 0x41, 0xbb},
 		},
 		{
 			name:     "byte slice marshaled to byte string enclosed in base64 expected encoding tag",
-			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase64},
+			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64},
 			in:       []byte{0xbb},
 			expected: []byte{0xd6, 0x41, 0xbb},
 		},
 		{
 			name:     "byte slice marshaled to byte string enclosed in base16 expected encoding tag",
-			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase16},
+			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase16},
 			in:       []byte{0xbb},
 			expected: []byte{0xd7, 0x41, 0xbb},
 		},
 		{
 			name:     "user-registered tag numbers are encoded with no expected encoding tag",
 			tags:     ts,
-			opts:     EncOptions{ByteSlice: ByteSliceToByteString},
+			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatNone},
 			in:       namedByteSlice{0xbb},
 			expected: []byte{0xd8, 0xcc, 0x41, 0xbb},
 		},
 		{
 			name:     "user-registered tag numbers are encoded after base64url expected encoding tag",
 			tags:     ts,
-			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase64URL},
+			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64URL},
 			in:       namedByteSlice{0xbb},
 			expected: []byte{0xd5, 0xd8, 0xcc, 0x41, 0xbb},
 		},
 		{
 			name:     "user-registered tag numbers are encoded after base64 expected encoding tag",
 			tags:     ts,
-			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase64},
+			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64},
 			in:       namedByteSlice{0xbb},
 			expected: []byte{0xd6, 0xd8, 0xcc, 0x41, 0xbb},
 		},
 		{
 			name:     "user-registered tag numbers are encoded after base16 expected encoding tag",
 			tags:     ts,
-			opts:     EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase16},
+			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase16},
 			in:       namedByteSlice{0xbb},
 			expected: []byte{0xd7, 0xd8, 0xcc, 0x41, 0xbb},
 		},

--- a/json_test.go
+++ b/json_test.go
@@ -15,9 +15,9 @@ func TestStdlibJSONCompatibility(t *testing.T) {
 	// configurations to users.
 
 	enc, err := cbor.EncOptions{
-		ByteSlice: cbor.ByteSliceToByteStringWithExpectedConversionToBase64,
-		String:    cbor.StringToByteString,
-		ByteArray: cbor.ByteArrayToArray,
+		ByteSliceLaterFormat: cbor.ByteSliceLaterFormatBase64,
+		String:               cbor.StringToByteString,
+		ByteArray:            cbor.ByteArrayToArray,
 	}.EncMode()
 	if err != nil {
 		t.Fatal(err)

--- a/tag_test.go
+++ b/tag_test.go
@@ -1503,13 +1503,13 @@ func TestEncodeBuiltinTag(t *testing.T) {
 		{
 			name: "unsigned bignum content not enclosed in expected encoding tag",
 			tag:  Tag{Number: tagNumUnsignedBignum, Content: []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			opts: EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase16},
+			opts: EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase16},
 			want: []byte{0xc2, 0x49, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		},
 		{
 			name: "negative bignum content not enclosed in expected encoding tag",
 			tag:  Tag{Number: tagNumNegativeBignum, Content: []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
-			opts: EncOptions{ByteSlice: ByteSliceToByteStringWithExpectedConversionToBase16},
+			opts: EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase16},
 			want: []byte{0xc3, 0x49, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		},
 		{


### PR DESCRIPTION
This PR renamed `ByteSliceMode` to `ByteSliceLaterFormatMode` and also renamed related options.

For context:

```Go
// ByteSliceLaterFormatMode specifies which later format conversion hint (CBOR tag 21-23)
// to include (if any) when encoding Go byte slice to CBOR byte string. The encoder will
// always encode unmodified bytes from the byte slice and just wrap it within
// CBOR tag 21, 22, or 23 if specified.
// See "Expected Later Encoding for CBOR-to-JSON Converters" in RFC 8949 Section 3.4.5.2.
```

Also considered using `ByteSliceLaterEncodingMode` but the word "format" (i.e. encoding format) is probably less ambiguous for people unfamiliar with RFC 8949 Section 3.4.5.2.

