### PR TITLE
.github: Require 97% or more code coverage

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -14,7 +14,7 @@
 # 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.  
 # 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
 
-name: cover ≥96%
+name: cover ≥97%
 
 # Remove default permissions.
 permissions: {}
@@ -44,7 +44,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
-        go-version: 1.23
+        go-version: 1.24
         check-latest: true
     - name: Install x448/float16
       run: go get github.com/x448/float16@v0.8.4

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [Quick&nbsp;Start](#quick-start) and [Releases](https://github.com/fxamacker
 ## fxamacker/cbor
 
 [![](https://github.com/fxamacker/cbor/workflows/ci/badge.svg)](https://github.com/fxamacker/cbor/actions?query=workflow%3Aci)
-[![](https://github.com/fxamacker/cbor/workflows/cover%20%E2%89%A596%25/badge.svg)](https://github.com/fxamacker/cbor/actions?query=workflow%3A%22cover+%E2%89%A596%25%22)
+[![](https://github.com/fxamacker/cbor/workflows/cover%20%E2%89%A597%25/badge.svg)](https://github.com/fxamacker/cbor/actions?query=workflow%3A%22cover+%E2%89%A597%25%22)
 [![CodeQL](https://github.com/fxamacker/cbor/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/fxamacker/cbor/actions/workflows/codeql-analysis.yml)
 [![](https://img.shields.io/badge/fuzzing-passing-44c010)](#fuzzing-and-code-coverage)
 [![Go Report Card](https://goreportcard.com/badge/github.com/fxamacker/cbor)](https://goreportcard.com/report/github.com/fxamacker/cbor)


### PR DESCRIPTION
Currently, `go test -short -cover` reports 97.6% coverage for cbor codec.

This PR updates ci-go-cover.yml to return error if `go test -short -cover` reports less than 97% coverage.

Other changes:
- bump go 1.23 to 1.24 for running coverage test
- update README to use new URL for auto-generated badge.svg
