### PR TITLE
Update docs for cbor v2.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Codec passed multiple confidential security assessments in 2022.  No vulnerabili
 
 __🗜️&nbsp; Data Size__
 
-Struct tags (`toarray`, `keyasint`, `omitempty`, `omitzero`) automatically reduce size of encoded structs. Encoding optionally shrinks float64→32→16 when values fit.
+Struct tag options (`toarray`, `keyasint`, `omitempty`, `omitzero`) automatically reduce size of encoded structs. Encoding optionally shrinks float64→32→16 when values fit.
 
 __:jigsaw:&nbsp; Usability__
 
@@ -139,11 +139,11 @@ In contrast, some codecs can crash or use excessive resources while decoding bad
 >
 > </details>
 
-### Smaller Encodings with Struct Tags
+### Smaller Encodings with Struct Tag Options
 
 Struct tags automatically reduce encoded size of structs and improve speed.
 
-We can write less code by using struct tags:
+We can write less code by using struct tag options:
 - `toarray`: encode without field names (decode back to original struct)
 - `keyasint`: encode field names as integers (decode back to original struct)
 - `omitempty`: omit empty fields when encoding
@@ -351,7 +351,7 @@ err = em.MarshalToBuffer(v, &buf) // encode v to provided buf
 
 ### Struct Tags
 
-Struct tags (`toarray`, `keyasint`, `omitempty`, `omitzero`) reduce encoded size of structs.
+Struct tag options (`toarray`, `keyasint`, `omitempty`, `omitzero`) reduce encoded size of structs.
 
 <details><summary> 🔎&nbsp; Example encoding 3-level nested Go struct to 1 byte CBOR</summary><p/>
 
@@ -421,13 +421,13 @@ JSON: {"Foo":{"Qux":{}}}
 
 </details>
 
-<details><summary> 🔎&nbsp; Example using several struct tags</summary><p/>
+<details><summary> 🔎&nbsp; Example using struct tag options</summary><p/>
 	
 ![alt text](https://github.com/fxamacker/images/raw/master/cbor/v2.3.0/cbor_struct_tags_api.svg?sanitize=1 "CBOR API and Go Struct Tags")
 
 </details>
 
-Struct tags simplify use of CBOR-based protocols that require CBOR arrays or maps with integer keys.
+Struct tag options simplify use of CBOR-based protocols that require CBOR arrays or maps with integer keys.
 
 ### CBOR Tags
 
@@ -511,11 +511,24 @@ Default limits may need to be increased for systems handling very large data (e.
 
 ## Status
 
-v2.7.0 (June 23, 2024) adds features and improvements that help large projects (e.g. Kubernetes) use CBOR as an alternative to JSON and Protocol Buffers. Other improvements include speedups, improved memory use, bug fixes, new serialization options, etc.   It passed fuzz tests (5+ billion executions) and is production quality.
+v2.8.0 (March 30, 2025) is a small release primarily to add `omitzero` option to struct field tags and fix bugs.   It passed fuzz tests (billions of executions) and is production quality.
+
+v2.8.0 and v2.7.1 fixes these 3 functions (when called directly by user apps) to use same error handling on bad inputs as `cbor.Unmarshal()`:
+- `ByteString.UnmarshalCBOR()`
+- `RawTag.UnmarshalCBOR()`
+- `SimpleValue.UnmarshalCBOR()`
+
+The above 3 `UnmarshalCBOR()` functions were initially created for internal use and are deprecated now, so please use `Unmarshal()` or `UnmarshalFirst()` instead.  To preserve backward compatibility, these deprecated functions were added to fuzz tests and will not be removed in v2.
+
+The minimum version of Go required to build:
+- v2.8.0 requires go 1.20.
+- v2.7.1 and older releases require go 1.17.
 
 For more details, see [release notes](https://github.com/fxamacker/cbor/releases).
 
-### Prior Release
+### Prior Releases
+
+v2.7.0 (June 23, 2024) adds features and improvements that help large projects (e.g. Kubernetes) use CBOR as an alternative to JSON and Protocol Buffers. Other improvements include speedups, improved memory use, bug fixes, new serialization options, etc.   It passed fuzz tests (5+ billion executions) and is production quality.
 
 [v2.6.0](https://github.com/fxamacker/cbor/releases/tag/v2.6.0) (February 2024) adds important new features, optimizations, and bug fixes. It is especially useful to systems that need to convert data between CBOR and JSON.  New options and optimizations improve handling of bignum, integers, maps, and strings.
 

--- a/doc.go
+++ b/doc.go
@@ -2,15 +2,15 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 /*
-Package cbor is a modern CBOR codec (RFC 8949 & RFC 7049) with CBOR tags,
+Package cbor is a modern CBOR codec (RFC 8949 & RFC 8742) with CBOR tags,
 Go struct tags (toarray/keyasint/omitempty), Core Deterministic Encoding,
 CTAP2, Canonical CBOR, float64->32->16, and duplicate map key detection.
 
 Encoding options allow "preferred serialization" by encoding integers and floats
 to their smallest forms (e.g. float16) when values fit.
 
-Struct tags like "keyasint", "toarray" and "omitempty" make CBOR data smaller
-and easier to use with structs.
+Struct tags "keyasint", "toarray", "omitempty", and "omitzero" reduce encoding size
+and reduce programming effort.
 
 For example, "toarray" tag makes struct fields encode to CBOR array elements.  And
 "keyasint" makes a field encode to an element of CBOR map with specified int key.
@@ -23,11 +23,19 @@ The Quick Start guide is at https://github.com/fxamacker/cbor#quick-start
 
 Function signatures identical to encoding/json include:
 
-	Marshal, Unmarshal, NewEncoder, NewDecoder, (*Encoder).Encode, (*Decoder).Decode.
+	Marshal, Unmarshal, NewEncoder, NewDecoder, (*Encoder).Encode, (*Decoder).Decode
 
 Standard interfaces include:
 
-	BinaryMarshaler, BinaryUnmarshaler, Marshaler, and Unmarshaler.
+	BinaryMarshaler, BinaryUnmarshaler, Marshaler, and Unmarshaler
+
+Diagnostic functions translate CBOR data item into Diagnostic Notation:
+
+	Diagnose, DiagnoseFirst
+
+Functions that simplify using CBOR Sequences (RFC 8742) include:
+
+	UnmarshalFirst
 
 Custom encoding and decoding is possible by implementing standard interfaces for
 user-defined Go types.
@@ -50,19 +58,19 @@ Modes are intended to be reused and are safe for concurrent use.
 
 EncMode and DecMode Interfaces
 
-	    // EncMode interface uses immutable options and is safe for concurrent use.
-	    type EncMode interface {
+	// EncMode interface uses immutable options and is safe for concurrent use.
+	type EncMode interface {
 		Marshal(v interface{}) ([]byte, error)
 		NewEncoder(w io.Writer) *Encoder
 		EncOptions() EncOptions  // returns copy of options
-	    }
+	}
 
-	    // DecMode interface uses immutable options and is safe for concurrent use.
-	    type DecMode interface {
+	// DecMode interface uses immutable options and is safe for concurrent use.
+	type DecMode interface {
 		Unmarshal(data []byte, v interface{}) error
 		NewDecoder(r io.Reader) *Decoder
 		DecOptions() DecOptions  // returns copy of options
-	    }
+	}
 
 Using Default Encoding Mode
 
@@ -77,6 +85,16 @@ Using Default Decoding Mode
 
 	decoder := cbor.NewDecoder(r)
 	err = decoder.Decode(&v)
+
+ Using Default Mode of UnmarshalFirst to Decode CBOR Sequences
+
+	// Decode the first CBOR data item and return remaining bytes:
+	rest, err = cbor.UnmarshalFirst(b, &v)   // decode []byte b to v
+
+Using Extended Diagnostic Notation (EDN) to represent CBOR data
+
+	// Translate the first CBOR data item into text and return remaining bytes.
+	text, rest, err = cbor.DiagnoseFirst(b)  // decode []byte b to text
 
 Creating and Using Encoding Modes
 

--- a/doc.go
+++ b/doc.go
@@ -86,7 +86,7 @@ Using Default Decoding Mode
 	decoder := cbor.NewDecoder(r)
 	err = decoder.Decode(&v)
 
- Using Default Mode of UnmarshalFirst to Decode CBOR Sequences
+Using Default Mode of UnmarshalFirst to Decode CBOR Sequences
 
 	// Decode the first CBOR data item and return remaining bytes:
 	rest, err = cbor.UnmarshalFirst(b, &v)   // decode []byte b to v

--- a/doc.go
+++ b/doc.go
@@ -3,13 +3,13 @@
 
 /*
 Package cbor is a modern CBOR codec (RFC 8949 & RFC 8742) with CBOR tags,
-Go struct tags (toarray/keyasint/omitempty), Core Deterministic Encoding,
+Go struct tag options (toarray/keyasint/omitempty/omitzero), Core Deterministic Encoding,
 CTAP2, Canonical CBOR, float64->32->16, and duplicate map key detection.
 
 Encoding options allow "preferred serialization" by encoding integers and floats
 to their smallest forms (e.g. float16) when values fit.
 
-Struct tags "keyasint", "toarray", "omitempty", and "omitzero" reduce encoding size
+Struct tag options "keyasint", "toarray", "omitempty", and "omitzero" reduce encoding size
 and reduce programming effort.
 
 For example, "toarray" tag makes struct fields encode to CBOR array elements.  And
@@ -129,7 +129,7 @@ Decoding Options: https://github.com/fxamacker/cbor#decoding-options
 Struct tags like `cbor:"name,omitempty"` and `json:"name,omitempty"` work as expected.
 If both struct tags are specified then `cbor` is used.
 
-Struct tags like "keyasint", "toarray", "omitempty", and "omitzero" make it easy to use
+Struct tag options like "keyasint", "toarray", "omitempty", and "omitzero" make it easy to use
 very compact formats like COSE and CWT (CBOR Web Tokens) with structs.
 
 The "omitzero" option omits zero values from encoding, matching
@@ -142,7 +142,7 @@ makes struct fields encode to elements of CBOR map with int keys.
 
 https://raw.githubusercontent.com/fxamacker/images/master/cbor/v2.0.0/cbor_easy_api.png
 
-Struct tags are listed at https://github.com/fxamacker/cbor#struct-tags-1
+Struct tag options are listed at https://github.com/fxamacker/cbor#struct-tags-1
 
 # Tests and Fuzzing
 

--- a/example_test.go
+++ b/example_test.go
@@ -82,7 +82,7 @@ func ExampleMarshal_canonical() {
 	// a46341676504644d616c65f4644e616d656543616e647968436f6e7461637473a2634a6f656c3232322d3232322d32323232644d6172796c3131312d3131312d31313131
 }
 
-// This example uses "toarray" struct tag to encode struct as CBOR array.
+// This example uses "toarray" struct tag option to encode struct as CBOR array.
 func ExampleMarshal_toarray() {
 	type Record struct {
 		_           struct{} `cbor:",toarray"`
@@ -100,7 +100,7 @@ func ExampleMarshal_toarray() {
 	// 836763757272656e74615601
 }
 
-// This example uses "keyasint" struct tag to encode struct's fiele names as integer.
+// This example uses "keyasint" struct tag option to encode struct's field names as integer.
 // This feautre is very useful in handling COSE, CWT, SenML data.
 func ExampleMarshal_keyasint() {
 	type Record struct {
@@ -353,7 +353,7 @@ func ExampleDecoder() {
 }
 
 func Example_cWT() {
-	// Use "keyasint" struct tag to encode/decode struct to/from CBOR map.
+	// Use "keyasint" struct tag option to encode/decode struct to/from CBOR map.
 	type claims struct {
 		Iss string `cbor:"1,keyasint"`
 		Sub string `cbor:"2,keyasint"`
@@ -403,14 +403,14 @@ func Example_cWTWithDupMapKeyOption() {
 }
 
 func Example_signedCWT() {
-	// Use "keyasint" struct tag to encode/decode struct to/from CBOR map.
+	// Use "keyasint" struct tag option to encode/decode struct to/from CBOR map.
 	// Partial COSE header definition
 	type coseHeader struct {
 		Alg int    `cbor:"1,keyasint,omitempty"`
 		Kid []byte `cbor:"4,keyasint,omitempty"`
 		IV  []byte `cbor:"5,keyasint,omitempty"`
 	}
-	// Use "toarray" struct tag to encode/decode struct to/from CBOR array.
+	// Use "toarray" struct tag option to encode/decode struct to/from CBOR array.
 	type signedCWT struct {
 		_           struct{} `cbor:",toarray"`
 		Protected   []byte
@@ -433,14 +433,14 @@ func Example_signedCWT() {
 }
 
 func Example_signedCWTWithTag() {
-	// Use "keyasint" struct tag to encode/decode struct to/from CBOR map.
+	// Use "keyasint" struct tag option to encode/decode struct to/from CBOR map.
 	// Partial COSE header definition
 	type coseHeader struct {
 		Alg int    `cbor:"1,keyasint,omitempty"`
 		Kid []byte `cbor:"4,keyasint,omitempty"`
 		IV  []byte `cbor:"5,keyasint,omitempty"`
 	}
-	// Use "toarray" struct tag to encode/decode struct to/from CBOR array.
+	// Use "toarray" struct tag option to encode/decode struct to/from CBOR array.
 	type signedCWT struct {
 		_           struct{} `cbor:",toarray"`
 		Protected   []byte
@@ -478,7 +478,7 @@ func Example_signedCWTWithTag() {
 }
 
 func Example_cOSE() {
-	// Use "keyasint" struct tag to encode/decode struct to/from CBOR map.
+	// Use "keyasint" struct tag option to encode/decode struct to/from CBOR map.
 	// Use cbor.RawMessage to delay unmarshaling (CrvOrNOrK's data type depends on Kty's value).
 	type coseKey struct {
 		Kty       int             `cbor:"1,keyasint,omitempty"`
@@ -507,7 +507,7 @@ func Example_cOSE() {
 }
 
 func Example_senML() {
-	// Use "keyasint" struct tag to encode/decode struct to/from CBOR map.
+	// Use "keyasint" struct tag option to encode/decode struct to/from CBOR map.
 	type SenMLRecord struct {
 		BaseName    string  `cbor:"-2,keyasint,omitempty"`
 		BaseTime    float64 `cbor:"-3,keyasint,omitempty"`


### PR DESCRIPTION
Update README.md:

- Update ["Status" section](https://github.com/fxamacker/cbor?tab=readme-ov-file#status).

- Replace "struct tags" with "struct tag options" when referring to options.

Update doc.go:

- Mention `omitzero` option (for struct tags) in more places.  Also mention `Diagnose`, `DiagnoseFirst`, `UnmarshalFirst`, etc. added in prior releases.

- Add example using `UnmarshalFirst` to show support for trailing bytes (extraneous data) typically found in CBOR Sequences ([RFC 8742](https://www.rfc-editor.org/rfc/rfc8742.html)).

- Add example using `DiagnoseFirst` to show support for representing binary CBOR data item in Extended Diagnostic Notation (human-readable text inspired by JSON).

- Replace "struct tags" with "struct tag options" when referring to options.

Update example_test.go

- Replace "struct tags" with "struct tag options" when referring to options.
