### PR TITLE
Add optional support for json.Marshaler and json.Unmarshaler via transcoding

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -37,6 +37,7 @@ const (
 	specialTypeIface
 	specialTypeTag
 	specialTypeTime
+	specialTypeJSONUnmarshalerIface
 )
 
 type typeInfo struct {
@@ -75,6 +76,8 @@ func newTypeInfo(t reflect.Type) *typeInfo {
 		tInfo.spclType = specialTypeUnexportedUnmarshalerIface
 	} else if reflect.PointerTo(t).Implements(typeUnmarshaler) {
 		tInfo.spclType = specialTypeUnmarshalerIface
+	} else if reflect.PointerTo(t).Implements(typeJSONUnmarshaler) {
+		tInfo.spclType = specialTypeJSONUnmarshalerIface
 	}
 
 	switch k {

--- a/common.go
+++ b/common.go
@@ -5,6 +5,7 @@ package cbor
 
 import (
 	"fmt"
+	"io"
 	"strconv"
 )
 
@@ -179,4 +180,12 @@ func validBuiltinTag(tagNum uint64, contentHead byte) error {
 	}
 
 	return nil
+}
+
+// Transcoder is a scheme for transcoding a single CBOR encoded data item to or from a different
+// data format.
+type Transcoder interface {
+	// Transcode reads the data item in its source format from a Reader and writes a
+	// corresponding representation in its destination format to a Writer.
+	Transcode(dst io.Writer, src io.Reader) error
 }

--- a/example_transcoding_test.go
+++ b/example_transcoding_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+type TranscoderFunc func(io.Writer, io.Reader) error
+
+func (f TranscoderFunc) Transcode(w io.Writer, r io.Reader) error {
+	return f(w, r)
+}
+
+func ExampleTranscoder_fromJSON() {
+	enc, _ := cbor.EncOptions{
+		JSONMarshalerTranscoder: TranscoderFunc(func(w io.Writer, r io.Reader) error {
+			d := json.NewDecoder(r)
+
+			for {
+				token, err := d.Token()
+				if err == io.EOF {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				switch token {
+				case json.Delim('['):
+					if _, err := w.Write([]byte{0x9f}); err != nil {
+						return err
+					}
+				case json.Delim('{'):
+					if _, err := w.Write([]byte{0xbf}); err != nil {
+						return err
+					}
+				case json.Delim(']'), json.Delim('}'):
+					if _, err := w.Write([]byte{0xff}); err != nil {
+						return err
+					}
+				default:
+					b, err := cbor.Marshal(token)
+					if err != nil {
+						return err
+					}
+					if _, err := w.Write(b); err != nil {
+						return err
+					}
+				}
+			}
+		}),
+	}.EncMode()
+
+	got, _ := enc.Marshal(json.RawMessage(`{"a": [true, "z", {"y": 3.14}], "b": {"c": null}}`))
+	diag, _ := cbor.Diagnose(got)
+	fmt.Println(diag)
+	// Output: {_ "a": [_ true, "z", {_ "y": 3.14}], "b": {_ "c": null}}
+}


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description

Recognition of types implementing these interfaces is important for users requiring drop-in compatibility with `encoding/json`. Without it, if a type implements the JSON interfaces without also implementing the corresponding CBOR interfaces, its JSON and CBOR representations can have substantial structural differences.

Consider what can happen with a type like https://pkg.go.dev/k8s.io/apimachinery/pkg/util/intstr#IntOrString if it were to only implement `json.Marshaler` and `json.Unmarshaler` (and not `cbor.Marshaler` or `cbor.Unmarshaler`):

1. `ToJSON(IntOrString{Type: String, StrVal: "a"}) => "a"`
2. `FromJSON[any]("a") => string("a")`
3. `ToCBOR(string("a")) => 0x6161`
4. `FromCBOR[IntOrString](0x6161) => **error: can't unmarshal CBOR text string number to struct**`

With automatic transcoding, we can preserve the faithful roundtrip:

4. `FromCBOR[IntOrString](0x6161) => FromJSON[IntOrString](CBORToJSON(0x6161)) => FromJSON[IntOrString]("a") => IntOrString{Type: String, StrVal: "a"}`

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

#### PR Was Proposed and Welcomed in Currently Open Issue

- [x] This PR was proposed and welcomed by maintainer(s) in issue #677
- [x] Closes or Updates Issue #677

#### Checklist (for code PR only, ignore for docs PR)

- [x] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all lint checks in CI (goimports, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

