### PR TITLE
.github: Bump govulncheck from 1.1.3 to 1.1.4

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -39,7 +39,7 @@ jobs:
         check-latest: true
  
     - name: Install latest govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@4ea4418106cea3bb2c9aa098527c924e9e1fbbb4 # v1.1.3
+      run: go install golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 # v1.1.4
 
     - name: Run govulncheck
       run: govulncheck -show=traces ./...


### PR DESCRIPTION
Bump [govulncheck](https://golang.org/x/vuln/cmd/govulncheck) from 1.1.3 to 1.1.4.