### PR TITLE
Replace interface{} with any

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -188,16 +188,16 @@ var decodeBenchmarks = []struct {
 var encodeBenchmarks = []struct {
 	name   string
 	data   []byte
-	values []interface{}
+	values []any
 }{
-	{"bool", hexDecode("f5"), []interface{}{true}},
-	{"positive int", hexDecode("1bffffffffffffffff"), []interface{}{uint64(18446744073709551615)}},
-	{"negative int", hexDecode("3903e7"), []interface{}{int64(-1000)}},
-	{"float", hexDecode("fbc010666666666666"), []interface{}{float64(-4.1)}},
-	{"bytes", hexDecode("581a0102030405060708090a0b0c0d0e0f101112131415161718191a"), []interface{}{[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}}},
-	{"text", hexDecode("782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67"), []interface{}{"The quick brown fox jumps over the lazy dog"}},
-	{"array", hexDecode("981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a"), []interface{}{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}}},
-	{"map", hexDecode("ad616161416162614261636143616461446165614561666146616761476168614861696149616a614a616c614c616d614d616e614e"), []interface{}{map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}}},
+	{"bool", hexDecode("f5"), []any{true}},
+	{"positive int", hexDecode("1bffffffffffffffff"), []any{uint64(18446744073709551615)}},
+	{"negative int", hexDecode("3903e7"), []any{int64(-1000)}},
+	{"float", hexDecode("fbc010666666666666"), []any{float64(-4.1)}},
+	{"bytes", hexDecode("581a0102030405060708090a0b0c0d0e0f101112131415161718191a"), []any{[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}}},
+	{"text", hexDecode("782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67"), []any{"The quick brown fox jumps over the lazy dog"}},
+	{"array", hexDecode("981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a"), []any{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}}},
+	{"map", hexDecode("ad616161416162614261636143616461446165614561666146616761476168614861696149616a614a616c614c616d614d616e614e"), []any{map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}}},
 }
 
 func BenchmarkUnmarshal(b *testing.B) {
@@ -226,7 +226,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 		{
 			"CBOR map to Go map[string]interface{}",
 			hexDecode("a86154f56255691bffffffffffffffff61493903e76146fbc0106666666666666142581a0102030405060708090a0b0c0d0e0f101112131415161718191a6153782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6764536c6369981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a634d7373ad6163614361656145616661466167614761686148616e614e616d614d61616141616261426164614461696149616a614a616c614c"),
-			reflect.TypeOf(map[string]interface{}{}),
+			reflect.TypeOf(map[string]any{}),
 		},
 		// Unmarshal CBOR map with string key to struct.
 		{
@@ -238,7 +238,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 		{
 			"CBOR map to Go map[int]interface{}",
 			hexDecode("a801f5021bffffffffffffffff033903e704fbc01066666666666605581a0102030405060708090a0b0c0d0e0f101112131415161718191a06782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6707981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a08ad61646144616661466167614761686148616d614d616e614e6161614161626142616361436165614561696149616a614a616c614c"),
-			reflect.TypeOf(map[int]interface{}{}),
+			reflect.TypeOf(map[int]any{}),
 		},
 		// Unmarshal CBOR map with integer key, such as COSE Key and SenML, to struct.
 		{
@@ -250,7 +250,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 		{
 			"CBOR array to Go []interface{}",
 			hexDecode("88f51bffffffffffffffff3903e7fbc010666666666666581a0102030405060708090a0b0c0d0e0f101112131415161718191a782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67981a0102030405060708090a0b0c0d0e0f101112131415161718181819181aad616261426163614361646144616561456166614661696149616e614e616161416167614761686148616a614a616c614c616d614d"),
-			reflect.TypeOf([]interface{}{}),
+			reflect.TypeOf([]any{}),
 		},
 		// Unmarshal CBOR array of known sequence of data types, such as signed/maced/encrypted CWT, to struct.
 		{
@@ -384,7 +384,7 @@ func BenchmarkMarshal(b *testing.B) {
 		}
 	}
 	// Marshal map[string]interface{} to CBOR map
-	m1 := map[string]interface{}{ //nolint:dupl
+	m1 := map[string]any{
 		"T":    true,
 		"UI":   uint(18446744073709551615),
 		"I":    -1000,
@@ -406,7 +406,7 @@ func BenchmarkMarshal(b *testing.B) {
 		Mss:  map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
 	}
 	// Marshal map[int]interface{} to CBOR map
-	m2 := map[int]interface{}{ //nolint:dupl
+	m2 := map[int]any{
 		1: true,
 		2: uint(18446744073709551615),
 		3: -1000,
@@ -428,7 +428,7 @@ func BenchmarkMarshal(b *testing.B) {
 		Mss:  map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
 	}
 	// Marshal []interface to CBOR array.
-	slc := []interface{}{
+	slc := []any{
 		true,
 		uint(18446744073709551615),
 		-1000,
@@ -451,7 +451,7 @@ func BenchmarkMarshal(b *testing.B) {
 	}
 	var moreBenchmarks = []struct {
 		name  string
-		value interface{}
+		value any
 	}{
 		{"Go map[string]interface{} to CBOR map", m1},
 		{"Go struct to CBOR map", v1},
@@ -501,9 +501,9 @@ func BenchmarkMarshalCanonical(b *testing.B) {
 	for _, bm := range []struct {
 		name   string
 		data   []byte
-		values []interface{}
+		values []any
 	}{
-		{"map", hexDecode("ad616161416162614261636143616461446165614561666146616761476168614861696149616a614a616c614c616d614d616e614e"), []interface{}{map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}, strc{A: "A", B: "B", C: "C", D: "D", E: "E", F: "F", G: "G", H: "H", I: "I", J: "J", L: "L", M: "M", N: "N"}, map[int]int{0: 0} /* single-entry map */}},
+		{"map", hexDecode("ad616161416162614261636143616461446165614561666146616761476168614861696149616a614a616c614c616d614d616e614e"), []any{map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}, strc{A: "A", B: "B", C: "C", D: "D", E: "E", F: "F", G: "G", H: "H", I: "I", J: "J", L: "L", M: "M", N: "N"}, map[int]int{0: 0} /* single-entry map */}},
 	} {
 		for _, v := range bm.values {
 			name := "Go " + reflect.TypeOf(v).String() + " to CBOR " + bm.name
@@ -860,7 +860,7 @@ func BenchmarkUnmarshalMapToStruct(b *testing.B) {
 	type input struct {
 		name   string
 		data   []byte
-		into   interface{}
+		into   any
 		reject bool
 	}
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -33,16 +33,16 @@ var (
 	typeByteArray       = reflect.TypeOf([5]byte{})
 	typeIntSlice        = reflect.TypeOf([]int{})
 	typeStringSlice     = reflect.TypeOf([]string{})
-	typeMapIntfIntf     = reflect.TypeOf(map[interface{}]interface{}{})
+	typeMapIntfIntf     = reflect.TypeOf(map[any]any{})
 	typeMapStringInt    = reflect.TypeOf(map[string]int{})
 	typeMapStringString = reflect.TypeOf(map[string]string{})
-	typeMapStringIntf   = reflect.TypeOf(map[string]interface{}{})
+	typeMapStringIntf   = reflect.TypeOf(map[string]any{})
 )
 
 type unmarshalTest struct {
 	data               []byte
-	wantInterfaceValue interface{}
-	wantValues         []interface{}
+	wantInterfaceValue any
+	wantValues         []any
 	wrongTypes         []reflect.Type
 }
 
@@ -53,7 +53,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("00"),
 		wantInterfaceValue: uint64(0),
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint8(0),
 			uint16(0),
 			uint32(0),
@@ -83,7 +83,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("01"),
 		wantInterfaceValue: uint64(1),
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint8(1),
 			uint16(1),
 			uint32(1),
@@ -113,7 +113,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("0a"),
 		wantInterfaceValue: uint64(10),
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint8(10),
 			uint16(10),
 			uint32(10),
@@ -143,7 +143,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("17"),
 		wantInterfaceValue: uint64(23),
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint8(23),
 			uint16(23),
 			uint32(23),
@@ -173,7 +173,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("1818"),
 		wantInterfaceValue: uint64(24),
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint8(24),
 			uint16(24),
 			uint32(24),
@@ -203,7 +203,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("1819"),
 		wantInterfaceValue: uint64(25),
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint8(25),
 			uint16(25),
 			uint32(25),
@@ -233,7 +233,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("1864"),
 		wantInterfaceValue: uint64(100),
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint8(100),
 			uint16(100),
 			uint32(100),
@@ -263,7 +263,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("1903e8"),
 		wantInterfaceValue: uint64(1000),
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint16(1000),
 			uint32(1000),
 			uint64(1000),
@@ -293,7 +293,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("1a000f4240"),
 		wantInterfaceValue: uint64(1000000),
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint32(1000000),
 			uint64(1000000),
 			uint(1000000),
@@ -323,7 +323,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("1b000000e8d4a51000"),
 		wantInterfaceValue: uint64(1000000000000),
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint64(1000000000000),
 			uint(1000000000000),
 			int64(1000000000000),
@@ -353,7 +353,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("1bffffffffffffffff"),
 		wantInterfaceValue: uint64(18446744073709551615),
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint64(18446744073709551615),
 			uint(18446744073709551615),
 			float32(18446744073709551615),
@@ -383,7 +383,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("20"),
 		wantInterfaceValue: int64(-1),
-		wantValues: []interface{}{
+		wantValues: []any{
 			int8(-1),
 			int16(-1),
 			int32(-1),
@@ -412,7 +412,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("29"),
 		wantInterfaceValue: int64(-10),
-		wantValues: []interface{}{
+		wantValues: []any{
 			int8(-10),
 			int16(-10),
 			int32(-10),
@@ -441,7 +441,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("3863"),
 		wantInterfaceValue: int64(-100),
-		wantValues: []interface{}{
+		wantValues: []any{
 			int8(-100),
 			int16(-100),
 			int32(-100),
@@ -470,7 +470,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("3903e7"),
 		wantInterfaceValue: int64(-1000),
-		wantValues: []interface{}{
+		wantValues: []any{
 			int16(-1000),
 			int32(-1000),
 			int64(-1000),
@@ -499,7 +499,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("3bffffffffffffffff"),
 		wantInterfaceValue: bigIntOrPanic("-18446744073709551616"),
-		wantValues: []interface{}{
+		wantValues: []any{
 			bigIntOrPanic("-18446744073709551616"),
 		},
 		wrongTypes: []reflect.Type{
@@ -527,7 +527,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("40"),
 		wantInterfaceValue: []byte{},
-		wantValues: []interface{}{
+		wantValues: []any{
 			[]byte{},
 			[0]byte{},
 			[1]byte{0},
@@ -557,7 +557,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("4401020304"),
 		wantInterfaceValue: []byte{1, 2, 3, 4},
-		wantValues: []interface{}{
+		wantValues: []any{
 			[]byte{1, 2, 3, 4},
 			[0]byte{},
 			[1]byte{1},
@@ -587,7 +587,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("5f42010243030405ff"),
 		wantInterfaceValue: []byte{1, 2, 3, 4, 5},
-		wantValues: []interface{}{
+		wantValues: []any{
 			[]byte{1, 2, 3, 4, 5},
 			[0]byte{},
 			[1]byte{1},
@@ -620,7 +620,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("60"),
 		wantInterfaceValue: "",
-		wantValues:         []interface{}{""},
+		wantValues:         []any{""},
 		wrongTypes: []reflect.Type{
 			typeUint8,
 			typeUint16,
@@ -646,7 +646,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("6161"),
 		wantInterfaceValue: "a",
-		wantValues:         []interface{}{"a"},
+		wantValues:         []any{"a"},
 		wrongTypes: []reflect.Type{
 			typeUint8,
 			typeUint16,
@@ -672,7 +672,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("6449455446"),
 		wantInterfaceValue: "IETF",
-		wantValues:         []interface{}{"IETF"},
+		wantValues:         []any{"IETF"},
 		wrongTypes: []reflect.Type{
 			typeUint8,
 			typeUint16,
@@ -698,7 +698,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("62225c"),
 		wantInterfaceValue: "\"\\",
-		wantValues:         []interface{}{"\"\\"},
+		wantValues:         []any{"\"\\"},
 		wrongTypes: []reflect.Type{
 			typeUint8,
 			typeUint16,
@@ -724,7 +724,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("62c3bc"),
 		wantInterfaceValue: "ü",
-		wantValues:         []interface{}{"ü"},
+		wantValues:         []any{"ü"},
 		wrongTypes: []reflect.Type{
 			typeUint8,
 			typeUint16,
@@ -750,7 +750,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("63e6b0b4"),
 		wantInterfaceValue: "水",
-		wantValues:         []interface{}{"水"},
+		wantValues:         []any{"水"},
 		wrongTypes: []reflect.Type{
 			typeUint8,
 			typeUint16,
@@ -776,7 +776,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("64f0908591"),
 		wantInterfaceValue: "𐅑",
-		wantValues:         []interface{}{"𐅑"},
+		wantValues:         []any{"𐅑"},
 		wrongTypes: []reflect.Type{
 			typeUint8,
 			typeUint16,
@@ -802,7 +802,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("7f657374726561646d696e67ff"),
 		wantInterfaceValue: "streaming",
-		wantValues:         []interface{}{"streaming"},
+		wantValues:         []any{"streaming"},
 		wrongTypes: []reflect.Type{
 			typeUint8,
 			typeUint16,
@@ -829,9 +829,9 @@ var unmarshalTests = []unmarshalTest{
 	// array
 	{
 		data:               hexDecode("80"),
-		wantInterfaceValue: []interface{}{},
-		wantValues: []interface{}{
-			[]interface{}{},
+		wantInterfaceValue: []any{},
+		wantValues: []any{
+			[]any{},
 			[]byte{},
 			[]string{},
 			[]int{},
@@ -864,9 +864,9 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("83010203"),
-		wantInterfaceValue: []interface{}{uint64(1), uint64(2), uint64(3)},
-		wantValues: []interface{}{
-			[]interface{}{uint64(1), uint64(2), uint64(3)},
+		wantInterfaceValue: []any{uint64(1), uint64(2), uint64(3)},
+		wantValues: []any{
+			[]any{uint64(1), uint64(2), uint64(3)},
 			[]byte{1, 2, 3},
 			[]int{1, 2, 3},
 			[]uint{1, 2, 3},
@@ -902,10 +902,10 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("8301820203820405"),
-		wantInterfaceValue: []interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
-		wantValues: []interface{}{
-			[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
-			[...]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
+		wantInterfaceValue: []any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
+		wantValues: []any{
+			[]any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
+			[...]any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
 		},
 		wrongTypes: []reflect.Type{
 			typeUint8,
@@ -932,10 +932,10 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("83018202039f0405ff"),
-		wantInterfaceValue: []interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
-		wantValues: []interface{}{
-			[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
-			[...]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
+		wantInterfaceValue: []any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
+		wantValues: []any{
+			[]any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
+			[...]any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
 		},
 		wrongTypes: []reflect.Type{
 			typeUint8,
@@ -962,10 +962,10 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("83019f0203ff820405"),
-		wantInterfaceValue: []interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
-		wantValues: []interface{}{
-			[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
-			[...]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
+		wantInterfaceValue: []any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
+		wantValues: []any{
+			[]any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
+			[...]any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
 		},
 		wrongTypes: []reflect.Type{
 			typeUint8,
@@ -992,9 +992,9 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("98190102030405060708090a0b0c0d0e0f101112131415161718181819"),
-		wantInterfaceValue: []interface{}{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
-		wantValues: []interface{}{
-			[]interface{}{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
+		wantInterfaceValue: []any{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
+		wantValues: []any{
+			[]any{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
 			[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
 			[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
 			[]uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
@@ -1029,9 +1029,9 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("9fff"),
-		wantInterfaceValue: []interface{}{},
-		wantValues: []interface{}{
-			[]interface{}{},
+		wantInterfaceValue: []any{},
+		wantValues: []any{
+			[]any{},
 			[]byte{},
 			[]string{},
 			[]int{},
@@ -1064,10 +1064,10 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("9f018202039f0405ffff"),
-		wantInterfaceValue: []interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
-		wantValues: []interface{}{
-			[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
-			[...]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
+		wantInterfaceValue: []any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
+		wantValues: []any{
+			[]any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
+			[...]any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
 		},
 		wrongTypes: []reflect.Type{
 			typeUint8,
@@ -1094,10 +1094,10 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("9f01820203820405ff"),
-		wantInterfaceValue: []interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
-		wantValues: []interface{}{
-			[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
-			[...]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
+		wantInterfaceValue: []any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
+		wantValues: []any{
+			[]any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
+			[...]any{uint64(1), []any{uint64(2), uint64(3)}, []any{uint64(4), uint64(5)}},
 		},
 		wrongTypes: []reflect.Type{
 			typeUint8,
@@ -1124,9 +1124,9 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff"),
-		wantInterfaceValue: []interface{}{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
-		wantValues: []interface{}{
-			[]interface{}{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
+		wantInterfaceValue: []any{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
+		wantValues: []any{
+			[]any{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
 			[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
 			[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
 			[]uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
@@ -1161,10 +1161,10 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("826161a161626163"),
-		wantInterfaceValue: []interface{}{"a", map[interface{}]interface{}{"b": "c"}},
-		wantValues: []interface{}{
-			[]interface{}{"a", map[interface{}]interface{}{"b": "c"}},
-			[...]interface{}{"a", map[interface{}]interface{}{"b": "c"}},
+		wantInterfaceValue: []any{"a", map[any]any{"b": "c"}},
+		wantValues: []any{
+			[]any{"a", map[any]any{"b": "c"}},
+			[...]any{"a", map[any]any{"b": "c"}},
 		},
 		wrongTypes: []reflect.Type{
 			typeUint8,
@@ -1192,10 +1192,10 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("826161bf61626163ff"),
-		wantInterfaceValue: []interface{}{"a", map[interface{}]interface{}{"b": "c"}},
-		wantValues: []interface{}{
-			[]interface{}{"a", map[interface{}]interface{}{"b": "c"}},
-			[...]interface{}{"a", map[interface{}]interface{}{"b": "c"}},
+		wantInterfaceValue: []any{"a", map[any]any{"b": "c"}},
+		wantValues: []any{
+			[]any{"a", map[any]any{"b": "c"}},
+			[...]any{"a", map[any]any{"b": "c"}},
 		},
 		wrongTypes: []reflect.Type{
 			typeUint8,
@@ -1225,9 +1225,9 @@ var unmarshalTests = []unmarshalTest{
 	// map
 	{
 		data:               hexDecode("a0"),
-		wantInterfaceValue: map[interface{}]interface{}{},
-		wantValues: []interface{}{
-			map[interface{}]interface{}{},
+		wantInterfaceValue: map[any]any{},
+		wantValues: []any{
+			map[any]any{},
 			map[string]bool{},
 			map[string]int{},
 			map[int]string{},
@@ -1257,9 +1257,9 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("a201020304"),
-		wantInterfaceValue: map[interface{}]interface{}{uint64(1): uint64(2), uint64(3): uint64(4)},
-		wantValues: []interface{}{
-			map[interface{}]interface{}{uint64(1): uint64(2), uint64(3): uint64(4)},
+		wantInterfaceValue: map[any]any{uint64(1): uint64(2), uint64(3): uint64(4)},
+		wantValues: []any{
+			map[any]any{uint64(1): uint64(2), uint64(3): uint64(4)},
 			map[uint]int{1: 2, 3: 4}, map[int]uint{1: 2, 3: 4},
 		},
 		wrongTypes: []reflect.Type{
@@ -1287,10 +1287,10 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("a26161016162820203"),
-		wantInterfaceValue: map[interface{}]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}},
-		wantValues: []interface{}{
-			map[interface{}]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}},
-			map[string]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}},
+		wantInterfaceValue: map[any]any{"a": uint64(1), "b": []any{uint64(2), uint64(3)}},
+		wantValues: []any{
+			map[any]any{"a": uint64(1), "b": []any{uint64(2), uint64(3)}},
+			map[string]any{"a": uint64(1), "b": []any{uint64(2), uint64(3)}},
 		},
 		wrongTypes: []reflect.Type{
 			typeUint8,
@@ -1317,10 +1317,10 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("a56161614161626142616361436164614461656145"),
-		wantInterfaceValue: map[interface{}]interface{}{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
-		wantValues: []interface{}{
-			map[interface{}]interface{}{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
-			map[string]interface{}{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
+		wantInterfaceValue: map[any]any{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
+		wantValues: []any{
+			map[any]any{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
+			map[string]any{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
 			map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
 		},
 		wrongTypes: []reflect.Type{
@@ -1348,10 +1348,10 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("bf61610161629f0203ffff"),
-		wantInterfaceValue: map[interface{}]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}},
-		wantValues: []interface{}{
-			map[interface{}]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}},
-			map[string]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}},
+		wantInterfaceValue: map[any]any{"a": uint64(1), "b": []any{uint64(2), uint64(3)}},
+		wantValues: []any{
+			map[any]any{"a": uint64(1), "b": []any{uint64(2), uint64(3)}},
+			map[string]any{"a": uint64(1), "b": []any{uint64(2), uint64(3)}},
 		},
 		wrongTypes: []reflect.Type{
 			typeUint8,
@@ -1378,10 +1378,10 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("bf6346756ef563416d7421ff"),
-		wantInterfaceValue: map[interface{}]interface{}{"Fun": true, "Amt": int64(-2)},
-		wantValues: []interface{}{
-			map[interface{}]interface{}{"Fun": true, "Amt": int64(-2)},
-			map[string]interface{}{"Fun": true, "Amt": int64(-2)},
+		wantInterfaceValue: map[any]any{"Fun": true, "Amt": int64(-2)},
+		wantValues: []any{
+			map[any]any{"Fun": true, "Amt": int64(-2)},
+			map[string]any{"Fun": true, "Amt": int64(-2)},
 		},
 		wrongTypes: []reflect.Type{
 			typeUint8,
@@ -1411,7 +1411,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("c074323031332d30332d32315432303a30343a30305a"),
 		wantInterfaceValue: time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC), // 2013-03-21 20:04:00 +0000 UTC
-		wantValues: []interface{}{
+		wantValues: []any{
 			"2013-03-21T20:04:00Z",
 			time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
 			Tag{0, "2013-03-21T20:04:00Z"},
@@ -1440,7 +1440,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("c11a514b67b0"),
 		wantInterfaceValue: time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC), // 2013-03-21 20:04:00 +0000 UTC
-		wantValues: []interface{}{
+		wantValues: []any{
 			uint32(1363896240),
 			uint64(1363896240),
 			int32(1363896240),
@@ -1469,7 +1469,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("c249010000000000000000"),
 		wantInterfaceValue: bigIntOrPanic("18446744073709551616"),
-		wantValues: []interface{}{
+		wantValues: []any{
 			// Decode to byte slice
 			[]byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 			// Decode to array of various lengths
@@ -1505,7 +1505,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("c349010000000000000000"),
 		wantInterfaceValue: bigIntOrPanic("-18446744073709551617"),
-		wantValues: []interface{}{
+		wantValues: []any{
 			// Decode to byte slice
 			[]byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 			// Decode to array of various lengths
@@ -1541,7 +1541,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("c1fb41d452d9ec200000"),
 		wantInterfaceValue: time.Date(2013, 3, 21, 20, 4, 0, 500000000, time.UTC), // 2013-03-21 20:04:00.5 +0000 UTC
-		wantValues: []interface{}{
+		wantValues: []any{
 			float32(1363896240.5),
 			float64(1363896240.5),
 			time.Date(2013, 3, 21, 20, 4, 0, 500000000, time.UTC),
@@ -1571,7 +1571,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("d74401020304"),
 		wantInterfaceValue: Tag{23, []byte{0x01, 0x02, 0x03, 0x04}},
-		wantValues: []interface{}{
+		wantValues: []any{
 			[]byte{0x01, 0x02, 0x03, 0x04},
 			[0]byte{},
 			[1]byte{0x01},
@@ -1603,7 +1603,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("d818456449455446"),
 		wantInterfaceValue: Tag{24, []byte{0x64, 0x49, 0x45, 0x54, 0x46}},
-		wantValues: []interface{}{
+		wantValues: []any{
 			[]byte{0x64, 0x49, 0x45, 0x54, 0x46},
 			[0]byte{},
 			[1]byte{0x64},
@@ -1635,7 +1635,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("d82076687474703a2f2f7777772e6578616d706c652e636f6d"),
 		wantInterfaceValue: Tag{32, "http://www.example.com"},
-		wantValues: []interface{}{
+		wantValues: []any{
 			"http://www.example.com",
 			Tag{32, "http://www.example.com"},
 			RawTag{32, hexDecode("76687474703a2f2f7777772e6578616d706c652e636f6d")},
@@ -1665,7 +1665,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("f4"),
 		wantInterfaceValue: false,
-		wantValues: []interface{}{
+		wantValues: []any{
 			false,
 			SimpleValue(20),
 		},
@@ -1694,7 +1694,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("f5"),
 		wantInterfaceValue: true,
-		wantValues: []interface{}{
+		wantValues: []any{
 			true,
 			SimpleValue(21),
 		},
@@ -1723,7 +1723,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("f6"),
 		wantInterfaceValue: nil,
-		wantValues: []interface{}{
+		wantValues: []any{
 			SimpleValue(22),
 			false,
 			uint(0),
@@ -1753,7 +1753,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("f7"),
 		wantInterfaceValue: nil,
-		wantValues: []interface{}{
+		wantValues: []any{
 			SimpleValue(23),
 			false,
 			uint(0),
@@ -1783,7 +1783,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("f0"),
 		wantInterfaceValue: SimpleValue(16),
-		wantValues: []interface{}{
+		wantValues: []any{
 			SimpleValue(16),
 			uint8(16),
 			uint16(16),
@@ -1823,7 +1823,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("f820"),
 		wantInterfaceValue: SimpleValue(32),
-		wantValues: []interface{}{
+		wantValues: []any{
 			SimpleValue(32),
 			uint8(32),
 			uint16(32),
@@ -1854,7 +1854,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("f8ff"),
 		wantInterfaceValue: SimpleValue(255),
-		wantValues: []interface{}{
+		wantValues: []any{
 			SimpleValue(255),
 			uint8(255),
 			uint16(255),
@@ -1886,7 +1886,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("5fff"), // empty indefinite length byte string
 		wantInterfaceValue: []byte{},
-		wantValues: []interface{}{
+		wantValues: []any{
 			[]byte{},
 			[0]byte{},
 			[1]byte{0x00},
@@ -1915,7 +1915,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("7fff"), // empty indefinite length text string
 		wantInterfaceValue: "",
-		wantValues:         []interface{}{""},
+		wantValues:         []any{""},
 		wrongTypes: []reflect.Type{
 			typeUint8,
 			typeUint16,
@@ -1940,9 +1940,9 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("bfff"), // empty indefinite length map
-		wantInterfaceValue: map[interface{}]interface{}{},
-		wantValues: []interface{}{
-			map[interface{}]interface{}{},
+		wantInterfaceValue: map[any]any{},
+		wantValues: []any{
+			map[any]any{},
 			map[string]bool{},
 			map[string]int{},
 			map[int]string{},
@@ -1975,7 +1975,7 @@ var unmarshalTests = []unmarshalTest{
 	{
 		data:               hexDecode("c13a0177f2cf"), // 1969-03-21T20:04:00Z, tag 1 with negative integer as epoch time
 		wantInterfaceValue: time.Date(1969, 3, 21, 20, 4, 0, 0, time.UTC),
-		wantValues: []interface{}{
+		wantValues: []any{
 			int32(-24638160),
 			int64(-24638160),
 			int32(-24638160),
@@ -2003,9 +2003,9 @@ var unmarshalTests = []unmarshalTest{
 	},
 	{
 		data:               hexDecode("d83dd183010203"), // 61(17([1, 2, 3])), nested tags 61 and 17
-		wantInterfaceValue: Tag{61, Tag{17, []interface{}{uint64(1), uint64(2), uint64(3)}}},
-		wantValues: []interface{}{
-			[]interface{}{uint64(1), uint64(2), uint64(3)},
+		wantInterfaceValue: Tag{61, Tag{17, []any{uint64(1), uint64(2), uint64(3)}}},
+		wantValues: []any{
+			[]any{uint64(1), uint64(2), uint64(3)},
 			[]byte{1, 2, 3},
 			[0]byte{},
 			[1]byte{1},
@@ -2016,7 +2016,7 @@ var unmarshalTests = []unmarshalTest{
 			[...]int{1, 2, 3},
 			[]float32{1, 2, 3},
 			[]float64{1, 2, 3},
-			Tag{61, Tag{17, []interface{}{uint64(1), uint64(2), uint64(3)}}},
+			Tag{61, Tag{17, []any{uint64(1), uint64(2), uint64(3)}}},
 			RawTag{61, hexDecode("d183010203")},
 		},
 		wrongTypes: []reflect.Type{
@@ -2043,8 +2043,8 @@ var unmarshalTests = []unmarshalTest{
 
 type unmarshalFloatTest struct {
 	data               []byte
-	wantInterfaceValue interface{}
-	wantValues         []interface{}
+	wantInterfaceValue any
+	wantValues         []any
 	equalityThreshold  float64 // Not used for +inf, -inf, and NaN.
 }
 
@@ -2080,145 +2080,145 @@ var unmarshalFloatTests = []unmarshalFloatTest{
 	{
 		data:               hexDecode("f90000"),
 		wantInterfaceValue: float64(0.0),
-		wantValues:         []interface{}{float32(0.0), float64(0.0)},
+		wantValues:         []any{float32(0.0), float64(0.0)},
 	},
 	{
 		data:               hexDecode("f98000"),
-		wantInterfaceValue: float64(-0.0),                               //nolint:staticcheck // we know -0.0 is 0.0 in Go
-		wantValues:         []interface{}{float32(-0.0), float64(-0.0)}, //nolint:staticcheck // we know -0.0 is 0.0 in Go
+		wantInterfaceValue: float64(-0.0),                       //nolint:staticcheck // we know -0.0 is 0.0 in Go
+		wantValues:         []any{float32(-0.0), float64(-0.0)}, //nolint:staticcheck // we know -0.0 is 0.0 in Go
 	},
 	{
 		data:               hexDecode("f93c00"),
 		wantInterfaceValue: float64(1.0),
-		wantValues:         []interface{}{float32(1.0), float64(1.0)},
+		wantValues:         []any{float32(1.0), float64(1.0)},
 	},
 	{
 		data:               hexDecode("f93e00"),
 		wantInterfaceValue: float64(1.5),
-		wantValues:         []interface{}{float32(1.5), float64(1.5)},
+		wantValues:         []any{float32(1.5), float64(1.5)},
 	},
 	{
 		data:               hexDecode("f97bff"),
 		wantInterfaceValue: float64(65504.0),
-		wantValues:         []interface{}{float32(65504.0), float64(65504.0)},
+		wantValues:         []any{float32(65504.0), float64(65504.0)},
 	},
 	{
 		data:               hexDecode("f90001"), // float16 subnormal value
 		wantInterfaceValue: float64(5.960464477539063e-08),
-		wantValues:         []interface{}{float32(5.960464477539063e-08), float64(5.960464477539063e-08)},
+		wantValues:         []any{float32(5.960464477539063e-08), float64(5.960464477539063e-08)},
 		equalityThreshold:  1e-16,
 	},
 	{
 		data:               hexDecode("f90400"),
 		wantInterfaceValue: float64(6.103515625e-05),
-		wantValues:         []interface{}{float32(6.103515625e-05), float64(6.103515625e-05)},
+		wantValues:         []any{float32(6.103515625e-05), float64(6.103515625e-05)},
 		equalityThreshold:  1e-16,
 	},
 	{
 		data:               hexDecode("f9c400"),
 		wantInterfaceValue: float64(-4.0),
-		wantValues:         []interface{}{float32(-4.0), float64(-4.0)},
+		wantValues:         []any{float32(-4.0), float64(-4.0)},
 	},
 	{
 		data:               hexDecode("f97c00"),
 		wantInterfaceValue: math.Inf(1),
-		wantValues:         []interface{}{math.Float32frombits(0x7f800000), math.Inf(1)},
+		wantValues:         []any{math.Float32frombits(0x7f800000), math.Inf(1)},
 	},
 	{
 		data:               hexDecode("f97e00"),
 		wantInterfaceValue: math.NaN(),
-		wantValues:         []interface{}{math.Float32frombits(0x7fc00000), math.NaN()},
+		wantValues:         []any{math.Float32frombits(0x7fc00000), math.NaN()},
 	},
 	{
 		data:               hexDecode("f9fc00"),
 		wantInterfaceValue: math.Inf(-1),
-		wantValues:         []interface{}{math.Float32frombits(0xff800000), math.Inf(-1)},
+		wantValues:         []any{math.Float32frombits(0xff800000), math.Inf(-1)},
 	},
 
 	// float32
 	{
 		data:               hexDecode("fa47c35000"),
 		wantInterfaceValue: float64(100000.0),
-		wantValues:         []interface{}{float32(100000.0), float64(100000.0)},
+		wantValues:         []any{float32(100000.0), float64(100000.0)},
 	},
 	{
 		data:               hexDecode("fa7f7fffff"),
 		wantInterfaceValue: float64(3.4028234663852886e+38),
-		wantValues:         []interface{}{float32(3.4028234663852886e+38), float64(3.4028234663852886e+38)},
+		wantValues:         []any{float32(3.4028234663852886e+38), float64(3.4028234663852886e+38)},
 		equalityThreshold:  1e-9,
 	},
 	{
 		data:               hexDecode("fa7f800000"),
 		wantInterfaceValue: math.Inf(1),
-		wantValues:         []interface{}{math.Float32frombits(0x7f800000), math.Inf(1)},
+		wantValues:         []any{math.Float32frombits(0x7f800000), math.Inf(1)},
 	},
 	{
 		data:               hexDecode("fa7fc00000"),
 		wantInterfaceValue: math.NaN(),
-		wantValues:         []interface{}{math.Float32frombits(0x7fc00000), math.NaN()},
+		wantValues:         []any{math.Float32frombits(0x7fc00000), math.NaN()},
 	},
 	{
 		data:               hexDecode("faff800000"),
 		wantInterfaceValue: math.Inf(-1),
-		wantValues:         []interface{}{math.Float32frombits(0xff800000), math.Inf(-1)},
+		wantValues:         []any{math.Float32frombits(0xff800000), math.Inf(-1)},
 	},
 
 	// float64
 	{
 		data:               hexDecode("fb3ff199999999999a"),
 		wantInterfaceValue: float64(1.1),
-		wantValues:         []interface{}{float32(1.1), float64(1.1)},
+		wantValues:         []any{float32(1.1), float64(1.1)},
 	},
 	{
 		data:               hexDecode("fb7e37e43c8800759c"),
 		wantInterfaceValue: float64(1.0e+300),
-		wantValues:         []interface{}{float64(1.0e+300)},
+		wantValues:         []any{float64(1.0e+300)},
 		equalityThreshold:  1e-9,
 	},
 	{
 		data:               hexDecode("fbc010666666666666"),
 		wantInterfaceValue: float64(-4.1),
-		wantValues:         []interface{}{float32(-4.1), float64(-4.1)},
+		wantValues:         []any{float32(-4.1), float64(-4.1)},
 	},
 	{
 		data:               hexDecode("fb7ff0000000000000"),
 		wantInterfaceValue: math.Inf(1),
-		wantValues:         []interface{}{math.Float32frombits(0x7f800000), math.Inf(1)},
+		wantValues:         []any{math.Float32frombits(0x7f800000), math.Inf(1)},
 	},
 	{
 		data:               hexDecode("fb7ff8000000000000"),
 		wantInterfaceValue: math.NaN(),
-		wantValues:         []interface{}{math.Float32frombits(0x7fc00000), math.NaN()},
+		wantValues:         []any{math.Float32frombits(0x7fc00000), math.NaN()},
 	},
 	{
 		data:               hexDecode("fbfff0000000000000"),
 		wantInterfaceValue: math.Inf(-1),
-		wantValues:         []interface{}{math.Float32frombits(0xff800000), math.Inf(-1)},
+		wantValues:         []any{math.Float32frombits(0xff800000), math.Inf(-1)},
 	},
 
 	// float16 test data from https://en.wikipedia.org/wiki/Half-precision_floating-point_format
 	{
 		data:               hexDecode("f903ff"),
 		wantInterfaceValue: float64(0.000060976),
-		wantValues:         []interface{}{float32(0.000060976), float64(0.000060976)},
+		wantValues:         []any{float32(0.000060976), float64(0.000060976)},
 		equalityThreshold:  1e-9,
 	},
 	{
 		data:               hexDecode("f93bff"),
 		wantInterfaceValue: float64(0.999511719),
-		wantValues:         []interface{}{float32(0.999511719), float64(0.999511719)},
+		wantValues:         []any{float32(0.999511719), float64(0.999511719)},
 		equalityThreshold:  1e-9,
 	},
 	{
 		data:               hexDecode("f93c01"),
 		wantInterfaceValue: float64(1.000976563),
-		wantValues:         []interface{}{float32(1.000976563), float64(1.000976563)},
+		wantValues:         []any{float32(1.000976563), float64(1.000976563)},
 		equalityThreshold:  1e-9,
 	},
 	{
 		data:               hexDecode("f93555"),
 		wantInterfaceValue: float64(0.333251953125),
-		wantValues:         []interface{}{float32(0.333251953125), float64(0.333251953125)},
+		wantValues:         []any{float32(0.333251953125), float64(0.333251953125)},
 		equalityThreshold:  1e-9,
 	},
 
@@ -2226,52 +2226,52 @@ var unmarshalFloatTests = []unmarshalFloatTest{
 	{
 		data:               hexDecode("f9bd00"),
 		wantInterfaceValue: float64(-1.25),
-		wantValues:         []interface{}{float32(-1.25), float64(-1.25)},
+		wantValues:         []any{float32(-1.25), float64(-1.25)},
 	},
 	{
 		data:               hexDecode("f93e00"),
 		wantInterfaceValue: float64(1.5),
-		wantValues:         []interface{}{float32(1.5), float64(1.5)},
+		wantValues:         []any{float32(1.5), float64(1.5)},
 	},
 	{
 		data:               hexDecode("fb4024333333333333"),
 		wantInterfaceValue: float64(10.1),
-		wantValues:         []interface{}{float32(10.1), float64(10.1)},
+		wantValues:         []any{float32(10.1), float64(10.1)},
 	},
 	{
 		data:               hexDecode("f90001"),
 		wantInterfaceValue: float64(5.960464477539063e-8),
-		wantValues:         []interface{}{float32(5.960464477539063e-8), float64(5.960464477539063e-8)},
+		wantValues:         []any{float32(5.960464477539063e-8), float64(5.960464477539063e-8)},
 	},
 	{
 		data:               hexDecode("fa7f7fffff"),
 		wantInterfaceValue: float64(3.4028234663852886e+38),
-		wantValues:         []interface{}{float32(3.4028234663852886e+38), float64(3.4028234663852886e+38)},
+		wantValues:         []any{float32(3.4028234663852886e+38), float64(3.4028234663852886e+38)},
 	},
 	{
 		data:               hexDecode("f90400"),
 		wantInterfaceValue: float64(0.00006103515625),
-		wantValues:         []interface{}{float32(0.00006103515625), float64(0.00006103515625)},
+		wantValues:         []any{float32(0.00006103515625), float64(0.00006103515625)},
 	},
 	{
 		data:               hexDecode("f933ff"),
 		wantInterfaceValue: float64(0.2498779296875),
-		wantValues:         []interface{}{float32(0.2498779296875), float64(0.2498779296875)},
+		wantValues:         []any{float32(0.2498779296875), float64(0.2498779296875)},
 	},
 	{
 		data:               hexDecode("fa33000000"),
 		wantInterfaceValue: float64(2.9802322387695312e-8),
-		wantValues:         []interface{}{float32(2.9802322387695312e-8), float64(2.9802322387695312e-8)},
+		wantValues:         []any{float32(2.9802322387695312e-8), float64(2.9802322387695312e-8)},
 	},
 	{
 		data:               hexDecode("fa33333866"),
 		wantInterfaceValue: float64(4.1727979294137185e-8),
-		wantValues:         []interface{}{float32(4.1727979294137185e-8), float64(4.1727979294137185e-8)},
+		wantValues:         []any{float32(4.1727979294137185e-8), float64(4.1727979294137185e-8)},
 	},
 	{
 		data:               hexDecode("fa37002000"),
 		wantInterfaceValue: float64(0.000007636845111846924),
-		wantValues:         []interface{}{float32(0.000007636845111846924), float64(0.000007636845111846924)},
+		wantValues:         []any{float32(0.000007636845111846924), float64(0.000007636845111846924)},
 	},
 }
 
@@ -2295,7 +2295,7 @@ func bigIntOrPanic(s string) big.Int {
 
 func TestUnmarshalToEmptyInterface(t *testing.T) {
 	for _, tc := range unmarshalTests {
-		var v interface{}
+		var v any
 		if err := Unmarshal(tc.data, &v); err != nil {
 			t.Errorf("Unmarshal(0x%x) returned error %v", tc.data, err)
 			continue
@@ -2358,14 +2358,14 @@ func testUnmarshalToRawMessage(t *testing.T, data []byte) {
 func TestUnmarshalToCompatibleTypes(t *testing.T) {
 	for _, tc := range unmarshalTests {
 		for _, wantValue := range tc.wantValues {
-			testUnmarshalToCompatibleType(t, tc.data, wantValue, func(gotValue interface{}) {
+			testUnmarshalToCompatibleType(t, tc.data, wantValue, func(gotValue any) {
 				compareNonFloats(t, tc.data, gotValue, wantValue)
 			})
 		}
 	}
 }
 
-func testUnmarshalToCompatibleType(t *testing.T, data []byte, wantValue interface{}, compare func(gotValue interface{})) {
+func testUnmarshalToCompatibleType(t *testing.T, data []byte, wantValue any, compare func(gotValue any)) {
 	var rv reflect.Value
 
 	cborNil := isCBORNil(data)
@@ -2469,7 +2469,7 @@ func testUnmarshalToIncompatibleType(t *testing.T, data []byte, wrongType reflec
 	}
 }
 
-func compareNonFloats(t *testing.T, data []byte, got interface{}, want interface{}) {
+func compareNonFloats(t *testing.T, data []byte, got any, want any) {
 	switch tm := want.(type) {
 	case time.Time:
 		if vt, ok := got.(time.Time); !ok || !tm.Equal(vt) {
@@ -2485,7 +2485,7 @@ func compareNonFloats(t *testing.T, data []byte, got interface{}, want interface
 
 func TestUnmarshalFloatToEmptyInterface(t *testing.T) {
 	for _, tc := range unmarshalFloatTests {
-		var v interface{}
+		var v any
 		if err := Unmarshal(tc.data, &v); err != nil {
 			t.Errorf("Unmarshal(0x%x) returned error %v", tc.data, err)
 			continue
@@ -2503,7 +2503,7 @@ func TestUnmarshalFloatToRawMessage(t *testing.T) {
 func TestUnmarshalFloatToCompatibleTypes(t *testing.T) {
 	for _, tc := range unmarshalFloatTests {
 		for _, wantValue := range tc.wantValues {
-			testUnmarshalToCompatibleType(t, tc.data, wantValue, func(gotValue interface{}) {
+			testUnmarshalToCompatibleType(t, tc.data, wantValue, func(gotValue any) {
 				compareFloats(t, tc.data, gotValue, wantValue, tc.equalityThreshold)
 			})
 		}
@@ -2518,7 +2518,7 @@ func TestUnmarshalFloatToIncompatibleTypes(t *testing.T) {
 	}
 }
 
-func compareFloats(t *testing.T, data []byte, got interface{}, want interface{}, equalityThreshold float64) {
+func compareFloats(t *testing.T, data []byte, got any, want any, equalityThreshold float64) {
 	var gotFloat64, wantFloat64 float64
 
 	switch want := want.(type) {
@@ -2561,7 +2561,7 @@ func TestNegIntOverflow(t *testing.T) {
 	data := hexDecode("3bffffffffffffffff") // -18446744073709551616
 
 	// Decode CBOR neg int that overflows Go int64 to empty interface
-	var v1 interface{}
+	var v1 any
 	wantObj := bigIntOrPanic("-18446744073709551616")
 	if err := Unmarshal(data, &v1); err != nil {
 		t.Errorf("Unmarshal(0x%x) returned error %+v", data, err)
@@ -2787,8 +2787,8 @@ func TestUnmarshalNil(t *testing.T) {
 
 	testCases := []struct {
 		name      string
-		value     interface{}
-		wantValue interface{}
+		value     any
+		wantValue any
 	}{
 		// Unmarshalling CBOR null to the following types is a no-op.
 		{"bool", true, true},
@@ -2857,7 +2857,7 @@ func TestUnmarshalNil(t *testing.T) {
 
 var invalidUnmarshalTests = []struct {
 	name         string
-	v            interface{}
+	v            any
 	wantErrorMsg string
 }{
 	{"unmarshal into nil interface{}", nil, "cbor: Unmarshal(nil)"},
@@ -2995,7 +2995,7 @@ var invalidCBORUnmarshalTests = []struct {
 func TestInvalidCBORUnmarshal(t *testing.T) {
 	for _, tc := range invalidCBORUnmarshalTests {
 		t.Run(tc.name, func(t *testing.T) {
-			var i interface{}
+			var i any
 			err := Unmarshal(tc.data, &i)
 			if err == nil {
 				t.Errorf("Unmarshal(0x%x) didn't return an error", tc.data)
@@ -3022,7 +3022,7 @@ func TestValidUTF8String(t *testing.T) {
 		name    string
 		data    []byte
 		dm      DecMode
-		wantObj interface{}
+		wantObj any
 	}{
 		{
 			name:    "with UTF8RejectInvalid",
@@ -3052,7 +3052,7 @@ func TestValidUTF8String(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Decode to empty interface
-			var i interface{}
+			var i any
 			err = tc.dm.Unmarshal(tc.data, &i)
 			if err != nil {
 				t.Errorf("Unmarshal(0x%x) returned error %q", tc.data, err)
@@ -3088,7 +3088,7 @@ func TestInvalidUTF8String(t *testing.T) {
 		name         string
 		data         []byte
 		dm           DecMode
-		wantObj      interface{}
+		wantObj      any
 		wantErrorMsg string
 	}{
 		{
@@ -3120,7 +3120,7 @@ func TestInvalidUTF8String(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Decode to empty interface
-			var v interface{}
+			var v any
 			err = tc.dm.Unmarshal(tc.data, &v)
 			if tc.wantErrorMsg != "" {
 				if err == nil {
@@ -3204,7 +3204,7 @@ func TestUnmarshalStruct(t *testing.T) {
 	tests := []struct {
 		name string
 		data []byte
-		want interface{}
+		want any
 	}{
 		{"case-insensitive field name match", hexDecode("a868696e746669656c64187b6a666c6f61746669656c64fa47c3500069626f6f6c6669656c64f56b537472696e674669656c6464746573746f42797465537472696e674669656c64430103056a41727261794669656c64826568656c6c6f65776f726c64684d61704669656c64a2676d6f726e696e67f56961667465726e6f6f6ef4714e65737465645374727563744669656c64a261581903e861591a000f4240"), want},
 		{"exact field name match", hexDecode("a868496e744669656c64187b6a466c6f61744669656c64fa47c3500069426f6f6c4669656c64f56b537472696e674669656c6464746573746f42797465537472696e674669656c64430103056a41727261794669656c64826568656c6c6f65776f726c64684d61704669656c64a2676d6f726e696e67f56961667465726e6f6f6ef4714e65737465645374727563744669656c64a261581903e861591a000f4240"), want},
@@ -3446,7 +3446,7 @@ func TestLengthOverflowsInt(t *testing.T) {
 	}
 	wantErrorMsg := "is too large"
 	for _, data := range data {
-		var intf interface{}
+		var intf any
 		if err := Unmarshal(data, &intf); err == nil {
 			t.Errorf("Unmarshal(0x%x) didn't return an error, want error containing substring %q", data, wantErrorMsg)
 		} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -3472,14 +3472,14 @@ func TestMapKeyUnhashable(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var v interface{}
+			var v any
 			if err := Unmarshal(tc.data, &v); err == nil {
 				t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", tc.data, tc.wantErrorMsg)
 			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
 				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.data, err.Error(), tc.wantErrorMsg)
 			}
-			if _, ok := v.(map[interface{}]interface{}); ok {
-				var v map[interface{}]interface{}
+			if _, ok := v.(map[any]any); ok {
+				var v map[any]any
 				if err := Unmarshal(tc.data, &v); err == nil {
 					t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", tc.data, tc.wantErrorMsg)
 				} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
@@ -3493,7 +3493,7 @@ func TestMapKeyUnhashable(t *testing.T) {
 func TestMapKeyNaN(t *testing.T) {
 	// Data is generating by go-fuzz.
 	data := hexDecode("b0303030303030303030303030303030303038303030faffff30303030303030303030303030") // {-17: -17, NaN: -17}
-	var intf interface{}
+	var intf any
 	if err := Unmarshal(data, &intf); err != nil {
 		t.Fatalf("Unmarshal(0x%x) returned error %v", data, err)
 	}
@@ -3509,7 +3509,7 @@ func TestMapKeyNaN(t *testing.T) {
 func TestUnmarshalUndefinedElement(t *testing.T) {
 	// Data is generating by go-fuzz.
 	data := hexDecode("bfd1a388f730303030303030303030303030ff") // {17({[undefined, -17, -17, -17, -17, -17, -17, -17]: -17, -17: -17}): -17}
-	var intf interface{}
+	var intf any
 	wantErrorMsg := "invalid map key type"
 	if err := Unmarshal(data, &intf); err == nil {
 		t.Errorf("Unmarshal(0x%x) didn't return an error, want error containing substring %q", data, wantErrorMsg)
@@ -3522,9 +3522,9 @@ func TestMapKeyNil(t *testing.T) {
 	testData := [][]byte{
 		hexDecode("a1f630"), // {null: -17}
 	}
-	want := map[interface{}]interface{}{nil: int64(-17)}
+	want := map[any]any{nil: int64(-17)}
 	for _, data := range testData {
-		var intf interface{}
+		var intf any
 		if err := Unmarshal(data, &intf); err != nil {
 			t.Fatalf("Unmarshal(0x%x) returned error %v", data, err)
 		} else if !reflect.DeepEqual(intf, want) {
@@ -3534,7 +3534,7 @@ func TestMapKeyNil(t *testing.T) {
 			t.Errorf("Marshal(%v) returned error %v", intf, err)
 		}
 
-		var v map[interface{}]interface{}
+		var v map[any]any
 		if err := Unmarshal(data, &v); err != nil {
 			t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
 		} else if !reflect.DeepEqual(v, want) {
@@ -3670,7 +3670,7 @@ func TestDecodeTimeWithTag(t *testing.T) {
 				t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborUnixTime, tm, tm, tc.wantTime, tc.wantTime)
 			}
 
-			var v interface{}
+			var v any
 			if err := Unmarshal(tc.cborRFC3339Time, &v); err != nil {
 				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborRFC3339Time, err)
 			} else if tm, ok := v.(time.Time); !ok || !tc.wantTime.Equal(tm) {
@@ -3848,7 +3848,7 @@ func TestDecodeTag0Error(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Decode to interface{}
-			var v interface{}
+			var v any
 			if err := tc.dm.Unmarshal(data, &v); err == nil {
 				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", data, wantErrorMsg)
 			} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -3894,7 +3894,7 @@ func TestDecodeTag1Error(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Decode to interface{}
-			var v interface{}
+			var v any
 			if err := tc.dm.Unmarshal(data, &v); err == nil {
 				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", data, wantErrorMsg)
 			} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -3968,7 +3968,7 @@ func TestDecodeTimeStreaming(t *testing.T) {
 	dm, _ := DecOptions{TimeTag: DecTagOptional}.DecMode()
 	dec := dm.NewDecoder(bytes.NewReader(data))
 	for _, tc := range testCases {
-		var v interface{}
+		var v any
 		err := dec.Decode(&v)
 		if tc.wantErrorMsg != "" {
 			if err == nil {
@@ -4465,7 +4465,7 @@ func TestCOSEExamples(t *testing.T) {
 		hexDecode("D18443A1010FA054546869732069732074686520636F6E74656E742E48726043745027214F"),
 	}
 	for _, d := range data {
-		var v interface{}
+		var v any
 		if err := Unmarshal(d, &v); err != nil {
 			t.Errorf("Unmarshal(0x%x) returned error %v", d, err)
 		}
@@ -4620,7 +4620,7 @@ func TestUnmarshalArrayToStructWrongFieldTypeError(t *testing.T) {
 		name         string
 		data         []byte
 		wantErrorMsg string
-		wantV        interface{}
+		wantV        any
 	}{
 		// [1, 2, 3]
 		{"wrong field type", hexDecode("83010203"), "cannot unmarshal", T{A: 1, C: 3}},
@@ -4676,11 +4676,11 @@ func TestUnmarshalArrayToStructCannotSetEmbeddedPointerError(t *testing.T) {
 func TestUnmarshalIntoSliceError(t *testing.T) {
 	data := []byte{0x83, 0x61, 0x61, 0x61, 0xfe, 0x61, 0x62} // ["a", 0xfe, "b"]
 	wantErrorMsg := invalidUTF8ErrorMsg
-	var want interface{}
+	var want any
 
 	// Unmarshal CBOR array into Go empty interface.
-	var v1 interface{}
-	want = []interface{}{"a", interface{}(nil), "b"}
+	var v1 any
+	want = []any{"a", any(nil), "b"}
 	if err := Unmarshal(data, &v1); err == nil {
 		t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", data, wantErrorMsg)
 	} else if err.Error() != wantErrorMsg {
@@ -4733,12 +4733,12 @@ func TestUnmarshalIntoMapError(t *testing.T) {
 		{0xa3, 0x61, 0x61, 0x61, 0x41, 0x61, 0x63, 0x61, 0xfe, 0x61, 0x62, 0x61, 0x42}, // {"a":"A", "c": 0xfe, "b":"B"}
 	}
 	wantErrorMsg := invalidUTF8ErrorMsg
-	var want interface{}
+	var want any
 
 	for _, data := range data {
 		// Unmarshal CBOR map into Go empty interface.
-		var v1 interface{}
-		want = map[interface{}]interface{}{"a": "A", "b": "B"}
+		var v1 any
+		want = map[any]any{"a": "A", "b": "B"}
 		if err := Unmarshal(data, &v1); err == nil {
 			t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", data, wantErrorMsg)
 		} else if err.Error() != wantErrorMsg {
@@ -4749,8 +4749,8 @@ func TestUnmarshalIntoMapError(t *testing.T) {
 		}
 
 		// Unmarshal CBOR map into Go map[interface{}]interface{}.
-		var v2 map[interface{}]interface{}
-		want = map[interface{}]interface{}{"a": "A", "b": "B"}
+		var v2 map[any]any
+		want = map[any]any{"a": "A", "b": "B"}
 		if err := Unmarshal(data, &v2); err == nil {
 			t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", data, wantErrorMsg)
 		} else if err.Error() != wantErrorMsg {
@@ -4881,8 +4881,8 @@ func TestStructKeyAsIntError(t *testing.T) {
 func TestUnmarshalToNotNilInterface(t *testing.T) {
 	data := hexDecode("83010203") // []uint64{1, 2, 3}
 	s := "hello"                  //nolint:goconst
-	var v interface{} = s         // Unmarshal() sees v as type interface{} and sets CBOR data as default Go type.  s is unmodified.  Same behavior as encoding/json.
-	wantV := []interface{}{uint64(1), uint64(2), uint64(3)}
+	var v any = s                 // Unmarshal() sees v as type interface{} and sets CBOR data as default Go type.  s is unmodified.  Same behavior as encoding/json.
+	wantV := []any{uint64(1), uint64(2), uint64(3)}
 	if err := Unmarshal(data, &v); err != nil {
 		t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
 	} else if !reflect.DeepEqual(v, wantV) {
@@ -4909,7 +4909,7 @@ func TestDecOptions(t *testing.T) {
 		IntDec:                   IntDecConvertSigned,
 		MapKeyByteString:         MapKeyByteStringForbidden,
 		ExtraReturnErrors:        ExtraDecErrorUnknownField,
-		DefaultMapType:           reflect.TypeOf(map[string]interface{}(nil)),
+		DefaultMapType:           reflect.TypeOf(map[string]any(nil)),
 		UTF8:                     UTF8DecodeInvalid,
 		FieldNameMatching:        FieldNameMatchingCaseSensitive,
 		BigIntDec:                BigIntDecodePointer,
@@ -4946,7 +4946,7 @@ func TestDecOptions(t *testing.T) {
 
 type roundTripTest struct {
 	name         string
-	obj          interface{}
+	obj          any
 	wantCborData []byte
 }
 
@@ -5216,7 +5216,7 @@ func TestUnmarshalStructKeyAsIntNumError(t *testing.T) {
 	testCases := []struct {
 		name         string
 		data         []byte
-		obj          interface{}
+		obj          any
 		wantErrorMsg string
 	}{
 		{
@@ -5249,17 +5249,17 @@ func TestUnmarshalEmptyMapWithDupMapKeyOpt(t *testing.T) {
 	testCases := []struct {
 		name  string
 		data  []byte
-		wantV interface{}
+		wantV any
 	}{
 		{
 			name:  "empty map",
 			data:  hexDecode("a0"),
-			wantV: map[interface{}]interface{}{},
+			wantV: map[any]any{},
 		},
 		{
 			name:  "indefinite empty map",
 			data:  hexDecode("bfff"),
-			wantV: map[interface{}]interface{}{},
+			wantV: map[any]any{},
 		},
 	}
 
@@ -5270,7 +5270,7 @@ func TestUnmarshalEmptyMapWithDupMapKeyOpt(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var v interface{}
+			var v any
 			if err := dm.Unmarshal(tc.data, &v); err != nil {
 				t.Errorf("Unmarshal(0x%x) returned error %v", tc.data, err)
 			}
@@ -5285,8 +5285,8 @@ func TestUnmarshalDupMapKeyToEmptyInterface(t *testing.T) {
 	data := hexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
 
 	// Duplicate key overwrites previous value (default).
-	wantV := map[interface{}]interface{}{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E"}
-	var v interface{}
+	wantV := map[any]any{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E"}
+	var v any
 	if err := Unmarshal(data, &v); err != nil {
 		t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
 	}
@@ -5295,10 +5295,10 @@ func TestUnmarshalDupMapKeyToEmptyInterface(t *testing.T) {
 	}
 
 	// Duplicate key triggers error.
-	wantV = map[interface{}]interface{}{"a": nil, "b": "B", "c": "C"}
+	wantV = map[any]any{"a": nil, "b": "B", "c": "C"}
 	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
-	var v2 interface{}
+	var v2 any
 	if err := dm.Unmarshal(data, &v2); err == nil {
 		t.Errorf("Unmarshal(0x%x) didn't return an error", data)
 	} else if _, ok := err.(*DupMapKeyError); !ok {
@@ -5320,10 +5320,10 @@ func TestStreamDupMapKeyToEmptyInterface(t *testing.T) {
 	}
 
 	// Duplicate key overwrites previous value (default).
-	wantV := map[interface{}]interface{}{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E"}
+	wantV := map[any]any{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E"}
 	dec := NewDecoder(bytes.NewReader(b))
 	for i := 0; i < 3; i++ {
-		var v1 interface{}
+		var v1 any
 		if err := dec.Decode(&v1); err != nil {
 			t.Errorf("Decode() returned error %v", err)
 		}
@@ -5331,18 +5331,18 @@ func TestStreamDupMapKeyToEmptyInterface(t *testing.T) {
 			t.Errorf("Decode() = %v (%T), want %v (%T)", v1, v1, wantV, wantV)
 		}
 	}
-	var v interface{}
+	var v any
 	if err := dec.Decode(&v); err != io.EOF {
 		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
 	}
 
 	// Duplicate key triggers error.
-	wantV = map[interface{}]interface{}{"a": nil, "b": "B", "c": "C"}
+	wantV = map[any]any{"a": nil, "b": "B", "c": "C"}
 	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	dec = dm.NewDecoder(bytes.NewReader(b))
 	for i := 0; i < 3; i++ {
-		var v2 interface{}
+		var v2 any
 		if err := dec.Decode(&v2); err == nil {
 			t.Errorf("Decode() didn't return an error")
 		} else if _, ok := err.(*DupMapKeyError); !ok {
@@ -5409,7 +5409,7 @@ func TestStreamDupMapKeyToEmptyMap(t *testing.T) {
 			t.Errorf("Decode() = %v (%T), want %v (%T)", m1, m1, wantM, wantM)
 		}
 	}
-	var v interface{}
+	var v any
 	if err := dec.Decode(&v); err != io.EOF {
 		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
 	}
@@ -5487,7 +5487,7 @@ func TestStreamDupMapKeyToNotEmptyMap(t *testing.T) {
 			t.Errorf("Decode() = %v (%T), want %v (%T)", m1, m1, wantM, wantM)
 		}
 	}
-	var v interface{}
+	var v any
 	if err := dec.Decode(&v); err != io.EOF {
 		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
 	}
@@ -5628,7 +5628,7 @@ func TestStreamDupMapKeyToStruct(t *testing.T) {
 			t.Errorf("Decode() = %v (%T), want %v (%T)", s1, s1, wantS, wantS)
 		}
 	}
-	var v interface{}
+	var v any
 	if err := dec.Decode(&v); err != io.EOF {
 		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
 	}
@@ -5717,7 +5717,7 @@ func TestStreamDupMapKeyToStructKeyAsInt(t *testing.T) {
 			t.Errorf("Decode() = %v (%T), want %v (%T)", s1, s1, wantS, wantS)
 		}
 	}
-	var v interface{}
+	var v any
 	if err := dec.Decode(&v); err != io.EOF {
 		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
 	}
@@ -5806,7 +5806,7 @@ func TestStreamDupMapKeyToStructNoMatchingField(t *testing.T) {
 			t.Errorf("Decode() = %v (%T), want %v (%T)", s1, s1, wantS, wantS)
 		}
 	}
-	var v interface{}
+	var v any
 	if err := dec.Decode(&v); err != io.EOF {
 		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
 	}
@@ -5891,7 +5891,7 @@ func TestStreamDupMapKeyToStructKeyAsIntNoMatchingField(t *testing.T) {
 			t.Errorf("Decode() = %v (%T), want %v (%T)", s1, s1, wantS, wantS)
 		}
 	}
-	var v interface{}
+	var v any
 	if err := dec.Decode(&v); err != io.EOF {
 		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
 	}
@@ -5990,7 +5990,7 @@ func TestStreamDupMapKeyToStructWrongType(t *testing.T) {
 			t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", data, s1, s1, wantS, wantS)
 		}
 	}
-	var v interface{}
+	var v any
 	if err := dec.Decode(&v); err != io.EOF {
 		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
 	}
@@ -6220,7 +6220,7 @@ func TestIndefiniteLengthArrayToArray(t *testing.T) {
 	testCases := []struct {
 		name  string
 		data  []byte
-		wantV interface{}
+		wantV any
 	}{
 		{
 			name:  "CBOR empty array to Go 5 elem array",
@@ -6275,7 +6275,7 @@ func TestExceedMaxArrayElements(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			dm, _ := tc.opts.DecMode()
-			var v interface{}
+			var v any
 			if err := dm.Unmarshal(tc.data, &v); err == nil {
 				t.Errorf("Unmarshal(0x%x) didn't return an error", tc.data)
 			} else if err.Error() != tc.wantErrorMsg {
@@ -6308,7 +6308,7 @@ func TestExceedMaxMapPairs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			dm, _ := tc.opts.DecMode()
-			var v interface{}
+			var v any
 			if err := dm.Unmarshal(tc.data, &v); err == nil {
 				t.Errorf("Unmarshal(0x%x) didn't return an error", tc.data)
 			} else if err.Error() != tc.wantErrorMsg {
@@ -6353,7 +6353,7 @@ func TestDecIndefiniteLengthOption(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Default option allows indefinite length items
-			var v interface{}
+			var v any
 			if err := Unmarshal(tc.data, &v); err != nil {
 				t.Errorf("Unmarshal(0x%x) returned an error %v", tc.data, err)
 			}
@@ -6373,7 +6373,7 @@ func TestDecTagsMdOption(t *testing.T) {
 	wantErrorMsg := "cbor: CBOR tag isn't allowed"
 
 	// Default option allows CBOR tags
-	var v interface{}
+	var v any
 	if err := Unmarshal(data, &v); err != nil {
 		t.Errorf("Unmarshal(0x%x) returned an error %v", data, err)
 	}
@@ -6443,7 +6443,7 @@ func TestIntDecConvertNone(t *testing.T) {
 	testCases := []struct {
 		name    string
 		data    []byte
-		wantObj interface{}
+		wantObj any
 	}{
 		{
 			name:    "CBOR pos int",
@@ -6468,7 +6468,7 @@ func TestIntDecConvertNone(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var v interface{}
+			var v any
 			err := dm.Unmarshal(tc.data, &v)
 			if err == nil {
 				if !reflect.DeepEqual(v, tc.wantObj) {
@@ -6493,7 +6493,7 @@ func TestIntDecConvertSigned(t *testing.T) {
 	testCases := []struct {
 		name         string
 		data         []byte
-		wantObj      interface{}
+		wantObj      any
 		wantErrorMsg string
 	}{
 		{
@@ -6519,7 +6519,7 @@ func TestIntDecConvertSigned(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var v interface{}
+			var v any
 			err := dm.Unmarshal(tc.data, &v)
 			if err == nil {
 				if tc.wantErrorMsg != "" {
@@ -6550,7 +6550,7 @@ func TestIntDecConvertSignedOrBigInt(t *testing.T) {
 	testCases := []struct {
 		name    string
 		data    []byte
-		wantObj interface{}
+		wantObj any
 	}{
 		{
 			name:    "CBOR pos int",
@@ -6575,7 +6575,7 @@ func TestIntDecConvertSignedOrBigInt(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var v interface{}
+			var v any
 			err := dm.Unmarshal(tc.data, &v)
 			if err == nil {
 				if !reflect.DeepEqual(v, tc.wantObj) {
@@ -6600,7 +6600,7 @@ func TestIntDecConvertSignedOrError(t *testing.T) {
 	testCases := []struct {
 		name         string
 		data         []byte
-		wantObj      interface{}
+		wantObj      any
 		wantErrorMsg string
 	}{
 		{
@@ -6626,7 +6626,7 @@ func TestIntDecConvertSignedOrError(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var v interface{}
+			var v any
 			err := dm.Unmarshal(tc.data, &v)
 			if err == nil {
 				if tc.wantErrorMsg != "" {
@@ -6687,7 +6687,7 @@ func TestMapKeyByteString(t *testing.T) {
 	testCases := []struct {
 		name         string
 		data         []byte
-		wantObj      interface{}
+		wantObj      any
 		wantErrorMsg string
 		dm           DecMode
 	}{
@@ -6712,7 +6712,7 @@ func TestMapKeyByteString(t *testing.T) {
 		{
 			name: "byte string map key with MapKeyByteStringAllowed",
 			data: hexDecode("a143abcdef187b"),
-			wantObj: map[interface{}]interface{}{
+			wantObj: map[any]any{
 				ByteString("\xab\xcd\xef"): uint64(123),
 			},
 			dm: bsAllowedMode,
@@ -6720,7 +6720,7 @@ func TestMapKeyByteString(t *testing.T) {
 		{
 			name: "tagged byte string map key with MapKeyByteStringAllowed",
 			data: hexDecode("a1d86443abcdef187b"),
-			wantObj: map[interface{}]interface{}{
+			wantObj: map[any]any{
 				Tag{Number: 100, Content: ByteString("\xab\xcd\xef")}: uint64(123),
 			},
 			dm: bsAllowedMode,
@@ -6728,7 +6728,7 @@ func TestMapKeyByteString(t *testing.T) {
 		{
 			name: "nested tagged byte string map key with MapKeyByteStringAllowed",
 			data: hexDecode("a1d865d86443abcdef187b"),
-			wantObj: map[interface{}]interface{}{
+			wantObj: map[any]any{
 				Tag{Number: 101, Content: Tag{Number: 100, Content: ByteString("\xab\xcd\xef")}}: uint64(123),
 			},
 			dm: bsAllowedMode,
@@ -6782,7 +6782,7 @@ func TestExtraErrorCondUnknownField(t *testing.T) {
 		name         string
 		data         []byte
 		dm           DecMode
-		wantObj      interface{}
+		wantObj      any
 		wantErrorMsg string
 	}{
 		{
@@ -6921,7 +6921,7 @@ func TestUnmarshalTagNum55799(t *testing.T) {
 		copy(data[6:], tc.data)
 
 		// Test unmarshalling CBOR into empty interface.
-		var v interface{}
+		var v any
 		if err := Unmarshal(data, &v); err != nil {
 			t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
 		} else {
@@ -6986,7 +6986,7 @@ func TestUnmarshalFloatWithTagNum55799(t *testing.T) {
 		copy(data[3:], tc.data)
 
 		// Test unmarshalling CBOR into empty interface.
-		var v interface{}
+		var v any
 		if err := Unmarshal(tc.data, &v); err != nil {
 			t.Errorf("Unmarshal(0x%x) returned error %v", tc.data, err)
 		} else {
@@ -7031,29 +7031,29 @@ func TestUnmarshalTagNum55799AsElement(t *testing.T) {
 	testCases := []struct {
 		name                string
 		data                []byte
-		emptyInterfaceValue interface{}
-		values              []interface{}
+		emptyInterfaceValue any
+		values              []any
 		wrongTypes          []reflect.Type
 	}{
 		{
 			"array",
 			hexDecode("d9d9f783d9d9f701d9d9f702d9d9f703"), // 55799([55799(1), 55799(2), 55799(3)])
-			[]interface{}{uint64(1), uint64(2), uint64(3)},
-			[]interface{}{[]interface{}{uint64(1), uint64(2), uint64(3)}, []byte{1, 2, 3}, []int{1, 2, 3}, []uint{1, 2, 3}, [0]int{}, [1]int{1}, [3]int{1, 2, 3}, [5]int{1, 2, 3, 0, 0}, []float32{1, 2, 3}, []float64{1, 2, 3}},
+			[]any{uint64(1), uint64(2), uint64(3)},
+			[]any{[]any{uint64(1), uint64(2), uint64(3)}, []byte{1, 2, 3}, []int{1, 2, 3}, []uint{1, 2, 3}, [0]int{}, [1]int{1}, [3]int{1, 2, 3}, [5]int{1, 2, 3, 0, 0}, []float32{1, 2, 3}, []float64{1, 2, 3}},
 			[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
 		},
 		{
 			"map",
 			hexDecode("d9d9f7a2d9d9f701d9d9f702d9d9f703d9d9f704"), // 55799({55799(1): 55799(2), 55799(3): 55799(4)})
-			map[interface{}]interface{}{uint64(1): uint64(2), uint64(3): uint64(4)},
-			[]interface{}{map[interface{}]interface{}{uint64(1): uint64(2), uint64(3): uint64(4)}, map[uint]int{1: 2, 3: 4}, map[int]uint{1: 2, 3: 4}},
+			map[any]any{uint64(1): uint64(2), uint64(3): uint64(4)},
+			[]any{map[any]any{uint64(1): uint64(2), uint64(3): uint64(4)}, map[uint]int{1: 2, 3: 4}, map[int]uint{1: 2, 3: 4}},
 			[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteSlice, typeByteArray, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Test unmarshalling CBOR into empty interface.
-			var v interface{}
+			var v any
 			if err := Unmarshal(tc.data, &v); err != nil {
 				t.Errorf("Unmarshal(0x%x) returned error %v", tc.data, err)
 			} else {
@@ -7151,7 +7151,7 @@ func TestUnmarshalNestedTagNum55799ToEmptyInterface(t *testing.T) {
 	data := hexDecode("d864d9d9f701") // 100(55799(1))
 	wantObj := Tag{100, Tag{55799, uint64(1)}}
 
-	var v interface{}
+	var v any
 	if err := Unmarshal(data, &v); err != nil {
 		t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
 	} else if !reflect.DeepEqual(v, wantObj) {
@@ -7246,7 +7246,7 @@ func TestUnmarshalPosIntToBigInt(t *testing.T) {
 	wantEmptyInterfaceValue := uint64(18446744073709551615)
 	wantBigIntValue := bigIntOrPanic("18446744073709551615")
 
-	var v1 interface{}
+	var v1 any
 	if err := Unmarshal(data, &v1); err != nil {
 		t.Errorf("Unmarshal(0x%x) returned error %+v", data, err)
 	} else if !reflect.DeepEqual(v1, wantEmptyInterfaceValue) {
@@ -7265,7 +7265,7 @@ func TestUnmarshalNegIntToBigInt(t *testing.T) {
 	testCases := []struct {
 		name                    string
 		data                    []byte
-		wantEmptyInterfaceValue interface{}
+		wantEmptyInterfaceValue any
 		wantBigIntValue         big.Int
 	}{
 		{
@@ -7283,7 +7283,7 @@ func TestUnmarshalNegIntToBigInt(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var v1 interface{}
+			var v1 any
 			if err := Unmarshal(tc.data, &v1); err != nil {
 				t.Errorf("Unmarshal(0x%x) returned error %+v", tc.data, err)
 			} else if !reflect.DeepEqual(v1, tc.wantEmptyInterfaceValue) {
@@ -7304,14 +7304,14 @@ func TestUnmarshalTag2(t *testing.T) {
 	testCases := []struct {
 		name                    string
 		data                    []byte
-		wantEmptyInterfaceValue interface{}
-		wantValues              []interface{}
+		wantEmptyInterfaceValue any
+		wantValues              []any
 	}{
 		{
 			name:                    "fit Go int64",
 			data:                    hexDecode("c2430f4240"), // 2(1000000)
 			wantEmptyInterfaceValue: bigIntOrPanic("1000000"),
-			wantValues: []interface{}{
+			wantValues: []any{
 				int64(1000000),
 				uint64(1000000),
 				float32(1000000),
@@ -7323,7 +7323,7 @@ func TestUnmarshalTag2(t *testing.T) {
 			name:                    "fit Go uint64",
 			data:                    hexDecode("c248ffffffffffffffff"), // 2(18446744073709551615)
 			wantEmptyInterfaceValue: bigIntOrPanic("18446744073709551615"),
-			wantValues: []interface{}{
+			wantValues: []any{
 				uint64(18446744073709551615),
 				float32(18446744073709551615),
 				float64(18446744073709551615),
@@ -7334,7 +7334,7 @@ func TestUnmarshalTag2(t *testing.T) {
 			name:                    "fit Go uint64 with leading zeros",
 			data:                    hexDecode("c24900ffffffffffffffff"), // 2(18446744073709551615)
 			wantEmptyInterfaceValue: bigIntOrPanic("18446744073709551615"),
-			wantValues: []interface{}{
+			wantValues: []any{
 				uint64(18446744073709551615),
 				float32(18446744073709551615),
 				float64(18446744073709551615),
@@ -7345,7 +7345,7 @@ func TestUnmarshalTag2(t *testing.T) {
 			name:                    "overflow Go uint64",
 			data:                    hexDecode("c249010000000000000000"), // 2(18446744073709551616)
 			wantEmptyInterfaceValue: bigIntOrPanic("18446744073709551616"),
-			wantValues: []interface{}{
+			wantValues: []any{
 				bigIntOrPanic("18446744073709551616"),
 			},
 		},
@@ -7353,14 +7353,14 @@ func TestUnmarshalTag2(t *testing.T) {
 			name:                    "overflow Go uint64 with leading zeros",
 			data:                    hexDecode("c24b0000010000000000000000"), // 2(18446744073709551616)
 			wantEmptyInterfaceValue: bigIntOrPanic("18446744073709551616"),
-			wantValues: []interface{}{
+			wantValues: []any{
 				bigIntOrPanic("18446744073709551616"),
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var v1 interface{}
+			var v1 any
 			if err := Unmarshal(tc.data, &v1); err != nil {
 				t.Errorf("Unmarshal(0x%x) returned error %+v", tc.data, err)
 			} else if !reflect.DeepEqual(v1, tc.wantEmptyInterfaceValue) {
@@ -7383,14 +7383,14 @@ func TestUnmarshalTag3(t *testing.T) {
 	testCases := []struct {
 		name                    string
 		data                    []byte
-		wantEmptyInterfaceValue interface{}
-		wantValues              []interface{}
+		wantEmptyInterfaceValue any
+		wantValues              []any
 	}{
 		{
 			name:                    "fit Go int64",
 			data:                    hexDecode("c3487fffffffffffffff"), // 3(-9223372036854775808)
 			wantEmptyInterfaceValue: bigIntOrPanic("-9223372036854775808"),
-			wantValues: []interface{}{
+			wantValues: []any{
 				int64(-9223372036854775808),
 				float32(-9223372036854775808),
 				float64(-9223372036854775808),
@@ -7401,7 +7401,7 @@ func TestUnmarshalTag3(t *testing.T) {
 			name:                    "fit Go int64 with leading zeros",
 			data:                    hexDecode("c349007fffffffffffffff"), // 3(-9223372036854775808)
 			wantEmptyInterfaceValue: bigIntOrPanic("-9223372036854775808"),
-			wantValues: []interface{}{
+			wantValues: []any{
 				int64(-9223372036854775808),
 				float32(-9223372036854775808),
 				float64(-9223372036854775808),
@@ -7412,7 +7412,7 @@ func TestUnmarshalTag3(t *testing.T) {
 			name:                    "overflow Go int64",
 			data:                    hexDecode("c349010000000000000000"), // 3(-18446744073709551617)
 			wantEmptyInterfaceValue: bigIntOrPanic("-18446744073709551617"),
-			wantValues: []interface{}{
+			wantValues: []any{
 				bigIntOrPanic("-18446744073709551617"),
 			},
 		},
@@ -7420,14 +7420,14 @@ func TestUnmarshalTag3(t *testing.T) {
 			name:                    "overflow Go int64 with leading zeros",
 			data:                    hexDecode("c34b0000010000000000000000"), // 3(-18446744073709551617)
 			wantEmptyInterfaceValue: bigIntOrPanic("-18446744073709551617"),
-			wantValues: []interface{}{
+			wantValues: []any{
 				bigIntOrPanic("-18446744073709551617"),
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var v1 interface{}
+			var v1 any
 			if err := Unmarshal(tc.data, &v1); err != nil {
 				t.Errorf("Unmarshal(0x%x) returned error %+v", tc.data, err)
 			} else if !reflect.DeepEqual(v1, tc.wantEmptyInterfaceValue) {
@@ -7766,8 +7766,8 @@ func TestUnmarshalRegisteredTagToInterface(t *testing.T) {
 	testCases := []struct {
 		name           string
 		data           []byte
-		unmarshalToObj interface{}
-		wantValue      interface{}
+		unmarshalToObj any
+		wantValue      any
 	}{
 		{
 			name:           "interface type",
@@ -7849,15 +7849,15 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 	cborDataNestedMap := hexDecode("a268496e744669656c6401684d61704669656c64a2616101616202") // {"IntField": 1, "MapField": {"a": 1, "b": 2}}
 
 	decOptionsDefault := DecOptions{}
-	decOptionsMapIntfIntfType := DecOptions{DefaultMapType: reflect.TypeOf(map[interface{}]interface{}(nil))}
+	decOptionsMapIntfIntfType := DecOptions{DefaultMapType: reflect.TypeOf(map[any]any(nil))}
 	decOptionsMapStringIntType := DecOptions{DefaultMapType: reflect.TypeOf(map[string]int(nil))}
-	decOptionsMapStringIntfType := DecOptions{DefaultMapType: reflect.TypeOf(map[string]interface{}(nil))}
+	decOptionsMapStringIntfType := DecOptions{DefaultMapType: reflect.TypeOf(map[string]any(nil))}
 
 	testCases := []struct {
 		name         string
 		opts         DecOptions
 		data         []byte
-		wantValue    interface{}
+		wantValue    any
 		wantErrorMsg string
 	}{
 		// Decode CBOR map to map[interface{}]interface{} using default options
@@ -7865,30 +7865,30 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 			name:      "decode CBOR map[int]int to Go map[interface{}]interface{} (default)",
 			opts:      decOptionsDefault,
 			data:      cborDataMapIntInt,
-			wantValue: map[interface{}]interface{}{uint64(1): uint64(2), uint64(3): uint64(4)},
+			wantValue: map[any]any{uint64(1): uint64(2), uint64(3): uint64(4)},
 		},
 		{
 			name:      "decode CBOR map[string]int to Go map[interface{}]interface{} (default)",
 			opts:      decOptionsDefault,
 			data:      cborDataMapStringInt,
-			wantValue: map[interface{}]interface{}{"a": uint64(1), "b": uint64(2)},
+			wantValue: map[any]any{"a": uint64(1), "b": uint64(2)},
 		},
 		{
 			name: "decode CBOR array of map[string]int to Go []map[interface{}]interface{} (default)",
 			opts: decOptionsDefault,
 			data: cborDataArrayOfMapStringint,
-			wantValue: []interface{}{
-				map[interface{}]interface{}{"a": uint64(1), "b": uint64(2)},
-				map[interface{}]interface{}{"c": uint64(3), "d": uint64(4)},
+			wantValue: []any{
+				map[any]any{"a": uint64(1), "b": uint64(2)},
+				map[any]any{"c": uint64(3), "d": uint64(4)},
 			},
 		},
 		{
 			name: "decode CBOR nested map to Go map[interface{}]interface{} (default)",
 			opts: decOptionsDefault,
 			data: cborDataNestedMap,
-			wantValue: map[interface{}]interface{}{
+			wantValue: map[any]any{
 				"IntField": uint64(1),
-				"MapField": map[interface{}]interface{}{"a": uint64(1), "b": uint64(2)},
+				"MapField": map[any]any{"a": uint64(1), "b": uint64(2)},
 			},
 		},
 		// Decode CBOR map to map[interface{}]interface{} using default map type option
@@ -7896,30 +7896,30 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 			name:      "decode CBOR map[int]int to Go map[interface{}]interface{}",
 			opts:      decOptionsMapIntfIntfType,
 			data:      cborDataMapIntInt,
-			wantValue: map[interface{}]interface{}{uint64(1): uint64(2), uint64(3): uint64(4)},
+			wantValue: map[any]any{uint64(1): uint64(2), uint64(3): uint64(4)},
 		},
 		{
 			name:      "decode CBOR map[string]int to Go map[interface{}]interface{}",
 			opts:      decOptionsMapIntfIntfType,
 			data:      cborDataMapStringInt,
-			wantValue: map[interface{}]interface{}{"a": uint64(1), "b": uint64(2)},
+			wantValue: map[any]any{"a": uint64(1), "b": uint64(2)},
 		},
 		{
 			name: "decode CBOR array of map[string]int to Go []map[interface{}]interface{}",
 			opts: decOptionsMapIntfIntfType,
 			data: cborDataArrayOfMapStringint,
-			wantValue: []interface{}{
-				map[interface{}]interface{}{"a": uint64(1), "b": uint64(2)},
-				map[interface{}]interface{}{"c": uint64(3), "d": uint64(4)},
+			wantValue: []any{
+				map[any]any{"a": uint64(1), "b": uint64(2)},
+				map[any]any{"c": uint64(3), "d": uint64(4)},
 			},
 		},
 		{
 			name: "decode CBOR nested map to Go map[interface{}]interface{}",
 			opts: decOptionsMapIntfIntfType,
 			data: cborDataNestedMap,
-			wantValue: map[interface{}]interface{}{
+			wantValue: map[any]any{
 				"IntField": uint64(1),
-				"MapField": map[interface{}]interface{}{"a": uint64(1), "b": uint64(2)},
+				"MapField": map[any]any{"a": uint64(1), "b": uint64(2)},
 			},
 		},
 		// Decode CBOR map to map[string]interface{} using default map type option
@@ -7933,24 +7933,24 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 			name:      "decode CBOR map[string]int to Go map[string]interface{}",
 			opts:      decOptionsMapStringIntfType,
 			data:      cborDataMapStringInt,
-			wantValue: map[string]interface{}{"a": uint64(1), "b": uint64(2)},
+			wantValue: map[string]any{"a": uint64(1), "b": uint64(2)},
 		},
 		{
 			name: "decode CBOR array of map[string]int to Go []map[string]interface{}",
 			opts: decOptionsMapStringIntfType,
 			data: cborDataArrayOfMapStringint,
-			wantValue: []interface{}{
-				map[string]interface{}{"a": uint64(1), "b": uint64(2)},
-				map[string]interface{}{"c": uint64(3), "d": uint64(4)},
+			wantValue: []any{
+				map[string]any{"a": uint64(1), "b": uint64(2)},
+				map[string]any{"c": uint64(3), "d": uint64(4)},
 			},
 		},
 		{
 			name: "decode CBOR nested map to Go map[string]interface{}",
 			opts: decOptionsMapStringIntfType,
 			data: cborDataNestedMap,
-			wantValue: map[string]interface{}{
+			wantValue: map[string]any{
 				"IntField": uint64(1),
-				"MapField": map[string]interface{}{"a": uint64(1), "b": uint64(2)},
+				"MapField": map[string]any{"a": uint64(1), "b": uint64(2)},
 			},
 		},
 		// Decode CBOR map to map[string]int using default map type option
@@ -7970,7 +7970,7 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 			name: "decode CBOR array of map[string]int to Go []map[string]int",
 			opts: decOptionsMapStringIntType,
 			data: cborDataArrayOfMapStringint,
-			wantValue: []interface{}{
+			wantValue: []any{
 				map[string]int{"a": 1, "b": 2},
 				map[string]int{"c": 3, "d": 4},
 			},
@@ -7987,7 +7987,7 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decMode, _ := tc.opts.DecMode()
 
-			var v interface{}
+			var v any
 			err := decMode.Unmarshal(tc.data, &v)
 			if err != nil {
 				if tc.wantErrorMsg == "" {
@@ -8008,7 +8008,7 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 
 func TestUnmarshalFirstNoTrailing(t *testing.T) {
 	for _, tc := range unmarshalTests {
-		var v interface{}
+		var v any
 		if rest, err := UnmarshalFirst(tc.data, &v); err != nil {
 			t.Errorf("UnmarshalFirst(0x%x) returned error %v", tc.data, err)
 		} else {
@@ -8034,7 +8034,7 @@ func TestUnmarshalfirstTrailing(t *testing.T) {
 		data := make([]byte, 0, len(tc.data)+len(trailingData))
 		data = append(data, tc.data...)
 		data = append(data, trailingData...)
-		var v interface{}
+		var v any
 		if rest, err := UnmarshalFirst(data, &v); err != nil {
 			t.Errorf("UnmarshalFirst(0x%x) returned error %v", data, err)
 		} else {
@@ -8056,7 +8056,7 @@ func TestUnmarshalfirstTrailing(t *testing.T) {
 func TestUnmarshalFirstInvalidItem(t *testing.T) {
 	// UnmarshalFirst should not return "rest" if the item was not well-formed
 	invalidCBOR := hexDecode("83FF20030102")
-	var v interface{}
+	var v any
 	rest, err := UnmarshalFirst(invalidCBOR, &v)
 	if rest != nil || err == nil {
 		t.Errorf("UnmarshalFirst(0x%x) = (%x, %v), want (nil, err)", invalidCBOR, rest, err)
@@ -8207,7 +8207,7 @@ func TestDecodeBignumToEmptyInterface(t *testing.T) {
 		name      string
 		opts      DecOptions
 		data      []byte
-		wantValue interface{}
+		wantValue any
 	}{
 		{
 			name:      "decode positive bignum to big.Int",
@@ -8251,7 +8251,7 @@ func TestDecodeBignumToEmptyInterface(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decMode, _ := tc.opts.DecMode()
 
-			var v interface{}
+			var v any
 			err := decMode.Unmarshal(tc.data, &v)
 			if err != nil {
 				t.Errorf("Unmarshal(0x%x) to empty interface returned error %v", tc.data, err)
@@ -8309,7 +8309,7 @@ func TestUnmarshalDefaultByteStringType(t *testing.T) {
 		name string
 		opts DecOptions
 		in   []byte
-		want interface{}
+		want any
 	}{
 		{
 			name: "default to []byte",
@@ -8348,7 +8348,7 @@ func TestUnmarshalDefaultByteStringType(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var got interface{}
+			var got any
 			if err := dm.Unmarshal(tc.in, &got); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -8515,7 +8515,7 @@ func TestUnmarshalWithUnrecognizedTagToAnyMode(t *testing.T) {
 		name string
 		opts DecOptions
 		in   []byte
-		want interface{}
+		want any
 	}{
 		{
 			name: "default to value of type Tag",
@@ -8536,7 +8536,7 @@ func TestUnmarshalWithUnrecognizedTagToAnyMode(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var got interface{}
+			var got any
 			if err := dm.Unmarshal(tc.in, &got); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -8553,7 +8553,7 @@ func TestUnmarshalWithUnrecognizedTagToAnyModeForSupportedTags(t *testing.T) {
 		name string
 		opts DecOptions
 		in   []byte
-		want interface{}
+		want any
 	}{
 		{
 			name: "Unmarshal with tag number 0 when UnrecognizedTagContentToAny option is not set",
@@ -8610,7 +8610,7 @@ func TestUnmarshalWithUnrecognizedTagToAnyModeForSupportedTags(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var got interface{}
+			var got any
 			if err := dm.Unmarshal(tc.in, &got); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -8635,7 +8635,7 @@ func TestUnmarshalWithUnrecognizedTagToAnyModeForSharedTag(t *testing.T) {
 		name string
 		opts DecOptions
 		in   []byte
-		want interface{}
+		want any
 	}{
 		{
 			name: "Unmarshal with a shared tag when UnrecognizedTagContentToAny option is not set",
@@ -8656,7 +8656,7 @@ func TestUnmarshalWithUnrecognizedTagToAnyModeForSharedTag(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var got interface{}
+			var got any
 
 			if err := dm.Unmarshal(tc.in, &got); err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -8719,7 +8719,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 		fns           []func(*SimpleValueRegistry) error
 		in            []byte
 		into          reflect.Type
-		want          interface{}
+		want          any
 		assertOnError func(t *testing.T, e error)
 	}{
 		{
@@ -8860,7 +8860,7 @@ func TestDecModeTimeTagToAny(t *testing.T) {
 		name           string
 		opts           DecOptions
 		in             []byte
-		want           interface{}
+		want           any
 		wantErrMessage string
 	}{
 		{
@@ -8930,7 +8930,7 @@ func TestDecModeTimeTagToAny(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var got interface{}
+			var got any
 			if err := dm.Unmarshal(tc.in, &got); err != nil {
 				if tc.wantErrMessage == "" {
 					t.Fatalf("unexpected error: %v", err)
@@ -8979,31 +8979,31 @@ func TestNaNDecMode(t *testing.T) {
 	for _, tc := range []struct {
 		opt    NaNMode
 		src    []byte
-		dst    interface{}
+		dst    any
 		reject bool
 	}{
 		{
 			opt:    NaNDecodeForbidden,
 			src:    hexDecode("197e00"),
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
 			opt:    NaNDecodeForbidden,
 			src:    hexDecode("1a7fc00000"),
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
 			opt:    NaNDecodeForbidden,
 			src:    hexDecode("1b7ff8000000000000"),
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
 			opt:    NaNDecodeForbidden,
 			src:    hexDecode("f90000"), // 0.0
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
@@ -9027,7 +9027,7 @@ func TestNaNDecMode(t *testing.T) {
 		{
 			opt:    NaNDecodeForbidden,
 			src:    hexDecode("fa47c35000"), // 100000.0
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
@@ -9051,7 +9051,7 @@ func TestNaNDecMode(t *testing.T) {
 		{
 			opt:    NaNDecodeForbidden,
 			src:    hexDecode("fb3ff199999999999a"), // 1.1
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
@@ -9075,7 +9075,7 @@ func TestNaNDecMode(t *testing.T) {
 		{
 			opt:    NaNDecodeForbidden,
 			src:    hexDecode("f97e00"),
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: true,
 		},
 		{
@@ -9099,7 +9099,7 @@ func TestNaNDecMode(t *testing.T) {
 		{
 			opt:    NaNDecodeForbidden,
 			src:    hexDecode("fa7fc00000"),
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: true,
 		},
 		{
@@ -9123,7 +9123,7 @@ func TestNaNDecMode(t *testing.T) {
 		{
 			opt:    NaNDecodeForbidden,
 			src:    hexDecode("fb7ff8000000000000"),
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: true,
 		},
 		{
@@ -9201,31 +9201,31 @@ func TestInfDecMode(t *testing.T) {
 	for _, tc := range []struct {
 		opt    InfMode
 		src    []byte
-		dst    interface{}
+		dst    any
 		reject bool
 	}{
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("197c00"),
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("1a7f800000"), // Infinity
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("1b7ff0000000000000"), // Infinity
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("f90000"), // 0.0
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
@@ -9249,7 +9249,7 @@ func TestInfDecMode(t *testing.T) {
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("fa47c35000"), // 100000.0
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
@@ -9273,7 +9273,7 @@ func TestInfDecMode(t *testing.T) {
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("fb3ff199999999999a"), // 1.1
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: false,
 		},
 		{
@@ -9297,7 +9297,7 @@ func TestInfDecMode(t *testing.T) {
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("f97c00"), // Infinity
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: true,
 		},
 		{
@@ -9321,7 +9321,7 @@ func TestInfDecMode(t *testing.T) {
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("f9fc00"), // -Infinity
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: true,
 		},
 		{
@@ -9345,7 +9345,7 @@ func TestInfDecMode(t *testing.T) {
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("fa7f800000"), // Infinity
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: true,
 		},
 		{
@@ -9369,7 +9369,7 @@ func TestInfDecMode(t *testing.T) {
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("faff800000"), // -Infinity
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: true,
 		},
 		{
@@ -9393,7 +9393,7 @@ func TestInfDecMode(t *testing.T) {
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("fb7ff0000000000000"), // Infinity
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: true,
 		},
 		{
@@ -9417,7 +9417,7 @@ func TestInfDecMode(t *testing.T) {
 		{
 			opt:    InfDecodeForbidden,
 			src:    hexDecode("fbfff0000000000000"), // -Infinity
-			dst:    new(interface{}),
+			dst:    new(any),
 			reject: true,
 		},
 		{
@@ -9769,7 +9769,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 		opts    DecOptions
 		dstType reflect.Type
 		in      []byte
-		want    interface{}
+		want    any
 	}{
 		{
 			name: "untagged into string",
@@ -10001,7 +10001,7 @@ func TestBinaryUnmarshalerMode(t *testing.T) {
 		name string
 		opts DecOptions
 		in   []byte
-		want interface{}
+		want any
 	}{
 		{
 			name: "UnmarshalBinary is called by default",

--- a/encode.go
+++ b/encode.go
@@ -92,7 +92,7 @@ import (
 //
 // Values of other types cannot be encoded in CBOR.  Attempting
 // to encode such a value causes Marshal to return an UnsupportedTypeError.
-func Marshal(v interface{}) ([]byte, error) {
+func Marshal(v any) ([]byte, error) {
 	return defaultEncMode.Marshal(v)
 }
 
@@ -103,7 +103,7 @@ func Marshal(v interface{}) ([]byte, error) {
 // partially encoded data if error is returned.
 //
 // See Marshal for more details.
-func MarshalToBuffer(v interface{}, buf *bytes.Buffer) error {
+func MarshalToBuffer(v any, buf *bytes.Buffer) error {
 	return defaultEncMode.MarshalToBuffer(v, buf)
 }
 
@@ -773,7 +773,7 @@ func (opts EncOptions) encMode() (*encMode, error) { //nolint:gocritic // ignore
 
 // EncMode is the main interface for CBOR encoding.
 type EncMode interface {
-	Marshal(v interface{}) ([]byte, error)
+	Marshal(v any) ([]byte, error)
 	NewEncoder(w io.Writer) *Encoder
 	EncOptions() EncOptions
 }
@@ -783,7 +783,7 @@ type EncMode interface {
 // into the built-in buffer pool.
 type UserBufferEncMode interface {
 	EncMode
-	MarshalToBuffer(v interface{}, buf *bytes.Buffer) error
+	MarshalToBuffer(v any, buf *bytes.Buffer) error
 
 	// This private method is to prevent users implementing
 	// this interface and so future additions to it will
@@ -921,7 +921,7 @@ func (em *encMode) encTagBytes(t reflect.Type) []byte {
 // Marshal returns the CBOR encoding of v using em encoding mode.
 //
 // See the documentation for Marshal for details.
-func (em *encMode) Marshal(v interface{}) ([]byte, error) {
+func (em *encMode) Marshal(v any) ([]byte, error) {
 	e := getEncodeBuffer()
 
 	if err := encode(e, em, reflect.ValueOf(v)); err != nil {
@@ -943,7 +943,7 @@ func (em *encMode) Marshal(v interface{}) ([]byte, error) {
 // partially encoded data if error is returned.
 //
 // See Marshal for more details.
-func (em *encMode) MarshalToBuffer(v interface{}, buf *bytes.Buffer) error {
+func (em *encMode) MarshalToBuffer(v any, buf *bytes.Buffer) error {
 	if buf == nil {
 		return fmt.Errorf("cbor: encoding buffer provided by user is nil")
 	}
@@ -957,7 +957,7 @@ func (em *encMode) NewEncoder(w io.Writer) *Encoder {
 
 // encodeBufferPool caches unused bytes.Buffer objects for later reuse.
 var encodeBufferPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		e := new(bytes.Buffer)
 		e.Grow(32) // TODO: make this configurable
 		return e

--- a/encode_map.go
+++ b/encode_map.go
@@ -74,13 +74,13 @@ func getEncodeMapFunc(t reflect.Type) encodeFunc {
 		kf: kf,
 		ef: ef,
 		kpool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				rk := reflect.New(t.Key()).Elem()
 				return &rk
 			},
 		},
 		vpool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				rv := reflect.New(t.Elem()).Elem()
 				return &rv
 			},

--- a/encode_test.go
+++ b/encode_test.go
@@ -18,65 +18,65 @@ import (
 
 type marshalTest struct {
 	wantData []byte
-	values   []interface{}
+	values   []any
 }
 
 type marshalErrorTest struct {
 	name         string
-	value        interface{}
+	value        any
 	wantErrorMsg string
 }
 
 // CBOR test data are from https://tools.ietf.org/html/rfc7049#appendix-A.
 var marshalTests = []marshalTest{
 	// unsigned integer
-	{wantData: hexDecode("00"), values: []interface{}{uint(0), uint8(0), uint16(0), uint32(0), uint64(0), int(0), int8(0), int16(0), int32(0), int64(0)}},
-	{wantData: hexDecode("01"), values: []interface{}{uint(1), uint8(1), uint16(1), uint32(1), uint64(1), int(1), int8(1), int16(1), int32(1), int64(1)}},
-	{wantData: hexDecode("0a"), values: []interface{}{uint(10), uint8(10), uint16(10), uint32(10), uint64(10), int(10), int8(10), int16(10), int32(10), int64(10)}},
-	{wantData: hexDecode("17"), values: []interface{}{uint(23), uint8(23), uint16(23), uint32(23), uint64(23), int(23), int8(23), int16(23), int32(23), int64(23)}},
-	{wantData: hexDecode("1818"), values: []interface{}{uint(24), uint8(24), uint16(24), uint32(24), uint64(24), int(24), int8(24), int16(24), int32(24), int64(24)}},
-	{wantData: hexDecode("1819"), values: []interface{}{uint(25), uint8(25), uint16(25), uint32(25), uint64(25), int(25), int8(25), int16(25), int32(25), int64(25)}},
-	{wantData: hexDecode("1864"), values: []interface{}{uint(100), uint8(100), uint16(100), uint32(100), uint64(100), int(100), int8(100), int16(100), int32(100), int64(100)}},
-	{wantData: hexDecode("18ff"), values: []interface{}{uint(255), uint8(255), uint16(255), uint32(255), uint64(255), int(255), int16(255), int32(255), int64(255)}},
-	{wantData: hexDecode("190100"), values: []interface{}{uint(256), uint16(256), uint32(256), uint64(256), int(256), int16(256), int32(256), int64(256)}},
-	{wantData: hexDecode("1903e8"), values: []interface{}{uint(1000), uint16(1000), uint32(1000), uint64(1000), int(1000), int16(1000), int32(1000), int64(1000)}},
-	{wantData: hexDecode("19ffff"), values: []interface{}{uint(65535), uint16(65535), uint32(65535), uint64(65535), int(65535), int32(65535), int64(65535)}},
-	{wantData: hexDecode("1a00010000"), values: []interface{}{uint(65536), uint32(65536), uint64(65536), int(65536), int32(65536), int64(65536)}},
-	{wantData: hexDecode("1a000f4240"), values: []interface{}{uint(1000000), uint32(1000000), uint64(1000000), int(1000000), int32(1000000), int64(1000000)}},
-	{wantData: hexDecode("1affffffff"), values: []interface{}{uint(4294967295), uint32(4294967295), uint64(4294967295), int64(4294967295)}},
-	{wantData: hexDecode("1b000000e8d4a51000"), values: []interface{}{uint64(1000000000000), int64(1000000000000)}},
-	{wantData: hexDecode("1bffffffffffffffff"), values: []interface{}{uint64(18446744073709551615)}},
+	{wantData: hexDecode("00"), values: []any{uint(0), uint8(0), uint16(0), uint32(0), uint64(0), int(0), int8(0), int16(0), int32(0), int64(0)}},
+	{wantData: hexDecode("01"), values: []any{uint(1), uint8(1), uint16(1), uint32(1), uint64(1), int(1), int8(1), int16(1), int32(1), int64(1)}},
+	{wantData: hexDecode("0a"), values: []any{uint(10), uint8(10), uint16(10), uint32(10), uint64(10), int(10), int8(10), int16(10), int32(10), int64(10)}},
+	{wantData: hexDecode("17"), values: []any{uint(23), uint8(23), uint16(23), uint32(23), uint64(23), int(23), int8(23), int16(23), int32(23), int64(23)}},
+	{wantData: hexDecode("1818"), values: []any{uint(24), uint8(24), uint16(24), uint32(24), uint64(24), int(24), int8(24), int16(24), int32(24), int64(24)}},
+	{wantData: hexDecode("1819"), values: []any{uint(25), uint8(25), uint16(25), uint32(25), uint64(25), int(25), int8(25), int16(25), int32(25), int64(25)}},
+	{wantData: hexDecode("1864"), values: []any{uint(100), uint8(100), uint16(100), uint32(100), uint64(100), int(100), int8(100), int16(100), int32(100), int64(100)}},
+	{wantData: hexDecode("18ff"), values: []any{uint(255), uint8(255), uint16(255), uint32(255), uint64(255), int(255), int16(255), int32(255), int64(255)}},
+	{wantData: hexDecode("190100"), values: []any{uint(256), uint16(256), uint32(256), uint64(256), int(256), int16(256), int32(256), int64(256)}},
+	{wantData: hexDecode("1903e8"), values: []any{uint(1000), uint16(1000), uint32(1000), uint64(1000), int(1000), int16(1000), int32(1000), int64(1000)}},
+	{wantData: hexDecode("19ffff"), values: []any{uint(65535), uint16(65535), uint32(65535), uint64(65535), int(65535), int32(65535), int64(65535)}},
+	{wantData: hexDecode("1a00010000"), values: []any{uint(65536), uint32(65536), uint64(65536), int(65536), int32(65536), int64(65536)}},
+	{wantData: hexDecode("1a000f4240"), values: []any{uint(1000000), uint32(1000000), uint64(1000000), int(1000000), int32(1000000), int64(1000000)}},
+	{wantData: hexDecode("1affffffff"), values: []any{uint(4294967295), uint32(4294967295), uint64(4294967295), int64(4294967295)}},
+	{wantData: hexDecode("1b000000e8d4a51000"), values: []any{uint64(1000000000000), int64(1000000000000)}},
+	{wantData: hexDecode("1bffffffffffffffff"), values: []any{uint64(18446744073709551615)}},
 
 	// negative integer
-	{wantData: hexDecode("20"), values: []interface{}{int(-1), int8(-1), int16(-1), int32(-1), int64(-1)}},
-	{wantData: hexDecode("29"), values: []interface{}{int(-10), int8(-10), int16(-10), int32(-10), int64(-10)}},
-	{wantData: hexDecode("37"), values: []interface{}{int(-24), int8(-24), int16(-24), int32(-24), int64(-24)}},
-	{wantData: hexDecode("3818"), values: []interface{}{int(-25), int8(-25), int16(-25), int32(-25), int64(-25)}},
-	{wantData: hexDecode("3863"), values: []interface{}{int(-100), int8(-100), int16(-100), int32(-100), int64(-100)}},
-	{wantData: hexDecode("38ff"), values: []interface{}{int(-256), int16(-256), int32(-256), int64(-256)}},
-	{wantData: hexDecode("390100"), values: []interface{}{int(-257), int16(-257), int32(-257), int64(-257)}},
-	{wantData: hexDecode("3903e7"), values: []interface{}{int(-1000), int16(-1000), int32(-1000), int64(-1000)}},
-	{wantData: hexDecode("39ffff"), values: []interface{}{int(-65536), int32(-65536), int64(-65536)}},
-	{wantData: hexDecode("3a00010000"), values: []interface{}{int(-65537), int32(-65537), int64(-65537)}},
-	{wantData: hexDecode("3affffffff"), values: []interface{}{int64(-4294967296)}},
+	{wantData: hexDecode("20"), values: []any{int(-1), int8(-1), int16(-1), int32(-1), int64(-1)}},
+	{wantData: hexDecode("29"), values: []any{int(-10), int8(-10), int16(-10), int32(-10), int64(-10)}},
+	{wantData: hexDecode("37"), values: []any{int(-24), int8(-24), int16(-24), int32(-24), int64(-24)}},
+	{wantData: hexDecode("3818"), values: []any{int(-25), int8(-25), int16(-25), int32(-25), int64(-25)}},
+	{wantData: hexDecode("3863"), values: []any{int(-100), int8(-100), int16(-100), int32(-100), int64(-100)}},
+	{wantData: hexDecode("38ff"), values: []any{int(-256), int16(-256), int32(-256), int64(-256)}},
+	{wantData: hexDecode("390100"), values: []any{int(-257), int16(-257), int32(-257), int64(-257)}},
+	{wantData: hexDecode("3903e7"), values: []any{int(-1000), int16(-1000), int32(-1000), int64(-1000)}},
+	{wantData: hexDecode("39ffff"), values: []any{int(-65536), int32(-65536), int64(-65536)}},
+	{wantData: hexDecode("3a00010000"), values: []any{int(-65537), int32(-65537), int64(-65537)}},
+	{wantData: hexDecode("3affffffff"), values: []any{int64(-4294967296)}},
 
 	// byte string
-	{wantData: hexDecode("40"), values: []interface{}{[]byte{}}},
-	{wantData: hexDecode("4401020304"), values: []interface{}{[]byte{1, 2, 3, 4}, [...]byte{1, 2, 3, 4}}},
+	{wantData: hexDecode("40"), values: []any{[]byte{}}},
+	{wantData: hexDecode("4401020304"), values: []any{[]byte{1, 2, 3, 4}, [...]byte{1, 2, 3, 4}}},
 
 	// text string
-	{wantData: hexDecode("60"), values: []interface{}{""}},
-	{wantData: hexDecode("6161"), values: []interface{}{"a"}},
-	{wantData: hexDecode("6449455446"), values: []interface{}{"IETF"}},
-	{wantData: hexDecode("62225c"), values: []interface{}{"\"\\"}},
-	{wantData: hexDecode("62c3bc"), values: []interface{}{"ü"}},
-	{wantData: hexDecode("63e6b0b4"), values: []interface{}{"水"}},
-	{wantData: hexDecode("64f0908591"), values: []interface{}{"𐅑"}},
+	{wantData: hexDecode("60"), values: []any{""}},
+	{wantData: hexDecode("6161"), values: []any{"a"}},
+	{wantData: hexDecode("6449455446"), values: []any{"IETF"}},
+	{wantData: hexDecode("62225c"), values: []any{"\"\\"}},
+	{wantData: hexDecode("62c3bc"), values: []any{"ü"}},
+	{wantData: hexDecode("63e6b0b4"), values: []any{"水"}},
+	{wantData: hexDecode("64f0908591"), values: []any{"𐅑"}},
 
 	// array
 	{
 		wantData: hexDecode("80"),
-		values: []interface{}{
+		values: []any{
 			[0]int{},
 			[]uint{},
 			// []uint8{},
@@ -92,12 +92,12 @@ var marshalTests = []marshalTest{
 			[]bool{},
 			[]float32{},
 			[]float64{},
-			[]interface{}{},
+			[]any{},
 		},
 	},
 	{
 		wantData: hexDecode("83010203"),
-		values: []interface{}{
+		values: []any{
 			[...]int{1, 2, 3},
 			[]uint{1, 2, 3},
 			// []uint8{1, 2, 3},
@@ -109,29 +109,29 @@ var marshalTests = []marshalTest{
 			[]int16{1, 2, 3},
 			[]int32{1, 2, 3},
 			[]int64{1, 2, 3},
-			[]interface{}{1, 2, 3},
+			[]any{1, 2, 3},
 		},
 	},
 	{
 		wantData: hexDecode("8301820203820405"),
-		values: []interface{}{
-			[...]interface{}{1, [...]int{2, 3}, [...]int{4, 5}},
-			[]interface{}{1, []uint{2, 3}, []uint{4, 5}},
+		values: []any{
+			[...]any{1, [...]int{2, 3}, [...]int{4, 5}},
+			[]any{1, []uint{2, 3}, []uint{4, 5}},
 			// []interface{}{1, []uint8{2, 3}, []uint8{4, 5}},
-			[]interface{}{1, []uint16{2, 3}, []uint16{4, 5}},
-			[]interface{}{1, []uint32{2, 3}, []uint32{4, 5}},
-			[]interface{}{1, []uint64{2, 3}, []uint64{4, 5}},
-			[]interface{}{1, []int{2, 3}, []int{4, 5}},
-			[]interface{}{1, []int8{2, 3}, []int8{4, 5}},
-			[]interface{}{1, []int16{2, 3}, []int16{4, 5}},
-			[]interface{}{1, []int32{2, 3}, []int32{4, 5}},
-			[]interface{}{1, []int64{2, 3}, []int64{4, 5}},
-			[]interface{}{1, []interface{}{2, 3}, []interface{}{4, 5}},
+			[]any{1, []uint16{2, 3}, []uint16{4, 5}},
+			[]any{1, []uint32{2, 3}, []uint32{4, 5}},
+			[]any{1, []uint64{2, 3}, []uint64{4, 5}},
+			[]any{1, []int{2, 3}, []int{4, 5}},
+			[]any{1, []int8{2, 3}, []int8{4, 5}},
+			[]any{1, []int16{2, 3}, []int16{4, 5}},
+			[]any{1, []int32{2, 3}, []int32{4, 5}},
+			[]any{1, []int64{2, 3}, []int64{4, 5}},
+			[]any{1, []any{2, 3}, []any{4, 5}},
 		},
 	},
 	{
 		wantData: hexDecode("98190102030405060708090a0b0c0d0e0f101112131415161718181819"),
-		values: []interface{}{
+		values: []any{
 			[...]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
 			[]uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
 			// []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
@@ -143,22 +143,22 @@ var marshalTests = []marshalTest{
 			[]int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
 			[]int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
 			[]int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
-			[]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]any{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
 		},
 	},
 	{
 		wantData: hexDecode("826161a161626163"),
-		values: []interface{}{
-			[...]interface{}{"a", map[string]string{"b": "c"}},
-			[]interface{}{"a", map[string]string{"b": "c"}},
-			[]interface{}{"a", map[interface{}]interface{}{"b": "c"}},
+		values: []any{
+			[...]any{"a", map[string]string{"b": "c"}},
+			[]any{"a", map[string]string{"b": "c"}},
+			[]any{"a", map[any]any{"b": "c"}},
 		},
 	},
 
 	// map
 	{
 		wantData: hexDecode("a0"),
-		values: []interface{}{
+		values: []any{
 			map[uint]bool{},
 			map[uint8]bool{},
 			map[uint16]bool{},
@@ -173,12 +173,12 @@ var marshalTests = []marshalTest{
 			map[float64]bool{},
 			map[bool]bool{},
 			map[string]bool{},
-			map[interface{}]interface{}{},
+			map[any]any{},
 		},
 	},
 	{
 		wantData: hexDecode("a201020304"),
-		values: []interface{}{
+		values: []any{
 			map[uint]uint{3: 4, 1: 2},
 			map[uint8]uint8{3: 4, 1: 2},
 			map[uint16]uint16{3: 4, 1: 2},
@@ -189,42 +189,42 @@ var marshalTests = []marshalTest{
 			map[int16]int16{3: 4, 1: 2},
 			map[int32]int32{3: 4, 1: 2},
 			map[int64]int64{3: 4, 1: 2},
-			map[interface{}]interface{}{3: 4, 1: 2},
+			map[any]any{3: 4, 1: 2},
 		},
 	},
 	{
 		wantData: hexDecode("a26161016162820203"),
-		values: []interface{}{
-			map[string]interface{}{"a": 1, "b": []interface{}{2, 3}},
-			map[interface{}]interface{}{"b": []interface{}{2, 3}, "a": 1},
+		values: []any{
+			map[string]any{"a": 1, "b": []any{2, 3}},
+			map[any]any{"b": []any{2, 3}, "a": 1},
 		},
 	},
 	{
 		wantData: hexDecode("a56161614161626142616361436164614461656145"),
-		values: []interface{}{
+		values: []any{
 			map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
-			map[interface{}]interface{}{"b": "B", "a": "A", "c": "C", "e": "E", "d": "D"},
+			map[any]any{"b": "B", "a": "A", "c": "C", "e": "E", "d": "D"},
 		},
 	},
 
 	// tag
 	{
 		wantData: hexDecode("c074323031332d30332d32315432303a30343a30305a"),
-		values: []interface{}{
+		values: []any{
 			Tag{0, "2013-03-21T20:04:00Z"},
 			RawTag{0, hexDecode("74323031332d30332d32315432303a30343a30305a")},
 		},
 	}, // 0: standard date/time
 	{
 		wantData: hexDecode("c11a514b67b0"),
-		values: []interface{}{
+		values: []any{
 			Tag{1, uint64(1363896240)},
 			RawTag{1, hexDecode("1a514b67b0")},
 		},
 	}, // 1: epoch-based date/time
 	{
 		wantData: hexDecode("c249010000000000000000"),
-		values: []interface{}{
+		values: []any{
 			bigIntOrPanic("18446744073709551616"),
 			Tag{2, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
 			RawTag{2, hexDecode("49010000000000000000")},
@@ -232,7 +232,7 @@ var marshalTests = []marshalTest{
 	}, // 2: positive bignum: 18446744073709551616
 	{
 		wantData: hexDecode("c349010000000000000000"),
-		values: []interface{}{
+		values: []any{
 			bigIntOrPanic("-18446744073709551617"),
 			Tag{3, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
 			RawTag{3, hexDecode("49010000000000000000")},
@@ -240,64 +240,64 @@ var marshalTests = []marshalTest{
 	}, // 3: negative bignum: -18446744073709551617
 	{
 		wantData: hexDecode("c1fb41d452d9ec200000"),
-		values: []interface{}{
+		values: []any{
 			Tag{1, float64(1363896240.5)},
 			RawTag{1, hexDecode("fb41d452d9ec200000")},
 		},
 	}, // 1: epoch-based date/time
 	{
 		wantData: hexDecode("d74401020304"),
-		values: []interface{}{
+		values: []any{
 			Tag{23, []byte{0x01, 0x02, 0x03, 0x04}},
 			RawTag{23, hexDecode("4401020304")},
 		},
 	}, // 23: expected conversion to base16 encoding
 	{
 		wantData: hexDecode("d818456449455446"),
-		values: []interface{}{
+		values: []any{
 			Tag{24, []byte{0x64, 0x49, 0x45, 0x54, 0x46}},
 			RawTag{24, hexDecode("456449455446")},
 		},
 	}, // 24: encoded cborBytes data item
 	{
 		wantData: hexDecode("d82076687474703a2f2f7777772e6578616d706c652e636f6d"),
-		values: []interface{}{
+		values: []any{
 			Tag{32, "http://www.example.com"},
 			RawTag{32, hexDecode("76687474703a2f2f7777772e6578616d706c652e636f6d")},
 		},
 	}, // 32: URI
 
 	// primitives
-	{wantData: hexDecode("f4"), values: []interface{}{false}},
-	{wantData: hexDecode("f5"), values: []interface{}{true}},
-	{wantData: hexDecode("f6"), values: []interface{}{nil, []byte(nil), []int(nil), map[uint]bool(nil), (*int)(nil), io.Reader(nil)}},
+	{wantData: hexDecode("f4"), values: []any{false}},
+	{wantData: hexDecode("f5"), values: []any{true}},
+	{wantData: hexDecode("f6"), values: []any{nil, []byte(nil), []int(nil), map[uint]bool(nil), (*int)(nil), io.Reader(nil)}},
 	// simple values
-	{wantData: hexDecode("e0"), values: []interface{}{SimpleValue(0)}},
-	{wantData: hexDecode("f0"), values: []interface{}{SimpleValue(16)}},
-	{wantData: hexDecode("f820"), values: []interface{}{SimpleValue(32)}},
-	{wantData: hexDecode("f8ff"), values: []interface{}{SimpleValue(255)}},
+	{wantData: hexDecode("e0"), values: []any{SimpleValue(0)}},
+	{wantData: hexDecode("f0"), values: []any{SimpleValue(16)}},
+	{wantData: hexDecode("f820"), values: []any{SimpleValue(32)}},
+	{wantData: hexDecode("f8ff"), values: []any{SimpleValue(255)}},
 	// nan, positive and negative inf
-	{wantData: hexDecode("f97c00"), values: []interface{}{math.Inf(1)}},
-	{wantData: hexDecode("f97e00"), values: []interface{}{math.NaN()}},
-	{wantData: hexDecode("f9fc00"), values: []interface{}{math.Inf(-1)}},
+	{wantData: hexDecode("f97c00"), values: []any{math.Inf(1)}},
+	{wantData: hexDecode("f97e00"), values: []any{math.NaN()}},
+	{wantData: hexDecode("f9fc00"), values: []any{math.Inf(-1)}},
 	// float32
-	{wantData: hexDecode("fa47c35000"), values: []interface{}{float32(100000.0)}},
-	{wantData: hexDecode("fa7f7fffff"), values: []interface{}{float32(3.4028234663852886e+38)}},
+	{wantData: hexDecode("fa47c35000"), values: []any{float32(100000.0)}},
+	{wantData: hexDecode("fa7f7fffff"), values: []any{float32(3.4028234663852886e+38)}},
 	// float64
-	{wantData: hexDecode("fb3ff199999999999a"), values: []interface{}{float64(1.1)}},
-	{wantData: hexDecode("fb7e37e43c8800759c"), values: []interface{}{float64(1.0e+300)}},
-	{wantData: hexDecode("fbc010666666666666"), values: []interface{}{float64(-4.1)}},
+	{wantData: hexDecode("fb3ff199999999999a"), values: []any{float64(1.1)}},
+	{wantData: hexDecode("fb7e37e43c8800759c"), values: []any{float64(1.0e+300)}},
+	{wantData: hexDecode("fbc010666666666666"), values: []any{float64(-4.1)}},
 
 	// More testcases not covered by https://tools.ietf.org/html/rfc7049#appendix-A.
 	{
 		wantData: hexDecode("d83dd183010203"), // 61(17([1, 2, 3])), nested tags 61 and 17
-		values: []interface{}{
-			Tag{61, Tag{17, []interface{}{uint64(1), uint64(2), uint64(3)}}},
+		values: []any{
+			Tag{61, Tag{17, []any{uint64(1), uint64(2), uint64(3)}}},
 			RawTag{61, hexDecode("d183010203")},
 		},
 	},
 
-	{wantData: hexDecode("83f6f6f6"), values: []interface{}{[]interface{}{nil, nil, nil}}}, // [nil, nil, nil]
+	{wantData: hexDecode("83f6f6f6"), values: []any{[]any{nil, nil, nil}}}, // [nil, nil, nil]
 }
 
 func TestMarshal(t *testing.T) {
@@ -366,7 +366,7 @@ func TestMarshalLargeByteString(t *testing.T) {
 			data.WriteByte(100)
 			value[j] = 100
 		}
-		tests[i] = marshalTest{data.Bytes(), []interface{}{value}}
+		tests[i] = marshalTest{data.Bytes(), []any{value}}
 	}
 
 	testMarshal(t, tests)
@@ -383,7 +383,7 @@ func TestMarshalLargeTextString(t *testing.T) {
 			data.WriteByte(100)
 			value[j] = 100
 		}
-		tests[i] = marshalTest{data.Bytes(), []interface{}{string(value)}}
+		tests[i] = marshalTest{data.Bytes(), []any{string(value)}}
 	}
 
 	testMarshal(t, tests)
@@ -400,7 +400,7 @@ func TestMarshalLargeArray(t *testing.T) {
 			data.Write([]byte{0x63, 0xe6, 0xb0, 0xb4})
 			value[j] = "水"
 		}
-		tests[i] = marshalTest{data.Bytes(), []interface{}{value}}
+		tests[i] = marshalTest{data.Bytes(), []any{value}}
 	}
 
 	testMarshal(t, tests)
@@ -419,7 +419,7 @@ func TestMarshalLargeMapCanonical(t *testing.T) {
 			data.Write(d)
 			value[j] = j
 		}
-		tests[i] = marshalTest{data.Bytes(), []interface{}{value}}
+		tests[i] = marshalTest{data.Bytes(), []any{value}}
 	}
 
 	testMarshal(t, tests)
@@ -598,7 +598,7 @@ func TestMarshalStruct(t *testing.T) {
 func TestMarshalStructVariableLength(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		in   interface{}
+		in   any
 		want []byte
 	}{
 		{
@@ -1135,8 +1135,8 @@ func TestOmitEmptyForBuiltinType(t *testing.T) {
 		Mo    map[int]string `cbor:"mo,omitempty"`
 		P     *int           `cbor:"p"`
 		Po    *int           `cbor:"po,omitempty"`
-		Intf  interface{}    `cbor:"intf"`
-		Intfo interface{}    `cbor:"intfo,omitempty"`
+		Intf  any            `cbor:"intf"`
+		Intfo any            `cbor:"intfo,omitempty"`
 	}
 
 	v := T{}
@@ -1182,7 +1182,7 @@ func TestOmitEmptyForStruct1(t *testing.T) {
 		Slco  []string       `cbor:"slco,omitempty"`
 		Mo    map[int]string `cbor:"mo,omitempty"`
 		Po    *int           `cbor:"po,omitempty"`
-		Intfo interface{}    `cbor:"intfo,omitempty"`
+		Intfo any            `cbor:"intfo,omitempty"`
 	}
 	type T struct {
 		Str  T1 `cbor:"str"`
@@ -1207,7 +1207,7 @@ func TestOmitEmptyForStruct2(t *testing.T) {
 		Slco  []string       `cbor:"slco,omitempty"`
 		Mo    map[int]string `cbor:"mo,omitempty"`
 		Po    *int           `cbor:"po,omitempty"`
-		Intfo interface{}    `cbor:"intfo"`
+		Intfo any            `cbor:"intfo"`
 	}
 	type T struct {
 		Stro T1 `cbor:"stro,omitempty"`
@@ -1268,8 +1268,8 @@ func TestOmitEmptyMode(t *testing.T) {
 		Mo    map[int]string `cbor:"mo,omitempty"`
 		P     *int           `cbor:"p"`
 		Po    *int           `cbor:"po,omitempty"`
-		Intf  interface{}    `cbor:"intf"`
-		Intfo interface{}    `cbor:"intfo,omitempty"`
+		Intf  any            `cbor:"intf"`
+		Intfo any            `cbor:"intfo,omitempty"`
 		Str   T1             `cbor:"str"`
 		Stro  T1             `cbor:"stro,omitempty"`
 	}
@@ -1324,7 +1324,7 @@ func TestOmitEmptyForNestedStruct(t *testing.T) {
 		Slco  []string       `cbor:"slco,omitempty"`
 		Mo    map[int]string `cbor:"mo,omitempty"`
 		Po    *int           `cbor:"po,omitempty"`
-		Intfo interface{}    `cbor:"intfo,omitempty"`
+		Intfo any            `cbor:"intfo,omitempty"`
 	}
 	type T2 struct {
 		Stro T1 `cbor:"stro,omitempty"`
@@ -1353,7 +1353,7 @@ func TestOmitEmptyForToArrayStruct1(t *testing.T) {
 		slc  []string
 		m    map[int]string
 		p    *int
-		intf interface{}
+		intf any
 	}
 	type T struct {
 		Str  T1 `cbor:"str"`
@@ -1382,7 +1382,7 @@ func TestOmitEmptyForToArrayStruct2(t *testing.T) {
 		Slco  []string       `cbor:"slco"`
 		Mo    map[int]string `cbor:"mo"`
 		Po    *int           `cbor:"po"`
-		Intfo interface{}    `cbor:"intfo"`
+		Intfo any            `cbor:"intfo"`
 	}
 	type T struct {
 		Stro T1 `cbor:"stro,omitempty"`
@@ -1413,7 +1413,7 @@ func TestOmitEmptyForStructWithPtrToAnonymousField(t *testing.T) {
 
 	testCases := []struct {
 		name         string
-		obj          interface{}
+		obj          any
 		wantCborData []byte
 	}{
 		{
@@ -1472,7 +1472,7 @@ func TestOmitEmptyForStructWithAnonymousField(t *testing.T) {
 
 	testCases := []struct {
 		name         string
-		obj          interface{}
+		obj          any
 		wantCborData []byte
 	}{
 		{
@@ -2212,24 +2212,24 @@ func TestMarshalRawMessageValue(t *testing.T) {
 	)
 
 	tests := []struct {
-		obj  interface{}
+		obj  any
 		want []byte
 	}{
 		// Test with nil RawMessage.
 		{rawNil, []byte{0xf6}},
 		{&rawNil, []byte{0xf6}},
-		{[]interface{}{rawNil}, []byte{0x81, 0xf6}},
-		{&[]interface{}{rawNil}, []byte{0x81, 0xf6}},
-		{[]interface{}{&rawNil}, []byte{0x81, 0xf6}},
-		{&[]interface{}{&rawNil}, []byte{0x81, 0xf6}},
+		{[]any{rawNil}, []byte{0x81, 0xf6}},
+		{&[]any{rawNil}, []byte{0x81, 0xf6}},
+		{[]any{&rawNil}, []byte{0x81, 0xf6}},
+		{&[]any{&rawNil}, []byte{0x81, 0xf6}},
 		{struct{ M RawMessage }{rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
 		{&struct{ M RawMessage }{rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
 		{struct{ M *RawMessage }{&rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
 		{&struct{ M *RawMessage }{&rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
-		{map[string]interface{}{"M": rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
-		{&map[string]interface{}{"M": rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
-		{map[string]interface{}{"M": &rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
-		{&map[string]interface{}{"M": &rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{map[string]any{"M": rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&map[string]any{"M": rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{map[string]any{"M": &rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&map[string]any{"M": &rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
 		{T1{rawNil}, []byte{0xa0}},
 		{T2{&rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
 		{&T1{rawNil}, []byte{0xa0}},
@@ -2238,18 +2238,18 @@ func TestMarshalRawMessageValue(t *testing.T) {
 		// Test with empty, but non-nil, RawMessage.
 		{rawEmpty, []byte{0xf6}},
 		{&rawEmpty, []byte{0xf6}},
-		{[]interface{}{rawEmpty}, []byte{0x81, 0xf6}},
-		{&[]interface{}{rawEmpty}, []byte{0x81, 0xf6}},
-		{[]interface{}{&rawEmpty}, []byte{0x81, 0xf6}},
-		{&[]interface{}{&rawEmpty}, []byte{0x81, 0xf6}},
+		{[]any{rawEmpty}, []byte{0x81, 0xf6}},
+		{&[]any{rawEmpty}, []byte{0x81, 0xf6}},
+		{[]any{&rawEmpty}, []byte{0x81, 0xf6}},
+		{&[]any{&rawEmpty}, []byte{0x81, 0xf6}},
 		{struct{ M RawMessage }{rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
 		{&struct{ M RawMessage }{rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
 		{struct{ M *RawMessage }{&rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
 		{&struct{ M *RawMessage }{&rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
-		{map[string]interface{}{"M": rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
-		{&map[string]interface{}{"M": rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
-		{map[string]interface{}{"M": &rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
-		{&map[string]interface{}{"M": &rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{map[string]any{"M": rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&map[string]any{"M": rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{map[string]any{"M": &rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&map[string]any{"M": &rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
 		{T1{rawEmpty}, []byte{0xa0}},
 		{T2{&rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
 		{&T1{rawEmpty}, []byte{0xa0}},
@@ -2258,18 +2258,18 @@ func TestMarshalRawMessageValue(t *testing.T) {
 		// Test with RawMessage with some data.
 		{raw, []byte{0x01}},
 		{&raw, []byte{0x01}},
-		{[]interface{}{raw}, []byte{0x81, 0x01}},
-		{&[]interface{}{raw}, []byte{0x81, 0x01}},
-		{[]interface{}{&raw}, []byte{0x81, 0x01}},
-		{&[]interface{}{&raw}, []byte{0x81, 0x01}},
+		{[]any{raw}, []byte{0x81, 0x01}},
+		{&[]any{raw}, []byte{0x81, 0x01}},
+		{[]any{&raw}, []byte{0x81, 0x01}},
+		{&[]any{&raw}, []byte{0x81, 0x01}},
 		{struct{ M RawMessage }{raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
 		{&struct{ M RawMessage }{raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
 		{struct{ M *RawMessage }{&raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
 		{&struct{ M *RawMessage }{&raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
-		{map[string]interface{}{"M": raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
-		{&map[string]interface{}{"M": raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
-		{map[string]interface{}{"M": &raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
-		{&map[string]interface{}{"M": &raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{map[string]any{"M": raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{&map[string]any{"M": raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{map[string]any{"M": &raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{&map[string]any{"M": &raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
 		{T1{raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
 		{T2{&raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
 		{&T1{raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
@@ -2318,7 +2318,7 @@ func TestMarshalUnmarshalStructKeyAsInt(t *testing.T) {
 	}
 	testCases := []struct {
 		name         string
-		obj          interface{}
+		obj          any
 		wantCborData []byte
 	}{
 		{
@@ -2366,7 +2366,7 @@ func TestMarshalStructKeyAsIntNumError(t *testing.T) {
 	}
 	testCases := []struct {
 		name         string
-		obj          interface{}
+		obj          any
 		wantErrorMsg string
 	}{
 		{
@@ -2471,7 +2471,7 @@ func TestMarshalUnmarshalStructToArray(t *testing.T) {
 }
 
 func TestMapSort(t *testing.T) {
-	m := make(map[interface{}]interface{})
+	m := make(map[any]any)
 	m[10] = true
 	m[100] = true
 	m[-1] = true
@@ -2981,7 +2981,7 @@ func TestShortestFloat16(t *testing.T) {
 func TestShortestFloatNone(t *testing.T) {
 	testCases := []struct {
 		name         string
-		f            interface{}
+		f            any
 		wantCborData []byte
 	}{
 		// Data from RFC 7049 appendix A
@@ -3081,7 +3081,7 @@ func TestInfConvert(t *testing.T) {
 	infConvertFloat16Opt := EncOptions{InfConvert: InfConvertFloat16}
 	testCases := []struct {
 		name         string
-		v            interface{}
+		v            any
 		opts         EncOptions
 		wantCborData []byte
 	}{
@@ -3161,7 +3161,7 @@ func TestNilContainers(t *testing.T) {
 
 	testCases := []struct {
 		name         string
-		v            interface{}
+		v            any
 		opts         EncOptions
 		wantCborData []byte
 	}{
@@ -3284,7 +3284,7 @@ func TestNaNConvert(t *testing.T) {
 		wantCborData []byte
 	}
 	testCases := []struct {
-		v       interface{}
+		v       any
 		convert []nanConvert
 	}{
 		// float32 qNaN dropped payload not zero
@@ -4182,7 +4182,7 @@ func TestMapWithSimpleValueKey(t *testing.T) {
 	}
 	decMode, _ := decOpts.DecMode()
 
-	var v map[interface{}]interface{}
+	var v map[any]any
 	err := decMode.Unmarshal(data, &v)
 	if err != nil {
 		t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
@@ -4247,7 +4247,7 @@ func TestMarshalFieldNameType(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		opts EncOptions
-		in   interface{}
+		in   any
 		want []byte
 	}{
 		{
@@ -4312,7 +4312,7 @@ func TestMarshalFieldNameType(t *testing.T) {
 func TestMarshalRawMessageContainingMalformedCBORData(t *testing.T) {
 	testCases := []struct {
 		name         string
-		value        interface{}
+		value        any
 		wantErrorMsg string
 	}{
 		// Nil RawMessage and empty RawMessage are encoded as CBOR nil.
@@ -4367,7 +4367,7 @@ func TestMarshalerReturnsMalformedCBORData(t *testing.T) {
 
 	testCases := []struct {
 		name         string
-		value        interface{}
+		value        any
 		wantErrorMsg string
 	}{
 		{
@@ -4414,7 +4414,7 @@ func TestMarshalerReturnsDisallowedCBORData(t *testing.T) {
 	testCases := []struct {
 		name         string
 		encOpts      EncOptions
-		value        interface{}
+		value        any
 		wantErrorMsg string
 	}{
 		{
@@ -4482,7 +4482,7 @@ func TestSortModeFastShuffle(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		trials int
-		in     interface{}
+		in     any
 	}{
 		{
 			name:   "fixed length struct",
@@ -4594,7 +4594,7 @@ func TestMarshalByteArrayMode(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		opts     EncOptions
-		in       interface{}
+		in       any
 		expected []byte
 	}{
 		{
@@ -4645,7 +4645,7 @@ func TestMarshalByteSliceMode(t *testing.T) {
 		name     string
 		tags     TagSet
 		opts     EncOptions
-		in       interface{}
+		in       any
 		expected []byte
 	}{
 		{
@@ -4791,7 +4791,7 @@ func TestBinaryMarshalerMode(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		opts EncOptions
-		in   interface{}
+		in   any
 		want []byte
 	}{
 		{

--- a/json_test.go
+++ b/json_test.go
@@ -34,7 +34,7 @@ func TestStdlibJSONCompatibility(t *testing.T) {
 
 	for _, tc := range []struct {
 		name       string
-		original   interface{}
+		original   any
 		ifaceEqual bool // require equal intermediate interface{} values from both protocols
 	}{
 		{
@@ -67,14 +67,14 @@ func TestStdlibJSONCompatibility(t *testing.T) {
 			}
 			t.Logf("original to cbor: %s", diag1)
 
-			var jintf interface{}
+			var jintf any
 			err = json.Unmarshal(j1, &jintf)
 			if err != nil {
 				t.Fatal(err)
 			}
 			t.Logf("json to interface{} (%T): %#v", jintf, jintf)
 
-			var cintf interface{}
+			var cintf any
 			err = dec.Unmarshal(c1, &cintf)
 			if err != nil {
 				t.Fatal(err)

--- a/simplevalue_test.go
+++ b/simplevalue_test.go
@@ -52,7 +52,7 @@ func TestUnmarshalSimpleValue(t *testing.T) {
 }
 
 func testUnmarshalInvalidSimpleValueToEmptyInterface(t *testing.T, data []byte) {
-	var v interface{}
+	var v any
 	if err := Unmarshal(data, v); err == nil {
 		t.Errorf("Unmarshal(0x%x) didn't return an error", data)
 	} else if _, ok := err.(*SyntaxError); !ok {
@@ -69,8 +69,8 @@ func testUnmarshalInvalidSimpleValue(t *testing.T, data []byte) {
 	}
 }
 
-func testUnmarshalSimpleValueToEmptyInterface(t *testing.T, data []byte, want interface{}) {
-	var v interface{}
+func testUnmarshalSimpleValueToEmptyInterface(t *testing.T, data []byte, want any) {
+	var v any
 	if err := Unmarshal(data, &v); err != nil {
 		t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
 		return

--- a/stream.go
+++ b/stream.go
@@ -26,7 +26,7 @@ func NewDecoder(r io.Reader) *Decoder {
 }
 
 // Decode reads CBOR value and decodes it into the value pointed to by v.
-func (dec *Decoder) Decode(v interface{}) error {
+func (dec *Decoder) Decode(v any) error {
 	_, err := dec.readNext()
 	if err != nil {
 		// Return validation error or read error.
@@ -170,7 +170,7 @@ func NewEncoder(w io.Writer) *Encoder {
 }
 
 // Encode writes the CBOR encoding of v.
-func (enc *Encoder) Encode(v interface{}) error {
+func (enc *Encoder) Encode(v any) error {
 	if len(enc.indefTypes) > 0 && v != nil {
 		indefType := enc.indefTypes[len(enc.indefTypes)-1]
 		if indefType == cborTypeTextString {

--- a/stream_test.go
+++ b/stream_test.go
@@ -37,7 +37,7 @@ func TestDecoder(t *testing.T) {
 			bytesRead := 0
 			for i := 0; i < 5; i++ {
 				for _, tc := range unmarshalTests {
-					var v interface{}
+					var v any
 					if err := decoder.Decode(&v); err != nil {
 						t.Fatalf("Decode() returned error %v", err)
 					}
@@ -56,7 +56,7 @@ func TestDecoder(t *testing.T) {
 			}
 			for i := 0; i < 2; i++ {
 				// no more data
-				var v interface{}
+				var v any
 				err := decoder.Decode(&v)
 				if v != nil {
 					t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
@@ -106,7 +106,7 @@ func TestDecoderUnmarshalTypeError(t *testing.T) {
 							t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
 						}
 
-						var vi interface{}
+						var vi any
 						if err := decoder.Decode(&vi); err != nil {
 							t.Errorf("Decode() returned error %v", err)
 						}
@@ -126,7 +126,7 @@ func TestDecoderUnmarshalTypeError(t *testing.T) {
 			}
 			for i := 0; i < 2; i++ {
 				// no more data
-				var v interface{}
+				var v any
 				err := decoder.Decode(&v)
 				if v != nil {
 					t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
@@ -162,7 +162,7 @@ func TestDecoderUnexpectedEOFError(t *testing.T) {
 			bytesRead := 0
 			for i := 0; i < len(unmarshalTests)-1; i++ {
 				tc := unmarshalTests[i]
-				var v interface{}
+				var v any
 				if err := decoder.Decode(&v); err != nil {
 					t.Fatalf("Decode() returned error %v", err)
 				}
@@ -180,7 +180,7 @@ func TestDecoderUnexpectedEOFError(t *testing.T) {
 			}
 			for i := 0; i < 2; i++ {
 				// truncated data
-				var v interface{}
+				var v any
 				err := decoder.Decode(&v)
 				if v != nil {
 					t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
@@ -217,7 +217,7 @@ func TestDecoderReadError(t *testing.T) {
 			bytesRead := 0
 			for i := 0; i < len(unmarshalTests)-1; i++ {
 				tc := unmarshalTests[i]
-				var v interface{}
+				var v any
 				if err := decoder.Decode(&v); err != nil {
 					t.Fatalf("Decode() returned error %v", err)
 				}
@@ -235,7 +235,7 @@ func TestDecoderReadError(t *testing.T) {
 			}
 			for i := 0; i < 2; i++ {
 				// truncated data because Reader returned error
-				var v interface{}
+				var v any
 				err := decoder.Decode(&v)
 				if v != nil {
 					t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
@@ -265,7 +265,7 @@ func TestDecoderNoData(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			for i := 0; i < 2; i++ {
-				var v interface{}
+				var v any
 				err := decoder.Decode(&v)
 				if v != nil {
 					t.Errorf("Decode() = %v (%T), want nil", v, v)
@@ -280,12 +280,12 @@ func TestDecoderNoData(t *testing.T) {
 
 func TestDecoderRecoverableReadError(t *testing.T) {
 	data := hexDecode("83010203") // [1,2,3]
-	wantValue := []interface{}{uint64(1), uint64(2), uint64(3)}
+	wantValue := []any{uint64(1), uint64(2), uint64(3)}
 	recoverableReaderErr := errors.New("recoverable reader error")
 
 	decoder := NewDecoder(newRecoverableReader(data, 1, recoverableReaderErr))
 
-	var v interface{}
+	var v any
 	err := decoder.Decode(&v)
 	if err != recoverableReaderErr {
 		t.Fatalf("Decode() returned error %v, want error %v", err, recoverableReaderErr)
@@ -303,7 +303,7 @@ func TestDecoderRecoverableReadError(t *testing.T) {
 	}
 
 	// no more data
-	v = interface{}(nil)
+	v = any(nil)
 	err = decoder.Decode(&v)
 	if v != nil {
 		t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
@@ -317,13 +317,13 @@ func TestDecoderInvalidData(t *testing.T) {
 	data := []byte{0x01, 0x3e}
 	decoder := NewDecoder(bytes.NewReader(data))
 
-	var v1 interface{}
+	var v1 any
 	err := decoder.Decode(&v1)
 	if err != nil {
 		t.Errorf("Decode() returned error %v when decoding valid data item", err)
 	}
 
-	var v2 interface{}
+	var v2 any
 	err = decoder.Decode(&v2)
 	if err == nil {
 		t.Errorf("Decode() didn't return error when decoding invalid data item")
@@ -645,7 +645,7 @@ func TestDecoderBuffered(t *testing.T) {
 				t.Errorf("Buffered() = 0x%x (%d bytes), want 0 bytes", buffered, len(buffered))
 			}
 
-			var v interface{}
+			var v any
 			err = decoder.Decode(&v)
 			if err != tc.decodeErr {
 				t.Errorf("Decode() returned error %v, want %v", err, tc.decodeErr)
@@ -688,7 +688,7 @@ func TestEncoder(t *testing.T) {
 func TestEncoderError(t *testing.T) {
 	testcases := []struct {
 		name         string
-		value        interface{}
+		value        any
 		wantErrorMsg string
 	}{
 		{"channel cannot be marshaled", make(chan bool), "cbor: unsupported type: chan bool"},

--- a/tag.go
+++ b/tag.go
@@ -12,7 +12,7 @@ import (
 // enclosed data item if it were to appear outside of a tag.
 type Tag struct {
 	Number  uint64
-	Content interface{}
+	Content any
 }
 
 // RawTag represents CBOR tag data, including tag number and raw tag content.

--- a/tag_test.go
+++ b/tag_test.go
@@ -905,7 +905,7 @@ func TestDecodeWrongTag(t *testing.T) {
 
 	testCases := []struct {
 		name         string
-		obj          interface{}
+		obj          any
 		data         []byte
 		wantErrorMsg string
 	}{
@@ -1240,7 +1240,7 @@ func TestMarshalRawTagWithEmptyContent(t *testing.T) {
 }
 
 func TestEncodeTag(t *testing.T) {
-	m := make(map[interface{}]bool)
+	m := make(map[any]bool)
 	m[10] = true
 	m[100] = true
 	m[-1] = true
@@ -1295,7 +1295,7 @@ func TestDecodeTagToEmptyIface(t *testing.T) {
 	testCases := []struct {
 		name    string
 		data    []byte
-		wantObj interface{}
+		wantObj any
 	}{
 		{
 			name:    "registered myBool",
@@ -1326,7 +1326,7 @@ func TestDecodeTagToEmptyIface(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var v1 interface{}
+			var v1 any
 			if err := dm.Unmarshal(tc.data, &v1); err != nil {
 				t.Errorf("Unmarshal() returned error %v", err)
 			}
@@ -1334,7 +1334,7 @@ func TestDecodeTagToEmptyIface(t *testing.T) {
 				t.Errorf("Unmarshal to interface{} returned different values: %v, %v", tc.wantObj, v1)
 			}
 
-			var v2 interface{}
+			var v2 any
 			if err := dmSharedTags.Unmarshal(tc.data, &v2); err != nil {
 				t.Errorf("Unmarshal() returned error %v", err)
 			}
@@ -1359,7 +1359,7 @@ func TestDecodeRegisteredTagToEmptyIfaceError(t *testing.T) {
 
 	data := hexDecode("d865d8663bffffffffffffffff") // 101(102(-18446744073709551616))
 
-	var v interface{}
+	var v any
 	if err := dm.Unmarshal(data, &v); err == nil {
 		t.Errorf("Unmarshal(0x%x) didn't return an error", data)
 	} else if _, ok := err.(*UnmarshalTypeError); !ok {
@@ -1415,7 +1415,7 @@ func TestDecodeRegisterTagForUnmarshaler(t *testing.T) {
 	em, _ := EncOptions{}.EncModeWithTags(tags)
 
 	// Decode to empty interface.  Unmarshal() should return object of registered type.
-	var v1 interface{}
+	var v1 any
 	if err := dm.Unmarshal(data, &v1); err != nil {
 		t.Errorf("Unmarshal() returned error %v", err)
 	}
@@ -1448,7 +1448,7 @@ func TestDecodeRegisterTagForUnmarshaler(t *testing.T) {
 func TestMarshalRawTagContainingMalformedCBORData(t *testing.T) {
 	testCases := []struct {
 		name         string
-		value        interface{}
+		value        any
 		wantErrorMsg string
 	}{
 		// Nil RawMessage and empty RawMessage are encoded as CBOR nil.


### PR DESCRIPTION
This PR replaces `interface{}` with `any`, so go1.18 or newer is required to to build.

Updates #625 