### PR TITLE
Use TextUnmarshaler on byte strings with ByteStringToStringAllowed.

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -10779,6 +10779,15 @@ func TestTextUnmarshalerMode(t *testing.T) {
 			in:   []byte("\x65hello"), // "hello"
 			want: testTextUnmarshaler("hello"),
 		},
+		{
+			name: "UnmarshalText is called for byte string with TextUnmarshalerTextString and ByteStringToStringAllowed",
+			opts: DecOptions{
+				TextUnmarshaler:    TextUnmarshalerTextString,
+				ByteStringToString: ByteStringToStringAllowed,
+			},
+			in:   []byte("\x45hello"), // 'hello'
+			want: testTextUnmarshaler("UnmarshalText"),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dm, err := tc.opts.DecMode()


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to fxamacker/cbor!
-->

### Description

Decode modes that allow unmarshaling CBOR byte strings into Go strings and recognize TextUnmarshalers should also allow unmarshaling CBOR byte strings into TextUnmarshalers. When interoperating with an encode mode that marshals Go strings to CBOR byte strings, this preserves roundtrippability of TextMarshaler -> CBOR text string -> Go string -> CBOR byte string -> TextUnmarshaler.

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

#### PR Was Proposed and Welcomed in Currently Open Issue

- [ ] This PR was proposed and welcomed by maintainer(s) in issue #___
- [x] Closes or Updates Issue #675 

#### Checklist (for code PR only, ignore for docs PR)

- [x] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all lint checks in CI (goimports, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

