### PR TITLE
Small bugfixes, defensive checks, and improvements

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -175,7 +175,7 @@ func (x *bytewiseFieldSorter) Swap(i, j int) {
 }
 
 func (x *bytewiseFieldSorter) Less(i, j int) bool {
-	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) <= 0
+	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) < 0
 }
 
 type lengthFirstFieldSorter struct {
@@ -194,7 +194,7 @@ func (x *lengthFirstFieldSorter) Less(i, j int) bool {
 	if len(x.fields[i].cborName) != len(x.fields[j].cborName) {
 		return len(x.fields[i].cborName) < len(x.fields[j].cborName)
 	}
-	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) <= 0
+	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) < 0
 }
 
 func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {

--- a/decode.go
+++ b/decode.go
@@ -1832,6 +1832,13 @@ func (d *decoder) parseToTime() (time.Time, bool, error) {
 			return time.Time{}, true, nil
 		}
 		seconds, fractional := math.Modf(f)
+		if seconds > math.MaxInt64 || seconds < math.MinInt64 {
+			return time.Time{}, false, &UnmarshalTypeError{
+				CBORType: t.String(),
+				GoType:   typeTime.String(),
+				errorMsg: fmt.Sprintf("%v overflows Go's int64", f),
+			}
+		}
 		return time.Unix(int64(seconds), int64(fractional*1e9)), true, nil
 
 	default:

--- a/decode_test.go
+++ b/decode_test.go
@@ -4377,6 +4377,18 @@ func TestDecodeInvalidTagTime(t *testing.T) {
 			wantErrorMsg:  "cbor: cannot unmarshal negative integer into Go value of type time.Time (-18446744073709551616 overflows Go's int64)",
 		},
 		{
+			name:          "tag 1 with positive float64 overflow",
+			data:          mustHexDecode("c1fb4415af1d78b58c40"), // 1(1e+20)
+			decodeToTypes: []reflect.Type{typeIntf, typeTime},
+			wantErrorMsg:  "overflows Go's int64",
+		},
+		{
+			name:          "tag 1 with negative float64 overflow",
+			data:          mustHexDecode("c1fbc415af1d78b58c40"), // 1(-1e+20)
+			decodeToTypes: []reflect.Type{typeIntf, typeTime},
+			wantErrorMsg:  "overflows Go's int64",
+		},
+		{
 			name:          "tag 1 with string content",
 			data:          mustHexDecode("c174323031332d30332d32315432303a30343a30305a"),
 			decodeToTypes: []reflect.Type{typeIntf, typeTime},

--- a/diagnose.go
+++ b/diagnose.go
@@ -605,7 +605,7 @@ func (di *diagnose) encodeTextString(val string, quote byte) error {
 
 		c, size := utf8.DecodeRuneInString(val[i:])
 		switch {
-		case c == utf8.RuneError:
+		case c == utf8.RuneError && size == 1:
 			return &SemanticError{"cbor: invalid UTF-8 string"}
 
 		case c < utf16SurrSelf:

--- a/diagnose_test.go
+++ b/diagnose_test.go
@@ -608,6 +608,12 @@ func TestDiagnoseTextString(t *testing.T) {
 			},
 		},
 		{
+			name:     "valid U+FFFD replacement character in text string",
+			data:     mustHexDecode("63efbfbd"),
+			wantDiag: `"\ufffd"`,
+			opts:     &DiagOptions{},
+		},
+		{
 			name:     "indefinite-length text string with no chunks",
 			data:     mustHexDecode("7fff"),
 			wantDiag: `""_`,

--- a/encode.go
+++ b/encode.go
@@ -1431,7 +1431,7 @@ func (x *bytewiseKeyValueSorter) Swap(i, j int) {
 
 func (x *bytewiseKeyValueSorter) Less(i, j int) bool {
 	kvi, kvj := x.kvs[i], x.kvs[j]
-	return bytes.Compare(x.data[kvi.offset:kvi.valueOffset], x.data[kvj.offset:kvj.valueOffset]) <= 0
+	return bytes.Compare(x.data[kvi.offset:kvi.valueOffset], x.data[kvj.offset:kvj.valueOffset]) < 0
 }
 
 type lengthFirstKeyValueSorter struct {
@@ -1452,7 +1452,7 @@ func (x *lengthFirstKeyValueSorter) Less(i, j int) bool {
 	if keyLengthDifference := (kvi.valueOffset - kvi.offset) - (kvj.valueOffset - kvj.offset); keyLengthDifference != 0 {
 		return keyLengthDifference < 0
 	}
-	return bytes.Compare(x.data[kvi.offset:kvi.valueOffset], x.data[kvj.offset:kvj.valueOffset]) <= 0
+	return bytes.Compare(x.data[kvi.offset:kvi.valueOffset], x.data[kvj.offset:kvj.valueOffset]) < 0
 }
 
 var keyValuePool = sync.Pool{}

--- a/stream.go
+++ b/stream.go
@@ -272,7 +272,9 @@ type RawMessage []byte
 // MarshalCBOR returns m or CBOR nil if m is nil.
 func (m RawMessage) MarshalCBOR() ([]byte, error) {
 	if len(m) == 0 {
-		return cborNil, nil
+		b := make([]byte, len(cborNil))
+		copy(b, cborNil)
+		return b, nil
 	}
 	return m, nil
 }

--- a/structfields.go
+++ b/structfields.go
@@ -48,7 +48,7 @@ func (x *indexFieldSorter) Less(i, j int) bool {
 			return iIdx[k] < jIdx[k]
 		}
 	}
-	return len(iIdx) <= len(jIdx)
+	return len(iIdx) < len(jIdx)
 }
 
 // nameLevelAndTagFieldSorter sorts fields by field name, idx depth, and presence of tag.


### PR DESCRIPTION
This PR fixes 4 minor issues found during refactoring:

- [Fix diagnostic functions rejecting valid U+FFFD](https://github.com/fxamacker/cbor/commit/b6c503c28d32070bf3391ac53d6ca3ffb03e745a)
- [Use strict weak ordering for struct fields and map keys](https://github.com/fxamacker/cbor/commit/1381263c394028da8d7512dd823b7aed859b8f56)
- [Add bounds check for decoding epoch time from floats](https://github.com/fxamacker/cbor/commit/5d9ad8fe2145f1a374edd445a914738832b552d9)
- [Return a copy of cborNil from RawMessage.MarshalCBOR](https://github.com/fxamacker/cbor/commit/cfc9720d87e2256bf0e107f1ea6590b646f32428)

NOTE: It is generally good practice to avoid using floating point to store epoch time for obvious reasons (even when not using CBOR).