### PR TITLE
Replace `reflect.PtrTo` with `reflect.PointerTo`

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -69,7 +69,7 @@ func newTypeInfo(t reflect.Type) *typeInfo {
 		tInfo.spclType = specialTypeTag
 	} else if t == typeTime {
 		tInfo.spclType = specialTypeTime
-	} else if reflect.PtrTo(t).Implements(typeUnmarshaler) {
+	} else if reflect.PointerTo(t).Implements(typeUnmarshaler) {
 		tInfo.spclType = specialTypeUnmarshalerIface
 	}
 

--- a/decode.go
+++ b/decode.go
@@ -1387,7 +1387,7 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 				registeredType := d.dm.tags.getTypeFromTagNum(tagNums)
 				if registeredType != nil {
 					if registeredType.Implements(tInfo.nonPtrType) ||
-						reflect.PtrTo(registeredType).Implements(tInfo.nonPtrType) {
+						reflect.PointerTo(registeredType).Implements(tInfo.nonPtrType) {
 						v.Set(reflect.New(registeredType))
 						v = v.Elem()
 						tInfo = getTypeInfo(registeredType)
@@ -3083,7 +3083,7 @@ func fillFloat(t cborType, val float64, v reflect.Value) error {
 }
 
 func fillByteString(t cborType, val []byte, shared bool, v reflect.Value, bsts ByteStringToStringMode, bum BinaryUnmarshalerMode) error {
-	if bum == BinaryUnmarshalerByteString && reflect.PtrTo(v.Type()).Implements(typeBinaryUnmarshaler) {
+	if bum == BinaryUnmarshalerByteString && reflect.PointerTo(v.Type()).Implements(typeBinaryUnmarshaler) {
 		if v.CanAddr() {
 			v = v.Addr()
 			if u, ok := v.Interface().(encoding.BinaryUnmarshaler); ok {

--- a/decode_test.go
+++ b/decode_test.go
@@ -2386,7 +2386,7 @@ func testUnmarshalToCompatibleType(t *testing.T, data []byte, wantValue any, com
 	//     var pv *wantType
 	//     Unmarshal(tc.data, &pv)
 
-	rv = reflect.New(reflect.PtrTo(wantType))
+	rv = reflect.New(reflect.PointerTo(wantType))
 	if err := Unmarshal(data, rv.Interface()); err != nil {
 		t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
 		return
@@ -2405,7 +2405,7 @@ func testUnmarshalToCompatibleType(t *testing.T, data []byte, wantValue any, com
 	//     Unmarshal(tc.data, &pv)
 
 	irv := reflect.New(wantType)
-	rv = reflect.New(reflect.PtrTo(wantType))
+	rv = reflect.New(reflect.PointerTo(wantType))
 	rv.Elem().Set(irv)
 	if err := Unmarshal(data, rv.Interface()); err != nil {
 		t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
@@ -2446,7 +2446,7 @@ func testUnmarshalToIncompatibleType(t *testing.T, data []byte, wrongType reflec
 	//     var pv *wrongType
 	//     Unmarshal(tc.data, &pv)
 
-	rv = reflect.New(reflect.PtrTo(wrongType))
+	rv = reflect.New(reflect.PointerTo(wrongType))
 	if err := Unmarshal(data, rv.Interface()); err == nil {
 		t.Errorf("Unmarshal(0x%x) didn't return an error", data)
 	} else if _, ok := err.(*UnmarshalTypeError); !ok {
@@ -2459,7 +2459,7 @@ func testUnmarshalToIncompatibleType(t *testing.T, data []byte, wrongType reflec
 	//     Unmarshal(tc.data, &pv)
 
 	irv := reflect.New(wrongType)
-	rv = reflect.New(reflect.PtrTo(wrongType))
+	rv = reflect.New(reflect.PointerTo(wrongType))
 	rv.Elem().Set(irv)
 
 	if err := Unmarshal(data, rv.Interface()); err == nil {

--- a/encode.go
+++ b/encode.go
@@ -1799,10 +1799,10 @@ func getEncodeFuncInternal(t reflect.Type) (ef encodeFunc, ief isEmptyFunc) {
 	case typeByteString:
 		return encodeMarshalerType, isEmptyString
 	}
-	if reflect.PtrTo(t).Implements(typeMarshaler) {
+	if reflect.PointerTo(t).Implements(typeMarshaler) {
 		return encodeMarshalerType, alwaysNotEmpty
 	}
-	if reflect.PtrTo(t).Implements(typeBinaryMarshaler) {
+	if reflect.PointerTo(t).Implements(typeBinaryMarshaler) {
 		defer func() {
 			// capture encoding method used for modes that disable BinaryMarshaler
 			bme := binaryMarshalerEncoder{


### PR DESCRIPTION
This PR replaces `reflect.PtrTo` with `reflect.PointerTo` (go1.18 or newer is required to to build).

Updates https://github.com/fxamacker/cbor/issues/625