### PR TITLE
Replace reflect.Ptr with reflect.Pointer

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -50,7 +50,7 @@ type typeInfo struct {
 func newTypeInfo(t reflect.Type) *typeInfo {
 	tInfo := typeInfo{typ: t, kind: t.Kind()}
 
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 

--- a/decode.go
+++ b/decode.go
@@ -1347,7 +1347,7 @@ func (d *decoder) value(v any) error {
 		return &InvalidUnmarshalError{"cbor: Unmarshal(nil)"}
 	}
 	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr {
+	if rv.Kind() != reflect.Pointer {
 		return &InvalidUnmarshalError{"cbor: Unmarshal(non-pointer " + rv.Type().String() + ")"}
 	} else if rv.IsNil() {
 		return &InvalidUnmarshalError{"cbor: Unmarshal(nil " + rv.Type().String() + ")"}
@@ -1361,7 +1361,7 @@ func (d *decoder) value(v any) error {
 func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolint:gocyclo
 
 	// Decode CBOR nil or CBOR undefined to pointer value by setting pointer value to nil.
-	if d.nextCBORNil() && v.Kind() == reflect.Ptr {
+	if d.nextCBORNil() && v.Kind() == reflect.Pointer {
 		d.skip()
 		v.Set(reflect.Zero(v.Type()))
 		return nil
@@ -1399,7 +1399,7 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 
 	// Create new value for the pointer v to point to.
 	// At this point, CBOR value is not nil/undefined if v is a pointer.
-	for v.Kind() == reflect.Ptr {
+	for v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			if !v.CanSet() {
 				d.skip()
@@ -1788,12 +1788,12 @@ func (d *decoder) parseToTime() (time.Time, bool, error) {
 // parseToUnmarshaler parses CBOR data to value implementing Unmarshaler interface.
 // It assumes data is well-formed, and does not perform bounds checking.
 func (d *decoder) parseToUnmarshaler(v reflect.Value) error {
-	if d.nextCBORNil() && v.Kind() == reflect.Ptr && v.IsNil() {
+	if d.nextCBORNil() && v.Kind() == reflect.Pointer && v.IsNil() {
 		d.skip()
 		return nil
 	}
 
-	if v.Kind() != reflect.Ptr && v.CanAddr() {
+	if v.Kind() != reflect.Pointer && v.CanAddr() {
 		v = v.Addr()
 	}
 	if u, ok := v.Interface().(Unmarshaler); ok {
@@ -2980,7 +2980,7 @@ var (
 
 func fillNil(_ cborType, v reflect.Value) error {
 	switch v.Kind() {
-	case reflect.Slice, reflect.Map, reflect.Interface, reflect.Ptr:
+	case reflect.Slice, reflect.Map, reflect.Interface, reflect.Pointer:
 		v.Set(reflect.Zero(v.Type()))
 		return nil
 	}

--- a/encode.go
+++ b/encode.go
@@ -1777,7 +1777,7 @@ var (
 
 func getEncodeFuncInternal(t reflect.Type) (ef encodeFunc, ief isEmptyFunc) {
 	k := t.Kind()
-	if k == reflect.Ptr {
+	if k == reflect.Pointer {
 		return getEncodeIndirectValueFunc(t), isEmptyPtr
 	}
 	switch t {
@@ -1868,7 +1868,7 @@ func getEncodeFuncInternal(t reflect.Type) (ef encodeFunc, ief isEmptyFunc) {
 }
 
 func getEncodeIndirectValueFunc(t reflect.Type) encodeFunc {
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	f, _ := getEncodeFunc(t)
@@ -1876,10 +1876,10 @@ func getEncodeIndirectValueFunc(t reflect.Type) encodeFunc {
 		return nil
 	}
 	return func(e *bytes.Buffer, em *encMode, v reflect.Value) error {
-		for v.Kind() == reflect.Ptr && !v.IsNil() {
+		for v.Kind() == reflect.Pointer && !v.IsNil() {
 			v = v.Elem()
 		}
-		if v.Kind() == reflect.Ptr && v.IsNil() {
+		if v.Kind() == reflect.Pointer && v.IsNil() {
 			e.Write(cborNil)
 			return nil
 		}

--- a/structfields.go
+++ b/structfields.go
@@ -157,7 +157,7 @@ func appendFields(
 		f := t.Field(i)
 
 		ft := f.Type
-		for ft.Kind() == reflect.Ptr {
+		for ft.Kind() == reflect.Pointer {
 			ft = ft.Elem()
 		}
 
@@ -244,7 +244,7 @@ func getFieldValue(v reflect.Value, idx []int, f embeddedFieldNullPtrFunc) (fv r
 		fv = fv.Field(n)
 
 		if i < len(idx)-1 {
-			if fv.Kind() == reflect.Ptr && fv.Type().Elem().Kind() == reflect.Struct {
+			if fv.Kind() == reflect.Pointer && fv.Type().Elem().Kind() == reflect.Struct {
 				if fv.IsNil() {
 					// Null pointer to embedded struct field
 					fv, err = f(fv)

--- a/tag.go
+++ b/tag.go
@@ -193,7 +193,7 @@ func (t *syncTagSet) Add(opts TagOptions, contentType reflect.Type, num uint64, 
 	if contentType == nil {
 		return errors.New("cbor: cannot add nil content type to TagSet")
 	}
-	for contentType.Kind() == reflect.Ptr {
+	for contentType.Kind() == reflect.Pointer {
 		contentType = contentType.Elem()
 	}
 	tag, err := newTagItem(opts, contentType, num, nestedNum...)
@@ -216,7 +216,7 @@ func (t *syncTagSet) Add(opts TagOptions, contentType reflect.Type, num uint64, 
 
 // Remove removes given tag content type from TagSet.
 func (t *syncTagSet) Remove(contentType reflect.Type) {
-	for contentType.Kind() == reflect.Ptr {
+	for contentType.Kind() == reflect.Pointer {
 		contentType = contentType.Elem()
 	}
 	t.Lock()


### PR DESCRIPTION
This PR replaces `reflect.Ptr` with `reflect.Pointer` (go1.18 or newer is required to to build).

Updates https://github.com/fxamacker/cbor/issues/625

