### PR TITLE
chore: export constants for external use

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -986,17 +986,17 @@ func (opts DecOptions) DecModeWithSharedTags(tags TagSet) (DecMode, error) { //n
 }
 
 const (
-	defaultMaxArrayElements = 131072
-	minMaxArrayElements     = 16
-	maxMaxArrayElements     = 2147483647
+	DefaultMaxArrayElements = 131072
+	MinMaxArrayElements     = 16
+	MaxMaxArrayElements     = 2147483647
 
-	defaultMaxMapPairs = 131072
-	minMaxMapPairs     = 16
-	maxMaxMapPairs     = 2147483647
+	DefaultMaxMapPairs = 131072
+	MinMaxMapPairs     = 16
+	MaxMaxMapPairs     = 2147483647
 
-	defaultMaxNestedLevels = 32
-	minMaxNestedLevels     = 4
-	maxMaxNestedLevels     = 65535
+	DefaultMaxNestedLevels = 32
+	MinMaxNestedLevels     = 4
+	MaxMaxNestedLevels     = 65535
 )
 
 var defaultSimpleValues = func() *SimpleValueRegistry {
@@ -1034,24 +1034,24 @@ func (opts DecOptions) decMode() (*decMode, error) { //nolint:gocritic // ignore
 	}
 
 	if opts.MaxNestedLevels == 0 {
-		opts.MaxNestedLevels = defaultMaxNestedLevels
-	} else if opts.MaxNestedLevels < minMaxNestedLevels || opts.MaxNestedLevels > maxMaxNestedLevels {
+		opts.MaxNestedLevels = DefaultMaxNestedLevels
+	} else if opts.MaxNestedLevels < MinMaxNestedLevels || opts.MaxNestedLevels > MaxMaxNestedLevels {
 		return nil, errors.New("cbor: invalid MaxNestedLevels " + strconv.Itoa(opts.MaxNestedLevels) +
-			" (range is [" + strconv.Itoa(minMaxNestedLevels) + ", " + strconv.Itoa(maxMaxNestedLevels) + "])")
+			" (range is [" + strconv.Itoa(MinMaxNestedLevels) + ", " + strconv.Itoa(MaxMaxNestedLevels) + "])")
 	}
 
 	if opts.MaxArrayElements == 0 {
-		opts.MaxArrayElements = defaultMaxArrayElements
-	} else if opts.MaxArrayElements < minMaxArrayElements || opts.MaxArrayElements > maxMaxArrayElements {
+		opts.MaxArrayElements = DefaultMaxArrayElements
+	} else if opts.MaxArrayElements < MinMaxArrayElements || opts.MaxArrayElements > MaxMaxArrayElements {
 		return nil, errors.New("cbor: invalid MaxArrayElements " + strconv.Itoa(opts.MaxArrayElements) +
-			" (range is [" + strconv.Itoa(minMaxArrayElements) + ", " + strconv.Itoa(maxMaxArrayElements) + "])")
+			" (range is [" + strconv.Itoa(MinMaxArrayElements) + ", " + strconv.Itoa(MaxMaxArrayElements) + "])")
 	}
 
 	if opts.MaxMapPairs == 0 {
-		opts.MaxMapPairs = defaultMaxMapPairs
-	} else if opts.MaxMapPairs < minMaxMapPairs || opts.MaxMapPairs > maxMaxMapPairs {
+		opts.MaxMapPairs = DefaultMaxMapPairs
+	} else if opts.MaxMapPairs < MinMaxMapPairs || opts.MaxMapPairs > MaxMaxMapPairs {
 		return nil, errors.New("cbor: invalid MaxMapPairs " + strconv.Itoa(opts.MaxMapPairs) +
-			" (range is [" + strconv.Itoa(minMaxMapPairs) + ", " + strconv.Itoa(maxMaxMapPairs) + "])")
+			" (range is [" + strconv.Itoa(MinMaxMapPairs) + ", " + strconv.Itoa(MaxMaxMapPairs) + "])")
 	}
 
 	if !opts.ExtraReturnErrors.valid() {

--- a/decode_test.go
+++ b/decode_test.go
@@ -5660,8 +5660,8 @@ func TestDecModeDefaultMaxMapPairs(t *testing.T) {
 		t.Errorf("DecMode() returned error %v", err)
 	} else {
 		maxMapPairs := dm.DecOptions().MaxMapPairs
-		if maxMapPairs != defaultMaxMapPairs {
-			t.Errorf("DecOptions().MaxMapPairs = %d, want %v", maxMapPairs, defaultMaxMapPairs)
+		if maxMapPairs != DefaultMaxMapPairs {
+			t.Errorf("DecOptions().MaxMapPairs = %d, want %v", maxMapPairs, DefaultMaxMapPairs)
 		}
 	}
 }
@@ -5701,8 +5701,8 @@ func TestDecModeDefaultMaxArrayElements(t *testing.T) {
 		t.Errorf("DecMode() returned error %v", err)
 	} else {
 		maxArrayElements := dm.DecOptions().MaxArrayElements
-		if maxArrayElements != defaultMaxArrayElements {
-			t.Errorf("DecOptions().MaxArrayElementsr = %d, want %v", maxArrayElements, defaultMaxArrayElements)
+		if maxArrayElements != DefaultMaxArrayElements {
+			t.Errorf("DecOptions().MaxArrayElementsr = %d, want %v", maxArrayElements, DefaultMaxArrayElements)
 		}
 	}
 }

--- a/encode.go
+++ b/encode.go
@@ -903,33 +903,33 @@ var defaultEncMode, _ = EncOptions{}.encMode()
 // non-Marshaler object that exceeds default limits.
 var (
 	marshalerForbidIndefLengthForbidTagsDecMode = decMode{
-		maxNestedLevels:  maxMaxNestedLevels,
-		maxArrayElements: maxMaxArrayElements,
-		maxMapPairs:      maxMaxMapPairs,
+		maxNestedLevels:  MaxMaxNestedLevels,
+		maxArrayElements: MaxMaxArrayElements,
+		maxMapPairs:      MaxMaxMapPairs,
 		indefLength:      IndefLengthForbidden,
 		tagsMd:           TagsForbidden,
 	}
 
 	marshalerAllowIndefLengthForbidTagsDecMode = decMode{
-		maxNestedLevels:  maxMaxNestedLevels,
-		maxArrayElements: maxMaxArrayElements,
-		maxMapPairs:      maxMaxMapPairs,
+		maxNestedLevels:  MaxMaxNestedLevels,
+		maxArrayElements: MaxMaxArrayElements,
+		maxMapPairs:      MaxMaxMapPairs,
 		indefLength:      IndefLengthAllowed,
 		tagsMd:           TagsForbidden,
 	}
 
 	marshalerForbidIndefLengthAllowTagsDecMode = decMode{
-		maxNestedLevels:  maxMaxNestedLevels,
-		maxArrayElements: maxMaxArrayElements,
-		maxMapPairs:      maxMaxMapPairs,
+		maxNestedLevels:  MaxMaxNestedLevels,
+		maxArrayElements: MaxMaxArrayElements,
+		maxMapPairs:      MaxMaxMapPairs,
 		indefLength:      IndefLengthForbidden,
 		tagsMd:           TagsAllowed,
 	}
 
 	marshalerAllowIndefLengthAllowTagsDecMode = decMode{
-		maxNestedLevels:  maxMaxNestedLevels,
-		maxArrayElements: maxMaxArrayElements,
-		maxMapPairs:      maxMaxMapPairs,
+		maxNestedLevels:  MaxMaxNestedLevels,
+		maxArrayElements: MaxMaxArrayElements,
+		maxMapPairs:      MaxMaxMapPairs,
 		indefLength:      IndefLengthAllowed,
 		tagsMd:           TagsAllowed,
 	}
@@ -956,9 +956,9 @@ func getMarshalerDecMode(indefLength IndefLengthMode, tagsMd TagsMode) *decMode 
 		// This should never happen, unless we add new options to
 		// IndefLengthMode or TagsMode without updating this function.
 		return &decMode{
-			maxNestedLevels:  maxMaxNestedLevels,
-			maxArrayElements: maxMaxArrayElements,
-			maxMapPairs:      maxMaxMapPairs,
+			maxNestedLevels:  MaxMaxNestedLevels,
+			maxArrayElements: MaxMaxArrayElements,
+			maxMapPairs:      MaxMaxMapPairs,
 			indefLength:      indefLength,
 			tagsMd:           tagsMd,
 		}


### PR DESCRIPTION
### Description

in some cases it is specially useful to know what are the maximum values allowed by this package. for example here:

https://github.com/kubernetes/kubernetes/pull/135340

we had to copy the values instead of referring to them. this broads the public scope of this package, if we don't want this then please feel free to close or suggest another approach.


#### PR Was Proposed and Welcomed in Currently Open Issue

- [ ] This PR was proposed and welcomed by maintainer(s) in issue #___
- [ ] Closes or Updates Issue #___

#### Checklist (for code PR only, ignore for docs PR)

- [ ] Include unit tests that cover the new code
- [x] Pass all unit tests 
- [x] Pass all lint checks in CI (goimports, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.  
      Last line of each commit message should be in this format:  
      Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify 
      the Developer Certificate of Origin 1.1.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

