### PR TITLE
Refactor parseMapToStruct(), getDecodingStructType(), getEncodingStructType(), and field struct

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -92,10 +92,11 @@ func newTypeInfo(t reflect.Type) *typeInfo {
 }
 
 type decodingStructType struct {
-	fields             fields
-	fieldIndicesByName map[string]int
-	err                error
-	toArray            bool
+	fields               fields
+	fieldIndicesByName   map[string]int
+	fieldIndicesByIntKey map[int64]int
+	err                  error
+	toArray              bool
 }
 
 func getDecodingStructType(t reflect.Type) *decodingStructType {
@@ -122,21 +123,29 @@ func getDecodingStructType(t reflect.Type) *decodingStructType {
 	}
 
 	fieldIndicesByName := make(map[string]int, len(flds))
+	var fieldIndicesByIntKey map[int64]int
 	for i, fld := range flds {
 		if _, ok := fieldIndicesByName[fld.name]; ok {
 			errs = append(errs, fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, fld.name))
 			continue
 		}
 		fieldIndicesByName[fld.name] = i
+		if fld.keyAsInt {
+			if fieldIndicesByIntKey == nil {
+				fieldIndicesByIntKey = make(map[int64]int, len(flds))
+			}
+			fieldIndicesByIntKey[fld.nameAsInt] = i
+		}
 	}
 
 	err := errors.Join(errs...)
 
 	structType := &decodingStructType{
-		fields:             flds,
-		fieldIndicesByName: fieldIndicesByName,
-		err:                err,
-		toArray:            toArray,
+		fields:               flds,
+		fieldIndicesByName:   fieldIndicesByName,
+		fieldIndicesByIntKey: fieldIndicesByIntKey,
+		err:                  err,
+		toArray:              toArray,
 	}
 	decodingStructTypeCache.Store(t, structType)
 	return structType

--- a/cache.go
+++ b/cache.go
@@ -92,9 +92,9 @@ func newTypeInfo(t reflect.Type) *typeInfo {
 }
 
 type decodingStructType struct {
-	fields               fields
-	fieldIndicesByName   map[string]int
-	fieldIndicesByIntKey map[int64]int
+	fields               decodingFields
+	fieldIndicesByName   map[string]int // Only populated if toArray is false
+	fieldIndicesByIntKey map[int64]int  // Only populated if toArray is false
 	err                  error
 	toArray              bool
 }
@@ -119,39 +119,43 @@ func getDecodingStructType(t reflect.Type) (*decodingStructType, error) {
 	fieldIndicesByName := make(map[string]int, len(flds))
 	var fieldIndicesByIntKey map[int64]int
 
-	for i := 0; i < len(flds); i++ {
-		if flds[i].keyAsInt {
-			nameAsInt, numErr := strconv.Atoi(flds[i].name)
+	decFlds := make(decodingFields, len(flds))
+	for i, f := range flds {
+		if f.keyAsInt {
+			nameAsInt, numErr := strconv.Atoi(f.name)
 			if numErr != nil {
 				structType := &decodingStructType{
-					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+					err: errors.New("cbor: failed to parse field name \"" + f.name + "\" to int (" + numErr.Error() + ")"),
 				}
 				decodingStructTypeCache.Store(t, structType)
 				return nil, structType.err
 			}
-			flds[i].nameAsInt = int64(nameAsInt)
+			f.nameAsInt = int64(nameAsInt)
 		}
 
-		if _, ok := fieldIndicesByName[flds[i].name]; ok {
+		if _, ok := fieldIndicesByName[f.name]; ok {
 			structType := &decodingStructType{
-				err: fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, flds[i].name),
+				err: fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, f.name),
 			}
 			decodingStructTypeCache.Store(t, structType)
 			return nil, structType.err
 		}
-		fieldIndicesByName[flds[i].name] = i
-		if flds[i].keyAsInt {
+		fieldIndicesByName[f.name] = i
+		if f.keyAsInt {
 			if fieldIndicesByIntKey == nil {
 				fieldIndicesByIntKey = make(map[int64]int, len(flds))
 			}
-			fieldIndicesByIntKey[flds[i].nameAsInt] = i
+			fieldIndicesByIntKey[f.nameAsInt] = i
 		}
 
-		flds[i].typInfo = getTypeInfo(flds[i].typ)
+		decFlds[i] = &decodingField{
+			field:   *f,
+			typInfo: getTypeInfo(f.typ),
+		}
 	}
 
 	structType := &decodingStructType{
-		fields:               flds,
+		fields:               decFlds,
 		fieldIndicesByName:   fieldIndicesByName,
 		fieldIndicesByIntKey: fieldIndicesByIntKey,
 	}
@@ -160,24 +164,28 @@ func getDecodingStructType(t reflect.Type) (*decodingStructType, error) {
 }
 
 func getDecodingStructToArrayType(t reflect.Type, flds fields) (*decodingStructType, error) {
-	for i := 0; i < len(flds); i++ {
+	decFlds := make(decodingFields, len(flds))
+	for i, f := range flds {
 		// nameAsInt is set in getFields() except for fields with an unparsable tagged name.
 		// Atoi() is called here to catch and save parsing errors.
-		if flds[i].keyAsInt && flds[i].nameAsInt == 0 {
-			if _, numErr := strconv.Atoi(flds[i].name); numErr != nil {
+		if f.keyAsInt && f.nameAsInt == 0 {
+			if _, numErr := strconv.Atoi(f.name); numErr != nil {
 				structType := &decodingStructType{
-					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+					err: errors.New("cbor: failed to parse field name \"" + f.name + "\" to int (" + numErr.Error() + ")"),
 				}
 				decodingStructTypeCache.Store(t, structType)
 				return nil, structType.err
 			}
 		}
 
-		flds[i].typInfo = getTypeInfo(flds[i].typ)
+		decFlds[i] = &decodingField{
+			field:   *f,
+			typInfo: getTypeInfo(f.typ),
+		}
 	}
 
 	structType := &decodingStructType{
-		fields:  flds,
+		fields:  decFlds,
 		toArray: true,
 	}
 	decodingStructTypeCache.Store(t, structType)
@@ -185,15 +193,15 @@ func getDecodingStructToArrayType(t reflect.Type, flds fields) (*decodingStructT
 }
 
 type encodingStructType struct {
-	fields             fields
-	bytewiseFields     fields
-	lengthFirstFields  fields
-	omitEmptyFieldsIdx []int
+	fields             encodingFields
+	bytewiseFields     encodingFields // Only populated if toArray is false
+	lengthFirstFields  encodingFields // Only populated if toArray is false
+	omitEmptyFieldsIdx []int          // Only populated if toArray is false
 	err                error
 	toArray            bool
 }
 
-func (st *encodingStructType) getFields(em *encMode) fields {
+func (st *encodingStructType) getFields(em *encMode) encodingFields {
 	switch em.sort {
 	case SortNone, SortFastShuffle:
 		return st.fields
@@ -205,7 +213,7 @@ func (st *encodingStructType) getFields(em *encMode) fields {
 }
 
 type bytewiseFieldSorter struct {
-	fields fields
+	fields encodingFields
 }
 
 func (x *bytewiseFieldSorter) Len() int {
@@ -221,7 +229,7 @@ func (x *bytewiseFieldSorter) Less(i, j int) bool {
 }
 
 type lengthFirstFieldSorter struct {
-	fields fields
+	fields encodingFields
 }
 
 func (x *lengthFirstFieldSorter) Len() int {
@@ -258,13 +266,18 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 	var hasKeyAsStr bool
 	var omitEmptyIdx []int
 
+	encFlds := make(encodingFields, len(flds))
+
 	e := getEncodeBuffer()
 	defer putEncodeBuffer(e)
 
-	for i := 0; i < len(flds); i++ {
+	for i, f := range flds {
+		encFlds[i] = &encodingField{field: *f}
+		ef := encFlds[i]
+
 		// Get field's encodeFunc
-		flds[i].ef, flds[i].ief, flds[i].izf = getEncodeFunc(flds[i].typ)
-		if flds[i].ef == nil {
+		ef.ef, ef.ief, ef.izf = getEncodeFunc(f.typ)
+		if ef.ef == nil {
 			structType := &encodingStructType{err: &UnsupportedTypeError{t}}
 			encodingStructTypeCache.Store(t, structType)
 			return nil, structType.err
@@ -287,51 +300,51 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 				n := nameAsInt*(-1) - 1
 				encodeHead(e, byte(cborTypeNegativeInt), uint64(n))
 			}
-			flds[i].cborName = make([]byte, e.Len())
-			copy(flds[i].cborName, e.Bytes())
+			ef.cborName = make([]byte, e.Len())
+			copy(ef.cborName, e.Bytes())
 			e.Reset()
 
 			hasKeyAsInt = true
 		} else {
-			encodeHead(e, byte(cborTypeTextString), uint64(len(flds[i].name)))
-			flds[i].cborName = make([]byte, e.Len()+len(flds[i].name))
-			n := copy(flds[i].cborName, e.Bytes())
-			copy(flds[i].cborName[n:], flds[i].name)
+			encodeHead(e, byte(cborTypeTextString), uint64(len(f.name)))
+			ef.cborName = make([]byte, e.Len()+len(f.name))
+			n := copy(ef.cborName, e.Bytes())
+			copy(ef.cborName[n:], f.name)
 			e.Reset()
 
 			// If cborName contains a text string, then cborNameByteString contains a
 			// string that has the byte string major type but is otherwise identical to
 			// cborName.
-			flds[i].cborNameByteString = make([]byte, len(flds[i].cborName))
-			copy(flds[i].cborNameByteString, flds[i].cborName)
+			ef.cborNameByteString = make([]byte, len(ef.cborName))
+			copy(ef.cborNameByteString, ef.cborName)
 			// Reset encoded CBOR type to byte string, preserving the "additional
 			// information" bits:
-			flds[i].cborNameByteString[0] = byte(cborTypeByteString) |
-				getAdditionalInformation(flds[i].cborNameByteString[0])
+			ef.cborNameByteString[0] = byte(cborTypeByteString) |
+				getAdditionalInformation(ef.cborNameByteString[0])
 
 			hasKeyAsStr = true
 		}
 
 		// Check if field can be omitted when empty
-		if flds[i].omitEmpty {
+		if f.omitEmpty {
 			omitEmptyIdx = append(omitEmptyIdx, i)
 		}
 	}
 
 	// Sort fields by canonical order
-	bytewiseFields := make(fields, len(flds))
-	copy(bytewiseFields, flds)
+	bytewiseFields := make(encodingFields, len(encFlds))
+	copy(bytewiseFields, encFlds)
 	sort.Sort(&bytewiseFieldSorter{bytewiseFields})
 
 	lengthFirstFields := bytewiseFields
 	if hasKeyAsInt && hasKeyAsStr {
-		lengthFirstFields = make(fields, len(flds))
-		copy(lengthFirstFields, flds)
+		lengthFirstFields = make(encodingFields, len(encFlds))
+		copy(lengthFirstFields, encFlds)
 		sort.Sort(&lengthFirstFieldSorter{lengthFirstFields})
 	}
 
 	structType := &encodingStructType{
-		fields:             flds,
+		fields:             encFlds,
 		bytewiseFields:     bytewiseFields,
 		lengthFirstFields:  lengthFirstFields,
 		omitEmptyFieldsIdx: omitEmptyIdx,
@@ -342,10 +355,11 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 }
 
 func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructType, error) {
-	for i := 0; i < len(flds); i++ {
-		// Get field's encodeFunc
-		flds[i].ef, flds[i].ief, flds[i].izf = getEncodeFunc(flds[i].typ)
-		if flds[i].ef == nil {
+	encFlds := make(encodingFields, len(flds))
+	for i, f := range flds {
+		encFlds[i] = &encodingField{field: *f}
+		encFlds[i].ef, encFlds[i].ief, encFlds[i].izf = getEncodeFunc(f.typ)
+		if encFlds[i].ef == nil {
 			structType := &encodingStructType{err: &UnsupportedTypeError{t}}
 			encodingStructTypeCache.Store(t, structType)
 			return nil, structType.err
@@ -353,7 +367,7 @@ func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructT
 	}
 
 	structType := &encodingStructType{
-		fields:  flds,
+		fields:  encFlds,
 		toArray: true,
 	}
 	encodingStructTypeCache.Store(t, structType)

--- a/cache.go
+++ b/cache.go
@@ -99,56 +99,89 @@ type decodingStructType struct {
 	toArray              bool
 }
 
-func getDecodingStructType(t reflect.Type) *decodingStructType {
+func getDecodingStructType(t reflect.Type) (*decodingStructType, error) {
 	if v, _ := decodingStructTypeCache.Load(t); v != nil {
-		return v.(*decodingStructType)
+		structType := v.(*decodingStructType)
+		if structType.err != nil {
+			return nil, structType.err
+		}
+		return structType, nil
 	}
 
 	flds, structOptions := getFields(t)
 
 	toArray := hasToArrayOption(structOptions)
 
-	var errs []error
+	if toArray {
+		return getDecodingStructToArrayType(t, flds)
+	}
+
+	fieldIndicesByName := make(map[string]int, len(flds))
+	var fieldIndicesByIntKey map[int64]int
+
 	for i := 0; i < len(flds); i++ {
 		if flds[i].keyAsInt {
 			nameAsInt, numErr := strconv.Atoi(flds[i].name)
 			if numErr != nil {
-				errs = append(errs, errors.New("cbor: failed to parse field name \""+flds[i].name+"\" to int ("+numErr.Error()+")"))
-				break
+				structType := &decodingStructType{
+					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+				}
+				decodingStructTypeCache.Store(t, structType)
+				return nil, structType.err
 			}
 			flds[i].nameAsInt = int64(nameAsInt)
+		}
+
+		if _, ok := fieldIndicesByName[flds[i].name]; ok {
+			structType := &decodingStructType{
+				err: fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, flds[i].name),
+			}
+			decodingStructTypeCache.Store(t, structType)
+			return nil, structType.err
+		}
+		fieldIndicesByName[flds[i].name] = i
+		if flds[i].keyAsInt {
+			if fieldIndicesByIntKey == nil {
+				fieldIndicesByIntKey = make(map[int64]int, len(flds))
+			}
+			fieldIndicesByIntKey[flds[i].nameAsInt] = i
 		}
 
 		flds[i].typInfo = getTypeInfo(flds[i].typ)
 	}
 
-	fieldIndicesByName := make(map[string]int, len(flds))
-	var fieldIndicesByIntKey map[int64]int
-	for i, fld := range flds {
-		if _, ok := fieldIndicesByName[fld.name]; ok {
-			errs = append(errs, fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, fld.name))
-			continue
-		}
-		fieldIndicesByName[fld.name] = i
-		if fld.keyAsInt {
-			if fieldIndicesByIntKey == nil {
-				fieldIndicesByIntKey = make(map[int64]int, len(flds))
-			}
-			fieldIndicesByIntKey[fld.nameAsInt] = i
-		}
-	}
-
-	err := errors.Join(errs...)
-
 	structType := &decodingStructType{
 		fields:               flds,
 		fieldIndicesByName:   fieldIndicesByName,
 		fieldIndicesByIntKey: fieldIndicesByIntKey,
-		err:                  err,
-		toArray:              toArray,
 	}
 	decodingStructTypeCache.Store(t, structType)
-	return structType
+	return structType, nil
+}
+
+func getDecodingStructToArrayType(t reflect.Type, flds fields) (*decodingStructType, error) {
+	for i := 0; i < len(flds); i++ {
+		// nameAsInt is set in getFields() except for fields with an unparsable tagged name.
+		// Atoi() is called here to catch and save parsing errors.
+		if flds[i].keyAsInt && flds[i].nameAsInt == 0 {
+			if _, numErr := strconv.Atoi(flds[i].name); numErr != nil {
+				structType := &decodingStructType{
+					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+				}
+				decodingStructTypeCache.Store(t, structType)
+				return nil, structType.err
+			}
+		}
+
+		flds[i].typInfo = getTypeInfo(flds[i].typ)
+	}
+
+	structType := &decodingStructType{
+		fields:  flds,
+		toArray: true,
+	}
+	decodingStructTypeCache.Store(t, structType)
+	return structType, nil
 }
 
 type encodingStructType struct {
@@ -209,7 +242,10 @@ func (x *lengthFirstFieldSorter) Less(i, j int) bool {
 func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 	if v, _ := encodingStructTypeCache.Load(t); v != nil {
 		structType := v.(*encodingStructType)
-		return structType, structType.err
+		if structType.err != nil {
+			return nil, structType.err
+		}
+		return structType, nil
 	}
 
 	flds, structOptions := getFields(t)
@@ -218,25 +254,31 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 		return getEncodingStructToArrayType(t, flds)
 	}
 
-	var err error
 	var hasKeyAsInt bool
 	var hasKeyAsStr bool
 	var omitEmptyIdx []int
+
 	e := getEncodeBuffer()
+	defer putEncodeBuffer(e)
+
 	for i := 0; i < len(flds); i++ {
 		// Get field's encodeFunc
 		flds[i].ef, flds[i].ief, flds[i].izf = getEncodeFunc(flds[i].typ)
 		if flds[i].ef == nil {
-			err = &UnsupportedTypeError{t}
-			break
+			structType := &encodingStructType{err: &UnsupportedTypeError{t}}
+			encodingStructTypeCache.Store(t, structType)
+			return nil, structType.err
 		}
 
 		// Encode field name
 		if flds[i].keyAsInt {
 			nameAsInt, numErr := strconv.Atoi(flds[i].name)
 			if numErr != nil {
-				err = errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")")
-				break
+				structType := &encodingStructType{
+					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+				}
+				encodingStructTypeCache.Store(t, structType)
+				return nil, structType.err
 			}
 			flds[i].nameAsInt = int64(nameAsInt)
 			if nameAsInt >= 0 {
@@ -275,13 +317,6 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 			omitEmptyIdx = append(omitEmptyIdx, i)
 		}
 	}
-	putEncodeBuffer(e)
-
-	if err != nil {
-		structType := &encodingStructType{err: err}
-		encodingStructTypeCache.Store(t, structType)
-		return structType, structType.err
-	}
 
 	// Sort fields by canonical order
 	bytewiseFields := make(fields, len(flds))
@@ -303,7 +338,7 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 	}
 
 	encodingStructTypeCache.Store(t, structType)
-	return structType, structType.err
+	return structType, nil
 }
 
 func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructType, error) {
@@ -313,7 +348,7 @@ func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructT
 		if flds[i].ef == nil {
 			structType := &encodingStructType{err: &UnsupportedTypeError{t}}
 			encodingStructTypeCache.Store(t, structType)
-			return structType, structType.err
+			return nil, structType.err
 		}
 	}
 
@@ -322,7 +357,7 @@ func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructT
 		toArray: true,
 	}
 	encodingStructTypeCache.Store(t, structType)
-	return structType, structType.err
+	return structType, nil
 }
 
 func getEncodeFunc(t reflect.Type) (encodeFunc, isEmptyFunc, isZeroFunc) {

--- a/decode.go
+++ b/decode.go
@@ -16,7 +16,6 @@ import (
 	"math/big"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -2644,7 +2643,68 @@ func (d *decoder) parseArrayToStruct(v reflect.Value, tInfo *typeInfo) error {
 	return err
 }
 
-// parseMapToStruct needs to be fast so gocyclo can be ignored for now.
+// skipMapEntriesFromIndex skips remaining map entries starting from index i.
+func (d *decoder) skipMapEntriesFromIndex(i, count int, hasSize bool) {
+	for ; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
+		d.skip()
+		d.skip()
+	}
+}
+
+// skipMapForDupKey skips the current map value and all remaining map entries,
+// then returns a DupMapKeyError for the given key at map index i.
+func (d *decoder) skipMapForDupKey(dupKey any, i, count int, hasSize bool) error {
+	// Skip the value of the duplicate key.
+	d.skip()
+	// Skip all remaining map entries.
+	d.skipMapEntriesFromIndex(i+1, count, hasSize)
+	return &DupMapKeyError{dupKey, i}
+}
+
+// skipMapForUnknownField skips the current map value and all remaining map entries,
+// then returns a UnknownFieldError for the given key at map index i.
+func (d *decoder) skipMapForUnknownField(i, count int, hasSize bool) error {
+	// Skip the value of the unknown key.
+	d.skip()
+	// Skip all remaining map entries.
+	d.skipMapEntriesFromIndex(i+1, count, hasSize)
+	return &UnknownFieldError{i}
+}
+
+// decodeToStructField decodes the next CBOR value into the struct field f in v.
+// If the field cannot be resolved, the CBOR value is skipped.
+func (d *decoder) decodeToStructField(v reflect.Value, f *field, tInfo *typeInfo) error {
+	var fv reflect.Value
+
+	if len(f.idx) == 1 {
+		fv = v.Field(f.idx[0])
+	} else {
+		var err error
+		fv, err = getFieldValue(v, f.idx, func(v reflect.Value) (reflect.Value, error) {
+			// Return a new value for embedded field null pointer to point to, or return error.
+			if !v.CanSet() {
+				return reflect.Value{}, errors.New("cbor: cannot set embedded pointer to unexported struct: " + v.Type().String())
+			}
+			v.Set(reflect.New(v.Type().Elem()))
+			return v, nil
+		})
+		if !fv.IsValid() {
+			d.skip()
+			return err
+		}
+	}
+
+	err := d.parseToValue(fv, f.typInfo)
+	if err != nil {
+		if typeError, ok := err.(*UnmarshalTypeError); ok {
+			typeError.StructFieldName = tInfo.nonPtrType.String() + "." + f.name
+		}
+		return err
+	}
+
+	return nil
+}
+
 func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //nolint:gocyclo
 	structType := getDecodingStructType(tInfo.nonPtrType)
 	if structType.err != nil {
@@ -2661,14 +2721,12 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 		}
 	}
 
-	var err, lastErr error
-
 	// Get CBOR map size
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
 	count := int(val)
 
-	// Keeps track of matched struct fields
+	// Keep track of matched struct fields to detect duplicate map keys.
 	var foundFldIdx []bool
 	{
 		const maxStackFields = 128
@@ -2682,94 +2740,64 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 		}
 	}
 
-	// Keeps track of CBOR map keys to detect duplicate map key
-	keyCount := 0
-	var mapKeys map[any]struct{}
+	// Keep track of unmatched CBOR map keys to detect duplicate map keys.
+	var unmatchedMapKeys map[any]struct{}
 
-	errOnUnknownField := (d.dm.extraReturnErrors & ExtraDecErrorUnknownField) > 0
+	var err error
 
-MapEntryLoop:
-	for j := 0; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-		var f *field
+	caseInsensitive := d.dm.fieldNameMatching == FieldNameMatchingPreferCaseSensitive
 
-		// If duplicate field detection is enabled and the key at index j did not match any
-		// field, k will hold the map key.
-		var k any
-
+	for i := 0; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
 		t := d.nextCBORType()
-		if t == cborTypeTextString || (t == cborTypeByteString && d.dm.fieldNameByteString == FieldNameByteStringAllowed) {
+
+		// Reclassify disallowed byte string keys so they fall to the default case.
+		// keyType is only used for branch control.
+		keyType := t
+		if t == cborTypeByteString && d.dm.fieldNameByteString != FieldNameByteStringAllowed {
+			keyType = 0xff
+		}
+
+		switch keyType {
+		case cborTypeTextString, cborTypeByteString:
 			var keyBytes []byte
 			if t == cborTypeTextString {
-				keyBytes, lastErr = d.parseTextString()
-				if lastErr != nil {
+				var parseErr error
+				keyBytes, parseErr = d.parseTextString()
+				if parseErr != nil {
 					if err == nil {
-						err = lastErr
+						err = parseErr
 					}
-					d.skip() // skip value
+					d.skip() // Skip value
 					continue
 				}
 			} else { // cborTypeByteString
 				keyBytes, _ = d.parseByteString()
 			}
 
-			// Check for exact match on field name.
-			if i, ok := structType.fieldIndicesByName[string(keyBytes)]; ok {
-				fld := structType.fields[i]
+			// Find matching struct field (exact match, then case-insensitive fallback).
+			if fldIdx, ok := findStructFieldByKey(structType, keyBytes, caseInsensitive); ok {
+				fld := structType.fields[fldIdx]
 
-				if !foundFldIdx[i] {
-					f = fld
-					foundFldIdx[i] = true
-				} else if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
-					err = &DupMapKeyError{fld.name, j}
-					d.skip() // skip value
-					j++
-					// skip the rest of the map
-					for ; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-						d.skip()
-						d.skip()
+				switch checkDupField(d.dm, foundFldIdx, fldIdx) {
+				case mapActionParseValueAndContinue:
+					if fieldErr := d.decodeToStructField(v, fld, tInfo); fieldErr != nil && err == nil {
+						err = fieldErr
 					}
-					return err
-				} else {
-					// discard repeated match
+					continue
+				case mapActionSkipAllAndReturnError:
+					return d.skipMapForDupKey(string(keyBytes), i, count, hasSize)
+				case mapActionSkipValueAndContinue:
 					d.skip()
-					continue MapEntryLoop
+					continue
 				}
 			}
 
-			// Find field with case-insensitive match
-			if f == nil && d.dm.fieldNameMatching == FieldNameMatchingPreferCaseSensitive {
-				keyLen := len(keyBytes)
-				keyString := string(keyBytes)
-				for i := 0; i < len(structType.fields); i++ {
-					fld := structType.fields[i]
-					if len(fld.name) == keyLen && strings.EqualFold(fld.name, keyString) {
-						if !foundFldIdx[i] {
-							f = fld
-							foundFldIdx[i] = true
-						} else if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
-							err = &DupMapKeyError{keyString, j}
-							d.skip() // skip value
-							j++
-							// skip the rest of the map
-							for ; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-								d.skip()
-								d.skip()
-							}
-							return err
-						} else {
-							// discard repeated match
-							d.skip()
-							continue MapEntryLoop
-						}
-						break
-					}
-				}
+			// No matching struct field found.
+			if unmatchedErr := handleUnmatchedMapKey(d, string(keyBytes), i, count, hasSize, &unmatchedMapKeys); unmatchedErr != nil {
+				return unmatchedErr
 			}
 
-			if d.dm.dupMapKey == DupMapKeyEnforcedAPF && f == nil {
-				k = string(keyBytes)
-			}
-		} else if t <= cborTypeNegativeInt { // uint/int
+		case cborTypePositiveInt, cborTypeNegativeInt:
 			var nameAsInt int64
 
 			if t == cborTypePositiveInt {
@@ -2791,36 +2819,32 @@ MapEntryLoop:
 				nameAsInt = int64(-1) ^ int64(val)
 			}
 
-			// Find field
-			for i := 0; i < len(structType.fields); i++ {
-				fld := structType.fields[i]
-				if fld.keyAsInt && fld.nameAsInt == nameAsInt {
-					if !foundFldIdx[i] {
-						f = fld
-						foundFldIdx[i] = true
-					} else if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
-						err = &DupMapKeyError{nameAsInt, j}
-						d.skip() // skip value
-						j++
-						// skip the rest of the map
-						for ; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-							d.skip()
-							d.skip()
-						}
-						return err
-					} else {
-						// discard repeated match
-						d.skip()
-						continue MapEntryLoop
+			// Find field by integer key
+			if fldIdx, ok := structType.fieldIndicesByIntKey[nameAsInt]; ok {
+				fld := structType.fields[fldIdx]
+
+				switch checkDupField(d.dm, foundFldIdx, fldIdx) {
+				case mapActionParseValueAndContinue:
+					if fieldErr := d.decodeToStructField(v, fld, tInfo); fieldErr != nil && err == nil {
+						err = fieldErr
 					}
-					break
+					continue
+				case mapActionSkipAllAndReturnError:
+					return d.skipMapForDupKey(nameAsInt, i, count, hasSize)
+				case mapActionSkipValueAndContinue:
+					d.skip()
+					continue
 				}
 			}
 
-			if d.dm.dupMapKey == DupMapKeyEnforcedAPF && f == nil {
-				k = nameAsInt
+			// No matching struct field found.
+			if unmatchedErr := handleUnmatchedMapKey(d, nameAsInt, i, count, hasSize, &unmatchedMapKeys); unmatchedErr != nil {
+				return unmatchedErr
 			}
-		} else {
+
+		default:
+			// CBOR map keys that can't be matched to any struct field.
+
 			if err == nil {
 				err = &UnmarshalTypeError{
 					CBORType: t.String(),
@@ -2828,97 +2852,31 @@ MapEntryLoop:
 					errorMsg: "map key is of type " + t.String() + " and cannot be used to match struct field name",
 				}
 			}
+
+			var otherKey any
 			if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
 				// parse key
-				k, lastErr = d.parse(true)
-				if lastErr != nil {
+				var parseErr error
+				otherKey, parseErr = d.parse(true)
+				if parseErr != nil {
 					d.skip() // skip value
 					continue
 				}
 				// Detect if CBOR map key can be used as Go map key.
-				if !isHashableValue(reflect.ValueOf(k)) {
+				if !isHashableValue(reflect.ValueOf(otherKey)) {
 					d.skip() // skip value
 					continue
 				}
 			} else {
 				d.skip() // skip key
 			}
-		}
 
-		if f == nil {
-			if errOnUnknownField {
-				err = &UnknownFieldError{j}
-				d.skip() // Skip value
-				j++
-				// skip the rest of the map
-				for ; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-					d.skip()
-					d.skip()
-				}
-				return err
-			}
-
-			// Two map keys that match the same struct field are immediately considered
-			// duplicates. This check detects duplicates between two map keys that do
-			// not match a struct field. If unknown field errors are enabled, then this
-			// check is never reached.
-			if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
-				if mapKeys == nil {
-					mapKeys = make(map[any]struct{}, 1)
-				}
-				mapKeys[k] = struct{}{}
-				newKeyCount := len(mapKeys)
-				if newKeyCount == keyCount {
-					err = &DupMapKeyError{k, j}
-					d.skip() // skip value
-					j++
-					// skip the rest of the map
-					for ; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-						d.skip()
-						d.skip()
-					}
-					return err
-				}
-				keyCount = newKeyCount
-			}
-
-			d.skip() // Skip value
-			continue
-		}
-
-		// Get field value by index
-		var fv reflect.Value
-		if len(f.idx) == 1 {
-			fv = v.Field(f.idx[0])
-		} else {
-			fv, lastErr = getFieldValue(v, f.idx, func(v reflect.Value) (reflect.Value, error) {
-				// Return a new value for embedded field null pointer to point to, or return error.
-				if !v.CanSet() {
-					return reflect.Value{}, errors.New("cbor: cannot set embedded pointer to unexported struct: " + v.Type().String())
-				}
-				v.Set(reflect.New(v.Type().Elem()))
-				return v, nil
-			})
-			if lastErr != nil && err == nil {
-				err = lastErr
-			}
-			if !fv.IsValid() {
-				d.skip()
-				continue
-			}
-		}
-
-		if lastErr = d.parseToValue(fv, f.typInfo); lastErr != nil {
-			if err == nil {
-				if typeError, ok := lastErr.(*UnmarshalTypeError); ok {
-					typeError.StructFieldName = tInfo.nonPtrType.String() + "." + f.name
-					err = typeError
-				} else {
-					err = lastErr
-				}
+			if unmatchedErr := handleUnmatchedMapKey(d, otherKey, i, count, hasSize, &unmatchedMapKeys); unmatchedErr != nil {
+				return unmatchedErr
 			}
 		}
 	}
+
 	return err
 }
 

--- a/decode.go
+++ b/decode.go
@@ -2572,9 +2572,9 @@ func (d *decoder) parseMapToMap(v reflect.Value, tInfo *typeInfo) error { //noli
 }
 
 func (d *decoder) parseArrayToStruct(v reflect.Value, tInfo *typeInfo) error {
-	structType := getDecodingStructType(tInfo.nonPtrType)
-	if structType.err != nil {
-		return structType.err
+	structType, structTypeErr := getDecodingStructType(tInfo.nonPtrType)
+	if structTypeErr != nil {
+		return structTypeErr
 	}
 
 	if !structType.toArray {
@@ -2706,9 +2706,9 @@ func (d *decoder) decodeToStructField(v reflect.Value, f *field, tInfo *typeInfo
 }
 
 func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //nolint:gocyclo
-	structType := getDecodingStructType(tInfo.nonPtrType)
-	if structType.err != nil {
-		return structType.err
+	structType, structTypeErr := getDecodingStructType(tInfo.nonPtrType)
+	if structTypeErr != nil {
+		return structTypeErr
 	}
 
 	if structType.toArray {

--- a/decode.go
+++ b/decode.go
@@ -2673,7 +2673,7 @@ func (d *decoder) skipMapForUnknownField(i, count int, hasSize bool) error {
 
 // decodeToStructField decodes the next CBOR value into the struct field f in v.
 // If the field cannot be resolved, the CBOR value is skipped.
-func (d *decoder) decodeToStructField(v reflect.Value, f *field, tInfo *typeInfo) error {
+func (d *decoder) decodeToStructField(v reflect.Value, f *decodingField, tInfo *typeInfo) error {
 	var fv reflect.Value
 
 	if len(f.idx) == 1 {

--- a/decode_map_utils.go
+++ b/decode_map_utils.go
@@ -49,17 +49,17 @@ func findStructFieldByKey(
 
 // findFieldCaseInsensitive returns the index of the first field whose name
 // case-insensitively matches key, or -1 and false if no field matches.
-func findFieldCaseInsensitive(flds fields, key string) (int, bool) {
+func findFieldCaseInsensitive(flds decodingFields, key string) (int, bool) {
 	keyLen := len(key)
-	for i := 0; i < len(flds); i++ {
-		if len(flds[i].name) == keyLen && strings.EqualFold(flds[i].name, key) {
+	for i, f := range flds {
+		if len(f.name) == keyLen && strings.EqualFold(f.name, key) {
 			return i, true
 		}
 	}
 	return -1, false
 }
 
-// handleUnmatchedMapKey handles a map entry whose key doesn not match any struct
+// handleUnmatchedMapKey handles a map entry whose key does not match any struct
 // field. It can return UnknownFieldError or DupMapKeyError.
 // handleUnmatchedMapKey consumes the CBOR value, so the caller doesn't need to skip any values.
 // If an error is returned, the caller should abort parsing the map and return the error.
@@ -70,7 +70,8 @@ func handleUnmatchedMapKey(
 	i int,
 	count int,
 	hasSize bool,
-	uks *map[any]struct{},
+	// *map[any]struct{} is used here because we use lazy initialization for uks
+	uks *map[any]struct{}, //nolint:gocritic
 ) error {
 	errOnUnknownField := (d.dm.extraReturnErrors & ExtraDecErrorUnknownField) > 0
 

--- a/decode_map_utils.go
+++ b/decode_map_utils.go
@@ -1,0 +1,94 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import "strings"
+
+// mapAction represents the next action during decoding a CBOR map to a Go struct.
+type mapAction int
+
+const (
+	mapActionParseValueAndContinue mapAction = iota // The caller should process the map value.
+	mapActionSkipValueAndContinue                   // The caller should skip the map value.
+	mapActionSkipAllAndReturnError                  // The caller should skip the rest of the map and return an error.
+)
+
+// checkDupField checks if a struct field at index i has already been matched and returns the next action.
+// If not matched, it marks the field as matched and returns mapActionParseValueAndContinue.
+// If matched and DupMapKeyEnforcedAPF is specified in the given dm, it returns mapActionSkipAllAndReturnError.
+// If matched and DupMapKeyEnforcedAPF is not specified in the given dm, it returns mapActionSkipValueAndContinue.
+func checkDupField(dm *decMode, foundFldIdx []bool, i int) mapAction {
+	if !foundFldIdx[i] {
+		foundFldIdx[i] = true
+		return mapActionParseValueAndContinue
+	}
+	if dm.dupMapKey == DupMapKeyEnforcedAPF {
+		return mapActionSkipAllAndReturnError
+	}
+	return mapActionSkipValueAndContinue
+}
+
+// findStructFieldByKey finds a struct field matching keyBytes by name.
+// It tries an exact match first. If no exact match is found and
+// caseInsensitive is true, it falls back to a case-insensitive search.
+// findStructFieldByKey returns the field index and true, or -1 and false.
+func findStructFieldByKey(
+	structType *decodingStructType,
+	keyBytes []byte,
+	caseInsensitive bool,
+) (int, bool) {
+	if fldIdx, ok := structType.fieldIndicesByName[string(keyBytes)]; ok {
+		return fldIdx, true
+	}
+	if caseInsensitive {
+		return findFieldCaseInsensitive(structType.fields, string(keyBytes))
+	}
+	return -1, false
+}
+
+// findFieldCaseInsensitive returns the index of the first field whose name
+// case-insensitively matches key, or -1 and false if no field matches.
+func findFieldCaseInsensitive(flds fields, key string) (int, bool) {
+	keyLen := len(key)
+	for i := 0; i < len(flds); i++ {
+		if len(flds[i].name) == keyLen && strings.EqualFold(flds[i].name, key) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// handleUnmatchedMapKey handles a map entry whose key doesn not match any struct
+// field. It can return UnknownFieldError or DupMapKeyError.
+// handleUnmatchedMapKey consumes the CBOR value, so the caller doesn't need to skip any values.
+// If an error is returned, the caller should abort parsing the map and return the error.
+// If no error is returned, the caller should continue to process the next map pair.
+func handleUnmatchedMapKey(
+	d *decoder,
+	key any,
+	i int,
+	count int,
+	hasSize bool,
+	uks *map[any]struct{},
+) error {
+	errOnUnknownField := (d.dm.extraReturnErrors & ExtraDecErrorUnknownField) > 0
+
+	if errOnUnknownField {
+		return d.skipMapForUnknownField(i, count, hasSize)
+	}
+
+	if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
+		if *uks == nil {
+			*uks = make(map[any]struct{})
+		}
+		if _, dup := (*uks)[key]; dup {
+			return d.skipMapForDupKey(key, i, count, hasSize)
+		}
+		(*uks)[key] = struct{}{}
+	}
+
+	// Skip value.
+	d.skip()
+	return nil
+}

--- a/structfields.go
+++ b/structfields.go
@@ -9,24 +9,39 @@ import (
 	"strings"
 )
 
+// field holds shared struct field metadata returned by getFields().
 type field struct {
-	name               string
-	nameAsInt          int64 // used to decoder to match field name with CBOR int
-	cborName           []byte
-	cborNameByteString []byte // major type 2 name encoding iff cborName has major type 3
-	idx                []int
-	typ                reflect.Type
-	ef                 encodeFunc
-	ief                isEmptyFunc
-	izf                isZeroFunc
-	typInfo            *typeInfo // used to decoder to reuse type info
-	tagged             bool      // used to choose dominant field (at the same level tagged fields dominate untagged fields)
-	omitEmpty          bool      // used to skip empty field
-	omitZero           bool      // used to skip zero field
-	keyAsInt           bool      // used to encode/decode field name as int
+	name      string
+	nameAsInt int64 // used to match field name with CBOR int
+	idx       []int
+	typ       reflect.Type // used during cache building only
+	keyAsInt  bool         // used to encode/decode field name as int
+	tagged    bool         // used to choose dominant field (at the same level tagged fields dominate untagged fields)
+	omitEmpty bool         // used to skip empty field
+	omitZero  bool         // used to skip zero field
 }
 
 type fields []*field
+
+// encodingField extends field with encoding-specific data.
+type encodingField struct {
+	field
+	cborName           []byte
+	cborNameByteString []byte // major type 2 name encoding if cborName has major type 3
+	ef                 encodeFunc
+	ief                isEmptyFunc
+	izf                isZeroFunc
+}
+
+type encodingFields []*encodingField
+
+// decodingField extends field with decoding-specific data.
+type decodingField struct {
+	field
+	typInfo *typeInfo // used by decoder to reuse type info
+}
+
+type decodingFields []*decodingField
 
 // indexFieldSorter sorts fields by field idx at each level, breaking ties with idx depth.
 type indexFieldSorter struct {


### PR DESCRIPTION
This PR refactors `parseMapToStruct()` (was 275 lines) by:
- extracting helper functions that can be inlined
- refactoring and simplifying control flow

Also, this PR refactors `getDecodingStructType()` and `getEncodingStructType()` for readability.  

`field` struct is also refactored into `encodingField` and `decodingField`, so that `encodingField` doesn't contain any data needed only for decoding, vice versa.

This PR does not change encoding or decoding behavior.