### PR TITLE
Mention new Tinygo feature branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,29 @@ API is mostly same as `encoding/json`, plus interfaces that simplify concurrency
 
 __Install__: `go get github.com/fxamacker/cbor/v2` and `import "github.com/fxamacker/cbor/v2"`.
 
+Tinygo users can try beta/experimental branch [feature/cbor-tinygo-beta](https://github.com/fxamacker/cbor/tree/feature/cbor-tinygo-beta).
+
+<details><summary>More about tinygo feature branch</summary>
+
+### Tinygo
+
+Branch [feature/cbor-tinygo-beta](https://github.com/fxamacker/cbor/tree/feature/cbor-tinygo-beta) is based on fxamacker/cbor v2.7.0 and it can be compiled using tinygo v0.33 (also compiles with golang/go).
+
+It passes unit tests (with both go1.22 and tinygo v0.33) and is considered beta/experimental for tinygo.
+
+:warning: The `feature/cbor-tinygo-beta` branch does not get fuzz tested yet.
+
+Changes in this feature branch only affect tinygo compiled software.  Summary of changes:
+- default `DecOptions.MaxNestedLevels` is reduced to 16 (was 32).  User can specify higher limit but 24+ crashes tests when compiled with tinygo v0.33.
+- disabled decoding CBOR tag data to Go interface because tinygo v0.33 is missing needed feature.
+- encoding error message can be different when encoding function type.
+
+Related tinygo issues:
+- https://github.com/tinygo-org/tinygo/issues/4277
+- https://github.com/tinygo-org/tinygo/issues/4458
+
+</details>
+
 ### Key Points
 
 This library can encode and decode CBOR (RFC 8949) and CBOR Sequences (RFC 8742).

--- a/decode.go
+++ b/decode.go
@@ -1386,8 +1386,7 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 
 				registeredType := d.dm.tags.getTypeFromTagNum(tagNums)
 				if registeredType != nil {
-					if registeredType.Implements(tInfo.nonPtrType) ||
-						reflect.PtrTo(registeredType).Implements(tInfo.nonPtrType) {
+					if implements(registeredType, tInfo.nonPtrType) {
 						v.Set(reflect.New(registeredType))
 						v = v.Elem()
 						tInfo = getTypeInfo(registeredType)

--- a/decode.go
+++ b/decode.go
@@ -960,10 +960,6 @@ const (
 	defaultMaxMapPairs = 131072
 	minMaxMapPairs     = 16
 	maxMaxMapPairs     = 2147483647
-
-	defaultMaxNestedLevels = 32
-	minMaxNestedLevels     = 4
-	maxMaxNestedLevels     = 65535
 )
 
 var defaultSimpleValues = func() *SimpleValueRegistry {

--- a/decode_not_tinygo.go
+++ b/decode_not_tinygo.go
@@ -1,0 +1,13 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+//go:build !tinygo
+
+package cbor
+
+import "reflect"
+
+func implements(concreteType reflect.Type, interfaceType reflect.Type) bool {
+	return concreteType.Implements(interfaceType) ||
+		reflect.PointerTo(concreteType).Implements(interfaceType)
+}

--- a/decode_not_tinygo.go
+++ b/decode_not_tinygo.go
@@ -7,6 +7,12 @@ package cbor
 
 import "reflect"
 
+const (
+	defaultMaxNestedLevels = 32
+	minMaxNestedLevels     = 4
+	maxMaxNestedLevels     = 65535
+)
+
 func implements(concreteType reflect.Type, interfaceType reflect.Type) bool {
 	return concreteType.Implements(interfaceType) ||
 		reflect.PointerTo(concreteType).Implements(interfaceType)

--- a/decode_not_tinygo_test.go
+++ b/decode_not_tinygo_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+//go:build !tinygo
+
+package cbor
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUnmarshalDeepNesting(t *testing.T) {
+	// Construct this object rather than embed such a large constant in the code
+	type TestNode struct {
+		Value int
+		Child *TestNode
+	}
+	n := &TestNode{Value: 0}
+	root := n
+	for i := 0; i < 65534; i++ {
+		child := &TestNode{Value: i}
+		n.Child = child
+		n = child
+	}
+	em, err := EncOptions{}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned error %v", err)
+	}
+	data, err := em.Marshal(root)
+	if err != nil {
+		t.Errorf("Marshal() deeply nested object returned error %v", err)
+	}
+
+	// Try unmarshal it
+	dm, err := DecOptions{MaxNestedLevels: 65535}.DecMode()
+	if err != nil {
+		t.Errorf("DecMode() returned error %v", err)
+	}
+	var readback TestNode
+	err = dm.Unmarshal(data, &readback)
+	if err != nil {
+		t.Errorf("Unmarshal() of deeply nested object returned error: %v", err)
+	}
+	if !reflect.DeepEqual(root, &readback) {
+		t.Errorf("Unmarshal() of deeply nested object did not match\nGot: %#v\n Want: %#v\n",
+			&readback, root)
+	}
+}

--- a/decode_not_tinygo_test.go
+++ b/decode_not_tinygo_test.go
@@ -47,3 +47,63 @@ func TestUnmarshalDeepNesting(t *testing.T) {
 			&readback, root)
 	}
 }
+
+func TestUnmarshalRegisteredTagToInterface(t *testing.T) {
+	var err error
+	tags := NewTagSet()
+	err = tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeOf(C{}), 279)
+	if err != nil {
+		t.Error(err)
+	}
+	err = tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeOf(D{}), 280)
+	if err != nil {
+		t.Error(err)
+	}
+
+	encMode, _ := PreferredUnsortedEncOptions().EncModeWithTags(tags)
+	decMode, _ := DecOptions{}.DecModeWithTags(tags)
+
+	v1 := A1{Field: &C{Field: 5}}
+	data1, err := encMode.Marshal(v1)
+	if err != nil {
+		t.Fatalf("Marshal(%+v) returned error %v", v1, err)
+	}
+
+	v2 := A2{Fields: []B{&C{Field: 5}, &D{Field: "a"}}}
+	data2, err := encMode.Marshal(v2)
+	if err != nil {
+		t.Fatalf("Marshal(%+v) returned error %v", v2, err)
+	}
+
+	testCases := []struct {
+		name           string
+		data           []byte
+		unmarshalToObj interface{}
+		wantValue      interface{}
+	}{
+		{
+			name:           "interface type",
+			data:           data1,
+			unmarshalToObj: &A1{},
+			wantValue:      &v1,
+		},
+		{
+			name:           "slice of interface type",
+			data:           data2,
+			unmarshalToObj: &A2{},
+			wantValue:      &v2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err = decMode.Unmarshal(tc.data, tc.unmarshalToObj)
+			if err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.data, err)
+			}
+			if !reflect.DeepEqual(tc.unmarshalToObj, tc.wantValue) {
+				t.Errorf("Unmarshal(0x%x) = %v, want %v", tc.data, tc.unmarshalToObj, tc.wantValue)
+			}
+		})
+	}
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -4786,44 +4786,6 @@ func TestUnmarshalIntoMapError(t *testing.T) {
 	}
 }
 
-func TestUnmarshalDeepNesting(t *testing.T) {
-	// Construct this object rather than embed such a large constant in the code
-	type TestNode struct {
-		Value int
-		Child *TestNode
-	}
-	n := &TestNode{Value: 0}
-	root := n
-	for i := 0; i < 65534; i++ {
-		child := &TestNode{Value: i}
-		n.Child = child
-		n = child
-	}
-	em, err := EncOptions{}.EncMode()
-	if err != nil {
-		t.Errorf("EncMode() returned error %v", err)
-	}
-	data, err := em.Marshal(root)
-	if err != nil {
-		t.Errorf("Marshal() deeply nested object returned error %v", err)
-	}
-
-	// Try unmarshal it
-	dm, err := DecOptions{MaxNestedLevels: 65535}.DecMode()
-	if err != nil {
-		t.Errorf("DecMode() returned error %v", err)
-	}
-	var readback TestNode
-	err = dm.Unmarshal(data, &readback)
-	if err != nil {
-		t.Errorf("Unmarshal() of deeply nested object returned error: %v", err)
-	}
-	if !reflect.DeepEqual(root, &readback) {
-		t.Errorf("Unmarshal() of deeply nested object did not match\nGot: %#v\n Want: %#v\n",
-			&readback, root)
-	}
-}
-
 func TestStructToArrayError(t *testing.T) {
 	type coseHeader struct {
 		Alg int    `cbor:"1,keyasint,omitempty"`

--- a/decode_test.go
+++ b/decode_test.go
@@ -4995,8 +4995,8 @@ func TestDecModeDefaultMaxNestedLevel(t *testing.T) {
 		t.Errorf("DecMode() returned error %v", err)
 	} else {
 		maxNestedLevels := dm.DecOptions().MaxNestedLevels
-		if maxNestedLevels != 32 {
-			t.Errorf("DecOptions().MaxNestedLevels = %d, want %v", maxNestedLevels, 32)
+		if maxNestedLevels != defaultMaxNestedLevels {
+			t.Errorf("DecOptions().MaxNestedLevels = %d, want %v", maxNestedLevels, defaultMaxNestedLevels)
 		}
 	}
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -7698,7 +7698,7 @@ type A2 struct {
 	Fields []B
 }
 
-func TestUnmarshalRegisteredTagToInterface(t *testing.T) {
+func TestUnmarshalRegisteredTagToConcreteType(t *testing.T) {
 	var err error
 	tags := NewTagSet()
 	err = tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeOf(C{}), 279)
@@ -7719,12 +7719,6 @@ func TestUnmarshalRegisteredTagToInterface(t *testing.T) {
 		t.Fatalf("Marshal(%+v) returned error %v", v1, err)
 	}
 
-	v2 := A2{Fields: []B{&C{Field: 5}, &D{Field: "a"}}}
-	data2, err := encMode.Marshal(v2)
-	if err != nil {
-		t.Fatalf("Marshal(%+v) returned error %v", v2, err)
-	}
-
 	testCases := []struct {
 		name           string
 		data           []byte
@@ -7732,22 +7726,10 @@ func TestUnmarshalRegisteredTagToInterface(t *testing.T) {
 		wantValue      interface{}
 	}{
 		{
-			name:           "interface type",
-			data:           data1,
-			unmarshalToObj: &A1{},
-			wantValue:      &v1,
-		},
-		{
 			name:           "concrete type",
 			data:           data1,
 			unmarshalToObj: &A1{Field: &C{}},
 			wantValue:      &v1,
-		},
-		{
-			name:           "slice of interface type",
-			data:           data2,
-			unmarshalToObj: &A2{},
-			wantValue:      &v2,
 		},
 	}
 

--- a/decode_tinygo.go
+++ b/decode_tinygo.go
@@ -7,6 +7,12 @@ package cbor
 
 import "reflect"
 
+const (
+	defaultMaxNestedLevels = 16    // was 32 for non-tinygo (24+ for tinygo v0.33 panics tests)
+	minMaxNestedLevels     = 4     // same as non-tinygo
+	maxMaxNestedLevels     = 65535 // same as non-tinygo (to allow testing)
+)
+
 // tinygo v0.33 doesn't implement Type.AssignableTo() and it panics.
 // Type.AssignableTo() is used under the hood for Type.Implements().
 //

--- a/decode_tinygo.go
+++ b/decode_tinygo.go
@@ -1,0 +1,18 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+//go:build tinygo
+
+package cbor
+
+import "reflect"
+
+// tinygo v0.33 doesn't implement Type.AssignableTo() and it panics.
+// Type.AssignableTo() is used under the hood for Type.Implements().
+//
+// More details in https://github.com/tinygo-org/tinygo/issues/4277.
+//
+// implements() always returns false until tinygo implements Type.AssignableTo().
+func implements(concreteType reflect.Type, interfaceType reflect.Type) bool {
+	return false
+}

--- a/decode_tinygo_test.go
+++ b/decode_tinygo_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+//go:build tinygo
+
+package cbor
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestUnmarshalDeepNesting tests marshaling and unmarshaling of deeply nesting objects.
+// tinygo v0.33 fails with roughly 24+ levels of nested objects.
+func TestUnmarshalDeepNesting(t *testing.T) {
+	// Construct this object rather than embed such a large constant in the code.
+	type TestNode struct {
+		Value int
+		Child *TestNode
+	}
+	n := &TestNode{Value: 0}
+	root := n
+	const tinygoNestedLevels = 24
+	for i := 1; i < tinygoNestedLevels; i++ {
+		child := &TestNode{Value: i}
+		n.Child = child
+		n = child
+	}
+	em, err := EncOptions{}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned error %v", err)
+	}
+	data, err := em.Marshal(root)
+	if err != nil {
+		t.Errorf("Marshal() deeply nested object returned error %v", err)
+	}
+
+	// Try unmarshal it
+	dm, err := DecOptions{MaxNestedLevels: tinygoNestedLevels}.DecMode()
+	if err != nil {
+		t.Errorf("DecMode() returned error %v", err)
+	}
+	var readback TestNode
+	err = dm.Unmarshal(data, &readback)
+	if err != nil {
+		t.Errorf("Unmarshal() of deeply nested object returned error: %v", err)
+	}
+	if !reflect.DeepEqual(root, &readback) {
+		t.Errorf("Unmarshal() of deeply nested object did not match\nGot: %#v\n Want: %#v\n",
+			&readback, root)
+	}
+}

--- a/encode_map.go
+++ b/encode_map.go
@@ -1,7 +1,7 @@
 // Copyright (c) Faye Amacker. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-//go:build go1.20
+//go:build go1.20 && !tinygo
 
 package cbor
 

--- a/encode_map_go117.go
+++ b/encode_map_go117.go
@@ -1,7 +1,7 @@
 // Copyright (c) Faye Amacker. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-//go:build !go1.20
+//go:build !go1.20 || tinygo
 
 package cbor
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -319,7 +319,7 @@ func TestInvalidTypeMarshal(t *testing.T) {
 		{"map of channel cannot be marshaled", make(map[string]chan bool), "cbor: unsupported type: map[string]chan bool"},
 		{"struct of channel cannot be marshaled", s1{}, "cbor: unsupported type: cbor.s1"},
 		{"struct of channel cannot be marshaled", s2{}, "cbor: unsupported type: cbor.s2"},
-		{"function cannot be marshaled", func(i int) int { return i * i }, "cbor: unsupported type: func(int) int"},
+		{"function cannot be marshaled", func(i int) int { return i * i }, "cbor: unsupported type: func"},
 		{"complex cannot be marshaled", complex(100, 8), "cbor: unsupported type: complex128"},
 	}
 	em, err := EncOptions{Sort: SortCanonical}.EncMode()
@@ -334,7 +334,7 @@ func TestInvalidTypeMarshal(t *testing.T) {
 				t.Errorf("Marshal(%v) didn't return an error, want error %q", tc.value, tc.wantErrorMsg)
 			} else if _, ok := err.(*UnsupportedTypeError); !ok {
 				t.Errorf("Marshal(%v) error type %T, want *UnsupportedTypeError", tc.value, err)
-			} else if err.Error() != tc.wantErrorMsg {
+			} else if !strings.HasPrefix(err.Error(), tc.wantErrorMsg) {
 				t.Errorf("Marshal(%v) error %q, want %q", tc.value, err.Error(), tc.wantErrorMsg)
 			} else if b != nil {
 				t.Errorf("Marshal(%v) = 0x%x, want nil", tc.value, b)
@@ -346,7 +346,7 @@ func TestInvalidTypeMarshal(t *testing.T) {
 				t.Errorf("Marshal(%v) didn't return an error, want error %q", tc.value, tc.wantErrorMsg)
 			} else if _, ok := err.(*UnsupportedTypeError); !ok {
 				t.Errorf("Marshal(%v) error type %T, want *UnsupportedTypeError", tc.value, err)
-			} else if err.Error() != tc.wantErrorMsg {
+			} else if !strings.HasPrefix(err.Error(), tc.wantErrorMsg) {
 				t.Errorf("Marshal(%v) error %q, want %q", tc.value, err.Error(), tc.wantErrorMsg)
 			} else if b != nil {
 				t.Errorf("Marshal(%v) = 0x%x, want nil", tc.value, b)

--- a/stream_test.go
+++ b/stream_test.go
@@ -692,7 +692,7 @@ func TestEncoderError(t *testing.T) {
 		wantErrorMsg string
 	}{
 		{"channel cannot be marshaled", make(chan bool), "cbor: unsupported type: chan bool"},
-		{"function cannot be marshaled", func(i int) int { return i * i }, "cbor: unsupported type: func(int) int"},
+		{"function cannot be marshaled", func(i int) int { return i * i }, "cbor: unsupported type: func"},
 		{"complex cannot be marshaled", complex(100, 8), "cbor: unsupported type: complex128"},
 	}
 	var w bytes.Buffer
@@ -705,7 +705,7 @@ func TestEncoderError(t *testing.T) {
 				t.Errorf("Encode(%v) didn't return an error, want error %q", tc.value, tc.wantErrorMsg)
 			} else if _, ok := err.(*UnsupportedTypeError); !ok {
 				t.Errorf("Encode(%v) error type %T, want *UnsupportedTypeError", tc.value, err)
-			} else if err.Error() != tc.wantErrorMsg {
+			} else if !strings.HasPrefix(err.Error(), tc.wantErrorMsg) {
 				t.Errorf("Encode(%v) error %q, want %q", tc.value, err.Error(), tc.wantErrorMsg)
 			}
 		})

--- a/valid_not_tinygo_test.go
+++ b/valid_not_tinygo_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+//go:build !tinygo
+
+package cbor
+
+import "testing"
+
+func Test32Depth(t *testing.T) {
+	testCases := []struct {
+		name      string
+		data      []byte
+		wantDepth int
+	}{
+		{"32-level array", hexDecode("82018181818181818181818181818181818181818181818181818181818181818101"), 32},
+		{"32-level indefinite length array", hexDecode("9f018181818181818181818181818181818181818181818181818181818181818101ff"), 32},
+		{"32-level map", hexDecode("a1018181818181818181818181818181818181818181818181818181818181818101"), 32},
+		{"32-level indefinite length map", hexDecode("bf018181818181818181818181818181818181818181818181818181818181818101ff"), 32},
+		{"32-level tag", hexDecode("d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d86474323031332d30332d32315432303a30343a30305a"), 32}, // 100(100(...("2013-03-21T20:04:00Z")))
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := decoder{data: tc.data, dm: defaultDecMode}
+			depth, err := d.wellformedInternal(0, false)
+			if err != nil {
+				t.Errorf("wellformed(0x%x) returned error %v", tc.data, err)
+			}
+			if depth != tc.wantDepth {
+				t.Errorf("wellformed(0x%x) returned depth %d, want %d", tc.data, depth, tc.wantDepth)
+			}
+		})
+	}
+}

--- a/valid_test.go
+++ b/valid_test.go
@@ -5,6 +5,7 @@ package cbor
 
 import (
 	"bytes"
+	"strconv"
 	"testing"
 )
 
@@ -102,11 +103,11 @@ func TestDepth(t *testing.T) {
 		{"tagged map and array", hexDecode("d864a26161016162d865820203"), 2},                                    // 100({"a": 1, "b": 101([2, 3])})
 		{"tagged map and array", hexDecode("d864a26161016162d865d866820203"), 3},                                // 100({"a": 1, "b": 101(102([2, 3]))})
 		{"nested tag", hexDecode("d864d865d86674323031332d30332d32315432303a30343a30305a"), 2},                  // 100(101(102("2013-03-21T20:04:00Z")))
-		{"32-level array", hexDecode("82018181818181818181818181818181818181818181818181818181818181818101"), 32},
-		{"32-level indefinite length array", hexDecode("9f018181818181818181818181818181818181818181818181818181818181818101ff"), 32},
-		{"32-level map", hexDecode("a1018181818181818181818181818181818181818181818181818181818181818101"), 32},
-		{"32-level indefinite length map", hexDecode("bf018181818181818181818181818181818181818181818181818181818181818101ff"), 32},
-		{"32-level tag", hexDecode("d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d86474323031332d30332d32315432303a30343a30305a"), 32}, // 100(100(...("2013-03-21T20:04:00Z")))
+		{"16-level array", hexDecode("820181818181818181818181818181818101"), 16},
+		{"16-level indefinite length array", hexDecode("9f0181818181818181818181818181818101ff"), 16},
+		{"16-level map", hexDecode("a10181818181818181818181818181818101"), 16},
+		{"16-level indefinite length map", hexDecode("bf0181818181818181818181818181818101ff"), 16},
+		{"16-level tag", hexDecode("d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d86474323031332d30332d32315432303a30343a30305a"), 16}, // 100(100(...("2013-03-21T20:04:00Z")))
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -145,31 +146,31 @@ func TestDepthError(t *testing.T) {
 			name:         "33-level array",
 			data:         hexDecode("8201818181818181818181818181818181818181818181818181818181818181818101"),
 			opts:         DecOptions{},
-			wantErrorMsg: "cbor: exceeded max nested level 32",
+			wantErrorMsg: "cbor: exceeded max nested level " + strconv.Itoa(defaultMaxNestedLevels),
 		},
 		{
 			name:         "33-level indefinite length array",
 			data:         hexDecode("9f01818181818181818181818181818181818181818181818181818181818181818101ff"),
 			opts:         DecOptions{},
-			wantErrorMsg: "cbor: exceeded max nested level 32",
+			wantErrorMsg: "cbor: exceeded max nested level " + strconv.Itoa(defaultMaxNestedLevels),
 		},
 		{
 			name:         "33-level map",
 			data:         hexDecode("a101818181818181818181818181818181818181818181818181818181818181818101"),
 			opts:         DecOptions{},
-			wantErrorMsg: "cbor: exceeded max nested level 32",
+			wantErrorMsg: "cbor: exceeded max nested level " + strconv.Itoa(defaultMaxNestedLevels),
 		},
 		{
 			name:         "33-level indefinite length map",
 			data:         hexDecode("bf01818181818181818181818181818181818181818181818181818181818181818101ff"),
 			opts:         DecOptions{},
-			wantErrorMsg: "cbor: exceeded max nested level 32",
+			wantErrorMsg: "cbor: exceeded max nested level " + strconv.Itoa(defaultMaxNestedLevels),
 		},
 		{
 			name:         "33-level tag",
 			data:         hexDecode("d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d86474323031332d30332d32315432303a30343a30305a"),
 			opts:         DecOptions{},
-			wantErrorMsg: "cbor: exceeded max nested level 32",
+			wantErrorMsg: "cbor: exceeded max nested level " + strconv.Itoa(defaultMaxNestedLevels),
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Update Quick Start section of README to mention new branch:
- feature/cbor-tinygo-beta

It can be compiled using tinygo v0.33+ and go1.20+.

### New TinyGo Feature Branch

Branch [feature/cbor-tinygo-beta](https://github.com/fxamacker/cbor/tree/feature/cbor-tinygo-beta) is based on fxamacker/cbor v2.7.0 and it can be compiled using tinygo v0.33 (also compiles with golang/go).

It passes unit tests (with both go1.22 and tinygo v0.33) and is considered beta/experimental for tinygo.

:warning: The `feature/cbor-tinygo-beta` branch does not get fuzz tested yet.

Changes in this feature branch only affect tinygo compiled software.  Summary of changes:
- default `DecOptions.MaxNestedLevels` is reduced to 16 (was 32).  User can specify higher limit but :warning: 24+ crashes tests when compiled with tinygo v0.33.
- disabled decoding CBOR tag data to Go interface because tinygo v0.33 is missing needed feature.
- encoding error message can be different when encoding function type.
