### PR TITLE
Use actual negative zero in tests

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -2085,8 +2085,8 @@ var unmarshalFloatTests = []unmarshalFloatTest{
 	},
 	{
 		data:               mustHexDecode("f98000"),
-		wantInterfaceValue: float64(-0.0),                       //nolint:staticcheck // we know -0.0 is 0.0 in Go
-		wantValues:         []any{float32(-0.0), float64(-0.0)}, //nolint:staticcheck // we know -0.0 is 0.0 in Go
+		wantInterfaceValue: math.Copysign(0, -1),
+		wantValues:         []any{float32(math.Copysign(0, -1)), math.Copysign(0, -1)},
 	},
 	{
 		data:               mustHexDecode("f93c00"),


### PR DESCRIPTION
### Description

This actually fixes the negative zero issue in the tests rather than just ignoring it. For the origin of this see [here](https://github.com/fxamacker/cbor/pull/292#issuecomment-864589245).

I caught this by running the actual `staticcheck` binary, which seems to be higher quality than golangci-lint's version of staticcheck rules.

```
❯ staticcheck ./...
decode_test.go:2088:31: in Go, the floating-point literal '-0.0' is the same as '0.0', it does not produce a negative zero (SA4026)
decode_test.go:2089:37: in Go, the floating-point literal '-0.0' is the same as '0.0', it does not produce a negative zero (SA4026)
decode_test.go:2089:52: in Go, the floating-point literal '-0.0' is the same as '0.0', it does not produce a negative zero (SA4026)
decode_test.go:5250:4: field x is unused (U1000)
decode_test.go:5254:4: field y is unused (U1000)

❯ staticcheck -explain SA4026
Go constants cannot express negative zero

In IEEE 754 floating point math, zero has a sign and can be positive
or negative. This can be useful in certain numerical code.

Go constants, however, cannot express negative zero. This means that
the literals -0.0 and 0.0 have the same ideal value (zero) and
will both represent positive zero at runtime.

To explicitly and reliably create a negative zero, you can use the
math.Copysign function: math.Copysign(0, -1).

Available since
    2021.1

Online documentation
    https://staticcheck.dev/docs/checks#SA4026
```

<!-- For code contributions, please complete all the items below this line. -->
<!-- For documentation-only contributions, please delete everything below this line. -->

#### PR Was Proposed and Welcomed in Currently Open Issue

- [ ] This PR was proposed and welcomed by maintainer(s) in issue #___
- [ ] Closes or Updates Issue #___

#### Checklist (for code PR only, ignore for docs PR)

- [ ] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all lint checks in CI (goimports, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

