### PR TITLE
fix typo in example (use em)

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ if err := dm.Unmarshal(data, &v); err != nil {
 em, _ := cbor.EncOptions{}.EncModeWithTags(tags)
 
 // Marshal signedCWT with tag number.
-if data, err := cbor.Marshal(v); err != nil {
+if data, err := em.Marshal(v); err != nil {
 	return err
 }
 ```


### PR DESCRIPTION
while reading the documentation/example i spottet this typo. you probably wanted to use em to do the encoding with tags 

