### PR TITLE
Add missing copyright notice to a few files

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 package cbor_test
 
 import (

--- a/simplevalue.go
+++ b/simplevalue.go
@@ -1,3 +1,6 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 package cbor
 
 import (

--- a/tag.go
+++ b/tag.go
@@ -1,3 +1,6 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 package cbor
 
 import (

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 package cbor
 
 import (


### PR DESCRIPTION
Several files were missing copyright notice. This PR updates them to add copyright notice:
- [x] simplevalue.go
- [x] tag.go
- [x] tag_test.go
