### PR TITLE
Improve UnknownFieldError message

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -207,11 +207,13 @@ func (e *DupMapKeyError) Error() string {
 
 // UnknownFieldError describes detected unknown field in CBOR map when decoding to Go struct.
 type UnknownFieldError struct {
-	Index int
+	Struct string // name of the struct being decoded
+	Field  string // field of the CBOR map that was unexpected
+	Index  int    // index of the field in the CBOR map
 }
 
 func (e *UnknownFieldError) Error() string {
-	return fmt.Sprintf("cbor: found unknown field at map element index %d", e.Index)
+	return fmt.Sprintf("cbor: found unknown field: struct '%s' has no field '%s', at map element index %d", e.Struct, e.Field, e.Index)
 }
 
 // UnacceptableDataItemError is returned when unmarshaling a CBOR input that contains a data item
@@ -2617,8 +2619,8 @@ MapEntryLoop:
 		var k any
 
 		t := d.nextCBORType()
+		var keyBytes []byte
 		if t == cborTypeTextString || (t == cborTypeByteString && d.dm.fieldNameByteString == FieldNameByteStringAllowed) {
-			var keyBytes []byte
 			if t == cborTypeTextString {
 				keyBytes, lastErr = d.parseTextString()
 				if lastErr != nil {
@@ -2767,7 +2769,7 @@ MapEntryLoop:
 
 		if f == nil {
 			if errOnUnknownField {
-				err = &UnknownFieldError{j}
+				err = &UnknownFieldError{Struct: tInfo.typ.String(), Field: string(keyBytes), Index: j}
 				d.skip() // Skip value
 				j++
 				// skip the rest of the map

--- a/decode_test.go
+++ b/decode_test.go
@@ -6825,7 +6825,7 @@ func TestExtraErrorCondUnknownField(t *testing.T) {
 			name:         "CBOR map unknown field with ExtraDecErrorUnknownField",
 			data:         hexDecode("a461416161614261626143616361446164"), // map[string]string{"A": "a", "B": "b", "C": "c", "D": "d"}
 			dm:           dmUnknownFieldError,
-			wantErrorMsg: "cbor: found unknown field at map element index 3",
+			wantErrorMsg: "cbor: found unknown field: struct 'cbor.s' has no field 'D', at map element index 3",
 		},
 	}
 	for _, tc := range testCases {
@@ -6885,7 +6885,7 @@ func TestStreamExtraErrorCondUnknownField(t *testing.T) {
 	}
 
 	data := hexDecode("a461416161614461646142616261436163a3614161616142616261436163") // map[string]string{"A": "a", "D": "d", "B": "b", "C": "c"}, map[string]string{"A": "a", "B": "b", "C": "c"}
-	wantErrorMsg := "cbor: found unknown field at map element index 1"
+	wantErrorMsg := "cbor: found unknown field: struct 'cbor.s' has no field 'D', at map element index 1"
 	wantObj := s{A: "a", B: "b", C: "c"}
 
 	dmUnknownFieldError, _ := DecOptions{ExtraReturnErrors: ExtraDecErrorUnknownField}.DecMode()


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description

Improves the error message for UnknownFieldError when a CBOR map does not match with the Go struct currently being decoded into. The message now includes struct and field names, allowing simpler debugging of issues that can occur due to mismatched struct types.
<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

#### PR Was Proposed and Welcomed in Currently Open Issue

- [x] This PR was proposed and welcomed by maintainer(s) in issue #668
- [x] Closes or Updates Issue #668

#### Checklist (for code PR only, ignore for docs PR)

- [ ] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [ ] Pass all lint checks in CI (goimports, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

