### PR TITLE
Fix several issues related to keyasint tag option

### DIFF
--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -16,10 +16,10 @@ on:
     branches: [main, master]
 
 env:
-  GO_VERSION: '1.22'
-  GOLINTERS_VERSION: 1.59.1
+  GO_VERSION: '1.25'
+  GOLINTERS_VERSION: 2.10.1
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791
+  GOLINTERS_TGZ_DGST: dfa775874cf0561b404a02a8f4481fc69b28091da95aa697259820d429b09c99
   GOLINTERS_TIMEOUT: 15m
   OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,104 +1,116 @@
-# Do not delete linter settings. Linters like gocritic can be enabled on the command line.
-
-linters-settings:
-  depguard:
-    rules:
-      prevent_unmaintained_packages:
-        list-mode: strict
-        files:
-          - $all
-          - "!$test"
-        allow:
-          - $gostd
-          - github.com/x448/float16
-        deny:
-          - pkg: io/ioutil
-            desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 100
-    statements: 50
-  goconst:
-    ignore-tests: true
-    min-len: 2
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - commentedOutCode
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - paramTypeCombine
-      - whyNoLint
-  gofmt:
-    simplify: false
-  goimports:
-    local-prefixes: github.com/fxamacker/cbor
-  golint:
-    min-confidence: 0
-  govet:
-    check-shadowing: true
-  lll:
-    line-length: 140
-  maligned:
-    suggest-new: true
-  misspell:
-    locale: US
-  staticcheck:
-    checks: ["all"]
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bidichk
     - depguard
     - errcheck
-    - exportloopref
+    - forbidigo
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nilerr
     - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unused
-
+  settings:
+    depguard:
+      rules:
+        prevent_unmaintained_packages:
+          list-mode: strict
+          files:
+            - $all
+            - '!$test'
+          allow:
+            - $gostd
+            - github.com/x448/float16
+          deny:
+            - pkg: io/ioutil
+              desc: 'replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil'
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 100
+      statements: 50
+    goconst:
+      min-len: 2
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - commentedOutCode
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - paramTypeCombine
+        - whyNoLint
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: decode.go
+        text: string ` overflows ` has (\d+) occurrences, make it a constant
+      - path: decode.go
+        text: string ` \(range is \[` has (\d+) occurrences, make it a constant
+      - path: decode.go
+        text: string `, ` has (\d+) occurrences, make it a constant
+      - path: decode.go
+        text: string ` overflows Go's int64` has (\d+) occurrences, make it a constant
+      - path: decode.go
+        text: string `\]\)` has (\d+) occurrences, make it a constant
+      - path: valid.go
+        text: string ` for type ` has (\d+) occurrences, make it a constant
+      - path: valid.go
+        text: 'string `cbor: ` has (\d+) occurrences, make it a constant'
+      - linters:
+          - goconst
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # max-issues-per-linter default is 50.  Set to 0 to disable limit.
   max-issues-per-linter: 0
-  # max-same-issues default is 3.  Set to 0 to disable limit.
   max-same-issues: 0
-
-  exclude-rules:
-    - path: decode.go
-      text: "string ` overflows ` has (\\d+) occurrences, make it a constant"
-    - path: decode.go
-      text: "string ` \\(range is \\[` has (\\d+) occurrences, make it a constant"
-    - path: decode.go
-      text: "string `, ` has (\\d+) occurrences, make it a constant"
-    - path: decode.go
-      text: "string ` overflows Go's int64` has (\\d+) occurrences, make it a constant"
-    - path: decode.go
-      text: "string `\\]\\)` has (\\d+) occurrences, make it a constant"
-    - path: valid.go
-      text: "string ` for type ` has (\\d+) occurrences, make it a constant"
-    - path: valid.go
-      text: "string `cbor: ` has (\\d+) occurrences, make it a constant"
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false
+    goimports:
+      local-prefixes:
+        - github.com/fxamacker/cbor
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/bench_test.go
+++ b/bench_test.go
@@ -986,13 +986,13 @@ func BenchmarkUnmarshalMapToStruct(b *testing.B) {
 			b.Fatalf("invalid test assumption: ManyFields expected to have no more than 255 fields, has %d", rt.NumField())
 		}
 		buf.WriteByte(0xb8)
-		buf.WriteByte(byte(rt.NumField()))
+		buf.WriteByte(byte(rt.NumField()))        //nolint:gosec
 		for i := rt.NumField() - 1; i >= 0; i-- { // backwards
 			f := rt.Field(i)
 			if len(f.Name) > 23 {
 				b.Fatalf("invalid test assumption: field name %q longer than 23 bytes", f.Name)
 			}
-			buf.WriteByte(byte(0x60 + len(f.Name)))
+			buf.WriteByte(byte(0x60 + len(f.Name))) //nolint:gosec
 			buf.WriteString(f.Name)
 			buf.WriteByte(0xf5) // true
 		}

--- a/cache.go
+++ b/cache.go
@@ -121,31 +121,41 @@ func getDecodingStructType(t reflect.Type) (*decodingStructType, error) {
 
 	decFlds := make(decodingFields, len(flds))
 	for i, f := range flds {
-		if f.keyAsInt {
-			nameAsInt, numErr := strconv.Atoi(f.name)
-			if numErr != nil {
+		// nameAsInt is set in getFields() except for fields with an unparsable tagged name.
+		// Atoi() is called here to catch and save parsing errors.
+		if f.keyAsInt && f.nameAsInt == 0 {
+			if _, numErr := strconv.Atoi(f.name); numErr != nil {
 				structType := &decodingStructType{
 					err: errors.New("cbor: failed to parse field name \"" + f.name + "\" to int (" + numErr.Error() + ")"),
 				}
 				decodingStructTypeCache.Store(t, structType)
 				return nil, structType.err
 			}
-			f.nameAsInt = int64(nameAsInt)
 		}
 
-		if _, ok := fieldIndicesByName[f.name]; ok {
-			structType := &decodingStructType{
-				err: fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, f.name),
-			}
-			decodingStructTypeCache.Store(t, structType)
-			return nil, structType.err
-		}
-		fieldIndicesByName[f.name] = i
 		if f.keyAsInt {
 			if fieldIndicesByIntKey == nil {
 				fieldIndicesByIntKey = make(map[int64]int, len(flds))
 			}
+			// The duplication check is only a safeguard, since getFields() already deduplicates fields.
+			if _, ok := fieldIndicesByIntKey[f.nameAsInt]; ok {
+				structType := &decodingStructType{
+					err: fmt.Errorf("cbor: two or more fields of %v have the same keyasint value %d", t, f.nameAsInt),
+				}
+				decodingStructTypeCache.Store(t, structType)
+				return nil, structType.err
+			}
 			fieldIndicesByIntKey[f.nameAsInt] = i
+		} else {
+			// The duplication check is only a safeguard, since getFields() already deduplicates fields.
+			if _, ok := fieldIndicesByName[f.name]; ok {
+				structType := &decodingStructType{
+					err: fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, f.name),
+				}
+				decodingStructTypeCache.Store(t, structType)
+				return nil, structType.err
+			}
+			fieldIndicesByName[f.name] = i
 		}
 
 		decFlds[i] = &decodingField{
@@ -284,16 +294,19 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 		}
 
 		// Encode field name
-		if flds[i].keyAsInt {
-			nameAsInt, numErr := strconv.Atoi(flds[i].name)
-			if numErr != nil {
-				structType := &encodingStructType{
-					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+		if f.keyAsInt {
+			if f.nameAsInt == 0 {
+				// nameAsInt is set in getFields() except for fields with an unparsable tagged name.
+				// Atoi() is called here to catch and save parsing errors.
+				if _, numErr := strconv.Atoi(f.name); numErr != nil {
+					structType := &encodingStructType{
+						err: errors.New("cbor: failed to parse field name \"" + f.name + "\" to int (" + numErr.Error() + ")"),
+					}
+					encodingStructTypeCache.Store(t, structType)
+					return nil, structType.err
 				}
-				encodingStructTypeCache.Store(t, structType)
-				return nil, structType.err
 			}
-			flds[i].nameAsInt = int64(nameAsInt)
+			nameAsInt := f.nameAsInt
 			if nameAsInt >= 0 {
 				encodeHead(e, byte(cborTypePositiveInt), uint64(nameAsInt))
 			} else {

--- a/cache.go
+++ b/cache.go
@@ -308,10 +308,10 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 			}
 			nameAsInt := f.nameAsInt
 			if nameAsInt >= 0 {
-				encodeHead(e, byte(cborTypePositiveInt), uint64(nameAsInt))
+				encodeHead(e, byte(cborTypePositiveInt), uint64(nameAsInt)) //nolint:gosec
 			} else {
 				n := nameAsInt*(-1) - 1
-				encodeHead(e, byte(cborTypeNegativeInt), uint64(n))
+				encodeHead(e, byte(cborTypeNegativeInt), uint64(n)) //nolint:gosec
 			}
 			ef.cborName = make([]byte, e.Len())
 			copy(ef.cborName, e.Bytes())

--- a/decode.go
+++ b/decode.go
@@ -377,6 +377,7 @@ const (
 	// - int64 if value fits
 	// - big.Int or *big.Int (see BigIntDecMode) if value < math.MinInt64
 	// - return UnmarshalTypeError if value > math.MaxInt64
+	//
 	// Deprecated: IntDecConvertSigned should not be used.
 	// Please use other options, such as IntDecConvertSignedOrError, IntDecConvertSignedOrBigInt, IntDecConvertNone.
 	IntDecConvertSigned
@@ -1683,6 +1684,7 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 		} else if tInfo.nonPtrKind == reflect.Struct {
 			return d.parseArrayToStruct(v, tInfo)
 		}
+
 		d.skip()
 		return &UnmarshalTypeError{CBORType: t.String(), GoType: tInfo.nonPtrType.String()}
 
@@ -2802,6 +2804,17 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 
 			if t == cborTypePositiveInt {
 				_, _, val := d.getHead()
+				if val > math.MaxInt64 {
+					if err == nil {
+						err = &UnmarshalTypeError{
+							CBORType: t.String(),
+							GoType:   reflect.TypeOf(int64(0)).String(),
+							errorMsg: strconv.FormatUint(val, 10) + " overflows Go's int64",
+						}
+					}
+					d.skip() // skip value
+					continue
+				}
 				nameAsInt = int64(val)
 			} else {
 				_, _, val := d.getHead()

--- a/decode.go
+++ b/decode.go
@@ -1055,7 +1055,7 @@ func (opts DecOptions) decMode() (*decMode, error) { //nolint:gocritic // ignore
 	}
 
 	if !opts.ExtraReturnErrors.valid() {
-		return nil, errors.New("cbor: invalid ExtraReturnErrors " + strconv.Itoa(int(opts.ExtraReturnErrors)))
+		return nil, errors.New("cbor: invalid ExtraReturnErrors " + strconv.Itoa(int(opts.ExtraReturnErrors))) //nolint:gosec
 	}
 
 	if opts.DefaultMapType != nil && opts.DefaultMapType.Kind() != reflect.Map {
@@ -1583,11 +1583,11 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 		_, ai, val := d.getHead()
 		switch ai {
 		case additionalInformationAsFloat16:
-			f := float64(float16.Frombits(uint16(val)).Float32())
+			f := float64(float16.Frombits(uint16(val)).Float32()) //nolint:gosec
 			return fillFloat(t, f, v)
 
 		case additionalInformationAsFloat32:
-			f := float64(math.Float32frombits(uint32(val)))
+			f := float64(math.Float32frombits(uint32(val))) //nolint:gosec
 			return fillFloat(t, f, v)
 
 		case additionalInformationAsFloat64:
@@ -1595,10 +1595,10 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 			return fillFloat(t, f, v)
 
 		default: // ai <= 24
-			if d.dm.simpleValues.rejected[SimpleValue(val)] {
+			if d.dm.simpleValues.rejected[SimpleValue(val)] { //nolint:gosec
 				return &UnacceptableDataItemError{
 					CBORType: t.String(),
-					Message:  "simple value " + strconv.FormatInt(int64(val), 10) + " is not recognized",
+					Message:  "simple value " + strconv.FormatInt(int64(val), 10) + " is not recognized", //nolint:gosec
 				}
 			}
 
@@ -1677,11 +1677,12 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 		return d.parseToValue(v, tInfo)
 
 	case cborTypeArray:
-		if tInfo.nonPtrKind == reflect.Slice {
+		switch tInfo.nonPtrKind {
+		case reflect.Slice:
 			return d.parseArrayToSlice(v, tInfo)
-		} else if tInfo.nonPtrKind == reflect.Array {
+		case reflect.Array:
 			return d.parseArrayToArray(v, tInfo)
-		} else if tInfo.nonPtrKind == reflect.Struct {
+		case reflect.Struct:
 			return d.parseArrayToStruct(v, tInfo)
 		}
 
@@ -1689,9 +1690,10 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 		return &UnmarshalTypeError{CBORType: t.String(), GoType: tInfo.nonPtrType.String()}
 
 	case cborTypeMap:
-		if tInfo.nonPtrKind == reflect.Struct {
+		switch tInfo.nonPtrKind {
+		case reflect.Struct:
 			return d.parseMapToStruct(v, tInfo)
-		} else if tInfo.nonPtrKind == reflect.Map {
+		case reflect.Map:
 			return d.parseMapToMap(v, tInfo)
 		}
 		d.skip()
@@ -1746,8 +1748,8 @@ func (d *decoder) parseToTime() (time.Time, bool, error) {
 			// Read tag number
 			_, _, tagNum := d.getHead()
 			if tagNum != 0 && tagNum != 1 {
-				d.skip() // skip tag content
-				return time.Time{}, false, errors.New("cbor: wrong tag number for time.Time, got " + strconv.Itoa(int(tagNum)) + ", expect 0 or 1")
+				d.skip()                                                                                                                            // skip tag content
+				return time.Time{}, false, errors.New("cbor: wrong tag number for time.Time, got " + strconv.Itoa(int(tagNum)) + ", expect 0 or 1") //nolint:gosec
 			}
 		}
 	} else {
@@ -1816,10 +1818,10 @@ func (d *decoder) parseToTime() (time.Time, bool, error) {
 		var f float64
 		switch ai {
 		case additionalInformationAsFloat16:
-			f = float64(float16.Frombits(uint16(val)).Float32())
+			f = float64(float16.Frombits(uint16(val)).Float32()) //nolint:gosec
 
 		case additionalInformationAsFloat32:
-			f = float64(math.Float32frombits(uint32(val)))
+			f = float64(math.Float32frombits(uint32(val))) //nolint:gosec
 
 		case additionalInformationAsFloat64:
 			f = math.Float64frombits(val)
@@ -2153,14 +2155,14 @@ func (d *decoder) parse(skipSelfDescribedTag bool) (any, error) { //nolint:gocyc
 
 	case cborTypePrimitives:
 		_, ai, val := d.getHead()
-		if ai <= 24 && d.dm.simpleValues.rejected[SimpleValue(val)] {
+		if ai <= 24 && d.dm.simpleValues.rejected[SimpleValue(val)] { //nolint:gosec
 			return nil, &UnacceptableDataItemError{
 				CBORType: t.String(),
-				Message:  "simple value " + strconv.FormatInt(int64(val), 10) + " is not recognized",
+				Message:  "simple value " + strconv.FormatInt(int64(val), 10) + " is not recognized", //nolint:gosec
 			}
 		}
 		if ai < 20 || ai == 24 {
-			return SimpleValue(val), nil
+			return SimpleValue(val), nil //nolint:gosec
 		}
 
 		switch ai {
@@ -2173,11 +2175,11 @@ func (d *decoder) parse(skipSelfDescribedTag bool) (any, error) { //nolint:gocyc
 			return nil, nil
 
 		case additionalInformationAsFloat16:
-			f := float64(float16.Frombits(uint16(val)).Float32())
+			f := float64(float16.Frombits(uint16(val)).Float32()) //nolint:gosec
 			return f, nil
 
 		case additionalInformationAsFloat32:
-			f := float64(math.Float32frombits(uint32(val)))
+			f := float64(math.Float32frombits(uint32(val))) //nolint:gosec
 			return f, nil
 
 		case additionalInformationAsFloat64:
@@ -2210,16 +2212,16 @@ func (d *decoder) parse(skipSelfDescribedTag bool) (any, error) { //nolint:gocyc
 func (d *decoder) parseByteString() ([]byte, bool) {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	if !indefiniteLength {
-		b := d.data[d.off : d.off+int(val)]
-		d.off += int(val)
+		b := d.data[d.off : d.off+int(val)] //nolint:gosec
+		d.off += int(val)                   //nolint:gosec
 		return b, false
 	}
 	// Process indefinite-length string chunks.
 	b := []byte{}
 	for !d.foundBreak() {
 		_, _, val = d.getHead()
-		b = append(b, d.data[d.off:d.off+int(val)]...)
-		d.off += int(val)
+		b = append(b, d.data[d.off:d.off+int(val)]...) //nolint:gosec
+		d.off += int(val)                              //nolint:gosec
 	}
 	return b, true
 }
@@ -2308,8 +2310,8 @@ func (d *decoder) applyByteStringTextConversion(
 func (d *decoder) parseTextString() ([]byte, error) {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	if !indefiniteLength {
-		b := d.data[d.off : d.off+int(val)]
-		d.off += int(val)
+		b := d.data[d.off : d.off+int(val)] //nolint:gosec
+		d.off += int(val)                   //nolint:gosec
 		if d.dm.utf8 == UTF8RejectInvalid && !utf8.Valid(b) {
 			return nil, &SemanticError{"cbor: invalid UTF-8 string"}
 		}
@@ -2319,8 +2321,8 @@ func (d *decoder) parseTextString() ([]byte, error) {
 	b := []byte{}
 	for !d.foundBreak() {
 		_, _, val = d.getHead()
-		x := d.data[d.off : d.off+int(val)]
-		d.off += int(val)
+		x := d.data[d.off : d.off+int(val)] //nolint:gosec
+		d.off += int(val)                   //nolint:gosec
 		if d.dm.utf8 == UTF8RejectInvalid && !utf8.Valid(x) {
 			for !d.foundBreak() {
 				d.skip() // Skip remaining chunk on error
@@ -2335,7 +2337,7 @@ func (d *decoder) parseTextString() ([]byte, error) {
 func (d *decoder) parseArray() ([]any, error) {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	if !hasSize {
 		count = d.numOfItemsUntilBreak() // peek ahead to get array size to preallocate slice for better performance
 	}
@@ -2357,7 +2359,7 @@ func (d *decoder) parseArray() ([]any, error) {
 func (d *decoder) parseArrayToSlice(v reflect.Value, tInfo *typeInfo) error {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	if !hasSize {
 		count = d.numOfItemsUntilBreak() // peek ahead to get array size to preallocate slice for better performance
 	}
@@ -2379,7 +2381,7 @@ func (d *decoder) parseArrayToSlice(v reflect.Value, tInfo *typeInfo) error {
 func (d *decoder) parseArrayToArray(v reflect.Value, tInfo *typeInfo) error {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	gi := 0
 	vLen := v.Len()
 	var err error
@@ -2408,7 +2410,7 @@ func (d *decoder) parseArrayToArray(v reflect.Value, tInfo *typeInfo) error {
 func (d *decoder) parseMap() (any, error) {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	m := make(map[any]any)
 	var k, e any
 	var err, lastErr error
@@ -2473,7 +2475,7 @@ func (d *decoder) parseMap() (any, error) {
 func (d *decoder) parseMapToMap(v reflect.Value, tInfo *typeInfo) error { //nolint:gocyclo
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	if v.IsNil() {
 		mapsize := count
 		if !hasSize {
@@ -2592,7 +2594,7 @@ func (d *decoder) parseArrayToStruct(v reflect.Value, tInfo *typeInfo) error {
 	start := d.off
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	if !hasSize {
 		count = d.numOfItemsUntilBreak() // peek ahead to get array size
 	}
@@ -2726,7 +2728,7 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 	// Get CBOR map size
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 
 	// Keep track of matched struct fields to detect duplicate map keys.
 	var foundFldIdx []bool
@@ -2815,7 +2817,7 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 					d.skip() // skip value
 					continue
 				}
-				nameAsInt = int64(val)
+				nameAsInt = int64(val) //nolint:gosec
 			} else {
 				_, _, val := d.getHead()
 				if val > math.MaxInt64 {
@@ -2829,7 +2831,7 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 					d.skip() // skip value
 					continue
 				}
-				nameAsInt = int64(-1) ^ int64(val)
+				nameAsInt = int64(-1) ^ int64(val) //nolint:gosec
 			}
 
 			// Find field by integer key
@@ -2936,15 +2938,15 @@ func (d *decoder) skip() {
 
 	switch t {
 	case cborTypeByteString, cborTypeTextString:
-		d.off += int(val)
+		d.off += int(val) //nolint:gosec
 
 	case cborTypeArray:
-		for i := 0; i < int(val); i++ {
+		for i := 0; i < int(val); i++ { //nolint:gosec
 			d.skip()
 		}
 
 	case cborTypeMap:
-		for i := 0; i < int(val)*2; i++ {
+		for i := 0; i < int(val)*2; i++ { //nolint:gosec
 			d.skip()
 		}
 

--- a/decode_map_utils.go
+++ b/decode_map_utils.go
@@ -52,6 +52,9 @@ func findStructFieldByKey(
 func findFieldCaseInsensitive(flds decodingFields, key string) (int, bool) {
 	keyLen := len(key)
 	for i, f := range flds {
+		if f.keyAsInt {
+			continue
+		}
 		if len(f.name) == keyLen && strings.EqualFold(f.name, key) {
 			return i, true
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -3404,12 +3404,12 @@ var invalidCBORUnmarshalTestCases = []struct {
 		wantErrorMsg: "cbor: wrong element type byte string for indefinite-length UTF-8 text string",
 	},
 	{
-		name:         "indefinite-length string chunks not definite-length",
+		name:         "indefinite-length string chunks not definite length",
 		data:         mustHexDecode("5f5f4100ffff"),
 		wantErrorMsg: "cbor: indefinite-length byte string chunk is not definite-length",
 	},
 	{
-		name:         "indefinite-length string chunks not definite-length",
+		name:         "indefinite-length string chunks not definite length",
 		data:         mustHexDecode("7f7f6100ffff"),
 		wantErrorMsg: "cbor: indefinite-length UTF-8 text string chunk is not definite-length",
 	},
@@ -6208,13 +6208,13 @@ func TestUnmarshalDupMapKeyToStruct(t *testing.T) {
 		},
 		{
 			name: "keyasint duplicate key does not overwrite previous value",
-			data: mustHexDecode("a36131616901614961616141"), // {"1": "i", 1: "I", "a": "A"}
+			data: mustHexDecode("a301616901614961616141"), // {1: "i", 1: "I", "a": "A"}
 			want: s{I: "i", A: "A"},
 		},
 		{
 			name:    "keyasint duplicate key triggers error",
 			opts:    DecOptions{DupMapKey: DupMapKeyEnforcedAPF},
-			data:    mustHexDecode("a36131616901614961616141"), // {"1": "i", 1: "I", "a": "A"}
+			data:    mustHexDecode("a301616901614961616141"), // {1: "i", 1: "I", "a": "A"}
 			want:    s{I: "i"},
 			wantErr: &DupMapKeyError{Key: int64(1), Index: 1},
 		},
@@ -8149,7 +8149,7 @@ func (f *IntFoo) Foo() string {
 type ByteFoo []byte
 
 func (f *ByteFoo) Foo() string {
-	return fmt.Sprint(*f)
+	return string(*f)
 }
 
 type StringFoo string
@@ -10981,6 +10981,217 @@ func TestJSONUnmarshalerTranscoder(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+// TestKeyAsIntTextKeyDoesNotMatchKeyAsIntField verifies that a CBOR text string
+// key does not match a struct field with the keyasint tag option, even if the
+// text content is the string representation of the integer key.
+func TestKeyAsIntTextKeyDoesNotMatchKeyAsIntField(t *testing.T) {
+	type s struct {
+		ID int `cbor:"1,keyasint"`
+	}
+
+	testCases := []struct {
+		name    string
+		opts    DecOptions
+		data    []byte
+		want    any
+		wantErr *UnknownFieldError
+	}{
+		{
+			name: "default options",
+			opts: defaultDecMode.DecOptions(),
+			data: mustHexDecode("a1613101"), // {"1": 1}
+			want: s{},
+		},
+		{
+			name:    "unknown field error options",
+			opts:    DecOptions{ExtraReturnErrors: ExtraDecErrorUnknownField},
+			data:    mustHexDecode("a1613101"), // {"1": 1}
+			want:    s{},
+			wantErr: &UnknownFieldError{Index: 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dm, err := tc.opts.DecMode()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var v s
+			err = dm.Unmarshal(tc.data, &v)
+			if err != nil {
+				if !reflect.DeepEqual(err, tc.wantErr) {
+					t.Errorf("got error: %v, wanted: %v", err, tc.wantErr)
+				}
+			} else {
+				if tc.wantErr != nil {
+					t.Errorf("got nil error, wanted: %v", tc.wantErr)
+				}
+			}
+
+			if !reflect.DeepEqual(v, tc.want) {
+				t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", tc.data, v, v, tc.want, tc.want)
+			}
+		})
+	}
+}
+
+// TestKeyAsIntNormalizedDuplicateFields verifies that struct fields with
+// keyasint tag values that are identical after integer normalization (e.g., "01"
+// and "1") are eliminated during field deduplication, matching the behavior of
+// two string-keyed fields with the same name.
+func TestKeyAsIntNormalizedDuplicateFields(t *testing.T) {
+	type s struct {
+		ID  int `cbor:"01,keyasint"`
+		ID2 int `cbor:"1,keyasint"`
+		ID3 int `cbor:"+1,keyasint"`
+	}
+
+	testCases := []struct {
+		name    string
+		opts    DecOptions
+		data    []byte
+		want    any
+		wantErr *UnknownFieldError
+	}{
+		{
+			name: "default options",
+			opts: defaultDecMode.DecOptions(),
+			data: mustHexDecode("a10101"), // {1: 1}
+			want: s{},
+		},
+		{
+			name:    "unknown field error options",
+			opts:    DecOptions{ExtraReturnErrors: ExtraDecErrorUnknownField},
+			data:    mustHexDecode("a10101"), // {1: 1}
+			want:    s{},
+			wantErr: &UnknownFieldError{Index: 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dm, err := tc.opts.DecMode()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var v s
+			err = dm.Unmarshal(tc.data, &v)
+			if err != nil {
+				if !reflect.DeepEqual(err, tc.wantErr) {
+					t.Errorf("got error: %v, wanted: %v", err, tc.wantErr)
+				}
+			} else {
+				if tc.wantErr != nil {
+					t.Errorf("got nil error, wanted: %v", tc.wantErr)
+				}
+			}
+
+			if !reflect.DeepEqual(v, tc.want) {
+				t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", tc.data, v, v, tc.want, tc.want)
+			}
+		})
+	}
+
+	v := s{ID: 1, ID2: 2, ID3: 3}
+	want := mustHexDecode("a0")
+
+	b, err := Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal() returned an error %v", err)
+	}
+	if !bytes.Equal(b, want) {
+		t.Errorf("Marshal() returned 0x%x, want 0x%x", b, want)
+	}
+}
+
+// TestKeyAsIntAndStringFieldsWithSameName verifies that a struct with both a
+// keyasint field and a string-keyed field with the same tag name (e.g.
+// cbor:"1,keyasint" and cbor:"1") can decode CBOR maps with integer and text
+// keys independently.
+func TestKeyAsIntAndStringFieldsWithSameName(t *testing.T) {
+	type s struct {
+		ID        int `cbor:"1,keyasint"`
+		AnotherID int `cbor:"1"`
+	}
+
+	data := mustHexDecode("a20101613102") // {1: 1, "1": 2}
+	want := s{
+		ID:        1,
+		AnotherID: 2,
+	}
+
+	var v s
+	err := Unmarshal(data, &v)
+	if err != nil {
+		t.Errorf("Unmarshal returned unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Unmarshal(0x%x) returned %+v, want %+v", data, v, want)
+	}
+
+	// Roundtrip
+	b, err := Marshal(want)
+	if err != nil {
+		t.Errorf("Marshal returned unexpected error: %v", err)
+	}
+	if !bytes.Equal(b, data) {
+		t.Errorf("Marshal(%+v) returned 0x%x, want 0x%x", want, b, data)
+	}
+}
+
+// TestMapKeyOverflowStructKeyAsInt verifies that a CBOR integer map
+// key that is outside the range of math.MinInt64 and math.MaxInt64
+// is rejected with an UnmarshalTypeError.
+func TestMapKeyOverflowStructKeyAsInt(t *testing.T) {
+	type s struct {
+		ID int `cbor:"-1,keyasint"`
+	}
+
+	testCases := []struct {
+		name    string
+		data    []byte
+		wantErr *UnmarshalTypeError
+	}{
+		{
+			name: "map key < math.MinInt64",
+			data: mustHexDecode("a13bffffffffffffffff01"), // {-18446744073709551616: 1}
+			wantErr: &UnmarshalTypeError{
+				CBORType: cborTypeNegativeInt.String(),
+				GoType:   "int64",
+				errorMsg: "-1-18446744073709551615 overflows Go's int64",
+			},
+		},
+		{
+			name: "map key > math.MaxInt64",
+			data: mustHexDecode("a11bffffffffffffffff01"), // {18446744073709551615: 1}
+			wantErr: &UnmarshalTypeError{
+				CBORType: cborTypePositiveInt.String(),
+				GoType:   "int64",
+				errorMsg: "18446744073709551615 overflows Go's int64",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v s
+			err := Unmarshal(tc.data, &v)
+			if err != nil {
+				if !reflect.DeepEqual(err, tc.wantErr) {
+					t.Errorf("got error: %v, wanted: %v", err, tc.wantErr)
+				}
+			} else {
+				if tc.wantErr != nil {
+					t.Errorf("got nil error, wanted: %v", tc.wantErr)
+				}
+			}
 		})
 	}
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -5276,11 +5276,11 @@ func TestUnmarshalArrayToStructWrongFieldTypeError(t *testing.T) {
 func TestUnmarshalArrayToStructCannotSetEmbeddedPointerError(t *testing.T) {
 	type (
 		s1 struct {
-			x int //nolint:unused,structcheck
+			x int //nolint:unused
 			X int
 		}
 		S2 struct {
-			y int //nolint:unused,structcheck
+			y int //nolint:unused
 			Y int
 		}
 		S struct {

--- a/diagnose.go
+++ b/diagnose.go
@@ -357,7 +357,7 @@ func (di *diagnose) item() error { //nolint:gocyclo
 
 	case cborTypeArray:
 		_, _, val := di.d.getHead()
-		count := int(val)
+		count := int(val) //nolint:gosec
 		di.w.WriteByte('[')
 
 		for i := 0; i < count; i++ {
@@ -373,7 +373,7 @@ func (di *diagnose) item() error { //nolint:gocyclo
 
 	case cborTypeMap:
 		_, _, val := di.d.getHead()
-		count := int(val)
+		count := int(val) //nolint:gosec
 		di.w.WriteByte('{')
 
 		for i := 0; i < count; i++ {
@@ -474,8 +474,8 @@ func (di *diagnose) item() error { //nolint:gocyclo
 func (di *diagnose) writeU16(val rune) {
 	di.w.WriteString("\\u")
 	var in [2]byte
-	in[0] = byte(val >> 8)
-	in[1] = byte(val)
+	in[0] = byte(val >> 8) //nolint:gosec
+	in[1] = byte(val)      //nolint:gosec
 	sz := hex.EncodedLen(len(in))
 	di.w.Grow(sz)
 	dst := di.w.Bytes()[di.w.Len() : di.w.Len()+sz]
@@ -628,7 +628,7 @@ func (di *diagnose) encodeFloat(ai byte, val uint64) error {
 	f64 := float64(0)
 	switch ai {
 	case additionalInformationAsFloat16:
-		f16 := float16.Frombits(uint16(val))
+		f16 := float16.Frombits(uint16(val)) //nolint:gosec
 		switch {
 		case f16.IsNaN():
 			di.w.WriteString("NaN")
@@ -644,7 +644,7 @@ func (di *diagnose) encodeFloat(ai byte, val uint64) error {
 		}
 
 	case additionalInformationAsFloat32:
-		f32 := math.Float32frombits(uint32(val))
+		f32 := math.Float32frombits(uint32(val)) //nolint:gosec
 		switch {
 		case f32 != f32:
 			di.w.WriteString("NaN")

--- a/diagnose_test.go
+++ b/diagnose_test.go
@@ -504,13 +504,13 @@ func TestDiagnoseByteString(t *testing.T) {
 			opts:     &DiagOptions{},
 		},
 		{
-			name:     "indefinite-length byte string with a empty byte string",
+			name:     "indefinite-length byte string with an empty byte string",
 			data:     mustHexDecode("5f40ff"),
 			wantDiag: `(_ h'')`, // RFC 8949, Section 8.1 says `(_ '')` but it looks wrong and conflicts with Appendix A.
 			opts:     &DiagOptions{},
 		},
 		{
-			name:     "indefinite-length byte string with two empty byte string",
+			name:     "indefinite-length byte string with two empty byte strings",
 			data:     mustHexDecode("5f4040ff"),
 			wantDiag: `(_ h'', h'')`,
 			opts:     &DiagOptions{},
@@ -620,13 +620,13 @@ func TestDiagnoseTextString(t *testing.T) {
 			opts:     &DiagOptions{},
 		},
 		{
-			name:     "indefinite-length text string with a empty text string",
+			name:     "indefinite-length text string with an empty text string",
 			data:     mustHexDecode("7f60ff"),
 			wantDiag: `(_ "")`,
 			opts:     &DiagOptions{},
 		},
 		{
-			name:     "indefinite-length text string with two empty text string",
+			name:     "indefinite-length text string with two empty text strings",
 			data:     mustHexDecode("7f6060ff"),
 			wantDiag: `(_ "", "")`,
 			opts:     &DiagOptions{},

--- a/encode.go
+++ b/encode.go
@@ -1136,10 +1136,11 @@ func encodeFloat(e *bytes.Buffer, em *encMode, v reflect.Value) error {
 	if fopt == ShortestFloat16 {
 		var f16 float16.Float16
 		p := float16.PrecisionFromfloat32(f32)
-		if p == float16.PrecisionExact {
+		switch p {
+		case float16.PrecisionExact:
 			// Roundtrip float32->float16->float32 test isn't needed.
 			f16 = float16.Fromfloat32(f32)
-		} else if p == float16.PrecisionUnknown {
+		case float16.PrecisionUnknown:
 			// Try roundtrip float32->float16->float32 to determine if float32 can fit into float16.
 			f16 = float16.Fromfloat32(f32)
 			if f16.Float32() == f32 {
@@ -1297,10 +1298,10 @@ func encodeByteString(e *bytes.Buffer, em *encMode, v reflect.Value) error {
 	if slen == 0 {
 		return e.WriteByte(byte(cborTypeByteString))
 	}
-	encodeHead(e, byte(cborTypeByteString), uint64(slen))
+	encodeHead(e, byte(cborTypeByteString), uint64(slen)) //nolint:gosec
 	if vk == reflect.Array {
 		for i := 0; i < slen; i++ {
-			e.WriteByte(byte(v.Index(i).Uint()))
+			e.WriteByte(byte(v.Index(i).Uint())) //nolint:gosec
 		}
 		return nil
 	}
@@ -1337,7 +1338,7 @@ func (ae arrayEncodeFunc) encode(e *bytes.Buffer, em *encMode, v reflect.Value) 
 	if alen == 0 {
 		return e.WriteByte(byte(cborTypeArray))
 	}
-	encodeHead(e, byte(cborTypeArray), uint64(alen))
+	encodeHead(e, byte(cborTypeArray), uint64(alen)) //nolint:gosec
 	for i := 0; i < alen; i++ {
 		if err := ae.f(e, em, v.Index(i)); err != nil {
 			return err
@@ -1368,7 +1369,7 @@ func (me mapEncodeFunc) encode(e *bytes.Buffer, em *encMode, v reflect.Value) er
 		return e.WriteByte(byte(cborTypeMap))
 	}
 
-	encodeHead(e, byte(cborTypeMap), uint64(mlen))
+	encodeHead(e, byte(cborTypeMap), uint64(mlen)) //nolint:gosec
 	if em.sort == SortNone || em.sort == SortFastShuffle || mlen <= 1 {
 		return me.e(e, em, v, nil)
 	}
@@ -1654,7 +1655,7 @@ func encodeTime(e *bytes.Buffer, em *encMode, v reflect.Value) error {
 
 	case TimeUnixDynamic:
 		t = t.UTC().Round(time.Microsecond)
-		secs, nsecs := t.Unix(), uint64(t.Nanosecond())
+		secs, nsecs := t.Unix(), uint64(t.Nanosecond()) //nolint:gosec
 		if nsecs == 0 {
 			return encodeInt(e, em, reflect.ValueOf(secs))
 		}

--- a/simplevalue.go
+++ b/simplevalue.go
@@ -93,6 +93,6 @@ func (sv *SimpleValue) unmarshalCBOR(data []byte) error {
 	// It is safe to cast val to uint8 here because
 	// - data is already verified to be well-formed CBOR simple value and
 	// - val is <= math.MaxUint8.
-	*sv = SimpleValue(val)
+	*sv = SimpleValue(val) //nolint:gosec
 	return nil
 }

--- a/structfields.go
+++ b/structfields.go
@@ -6,6 +6,7 @@ package cbor
 import (
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -84,6 +85,10 @@ func (x *nameLevelAndTagFieldSorter) Less(i, j int) bool {
 	if fi.name != fj.name {
 		return fi.name < fj.name
 	}
+	// Fields with the same name but different keyAsInt are in separate namespaces.
+	if fi.keyAsInt != fj.keyAsInt {
+		return fi.keyAsInt
+	}
 	if len(fi.idx) != len(fj.idx) {
 		return len(fi.idx) < len(fj.idx)
 	}
@@ -132,22 +137,37 @@ func getFields(t reflect.Type) (flds fields, structOptions string) {
 		}
 	}
 
+	// Normalize keyasint field names to their canonical integer string form.
+	// This ensures that "01", "+1", and "1" are treated as the same key
+	// during deduplication.
+	for _, f := range flds {
+		if f.keyAsInt {
+			nameAsInt, err := strconv.Atoi(f.name)
+			if err != nil {
+				continue // Leave invalid names for callers to report.
+			}
+			f.nameAsInt = int64(nameAsInt)
+			f.name = strconv.Itoa(nameAsInt)
+		}
+	}
+
 	sort.Sort(&nameLevelAndTagFieldSorter{flds})
 
 	// Keep visible fields.
 	j := 0 // index of next unique field
 	for i := 0; i < len(flds); {
 		name := flds[i].name
+		keyAsInt := flds[i].keyAsInt
 		if i == len(flds)-1 || // last field
-			name != flds[i+1].name || // field i has unique field name
+			name != flds[i+1].name || flds[i+1].keyAsInt != keyAsInt || // field i has unique (name, keyAsInt)
 			len(flds[i].idx) < len(flds[i+1].idx) || // field i is at a less nested level than field i+1
 			(flds[i].tagged && !flds[i+1].tagged) { // field i is tagged while field i+1 is not
 			flds[j] = flds[i]
 			j++
 		}
 
-		// Skip fields with the same field name.
-		for i++; i < len(flds) && name == flds[i].name; i++ { //nolint:revive
+		// Skip fields with the same (name, keyAsInt).
+		for i++; i < len(flds) && name == flds[i].name && keyAsInt == flds[i].keyAsInt; i++ { //nolint:revive
 		}
 	}
 	if j != len(flds) {

--- a/tag_test.go
+++ b/tag_test.go
@@ -689,7 +689,7 @@ func TestAddTagTypeAliasError(t *testing.T) {
 	tags := NewTagSet()
 	for i, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, tc.typ, uint64(100+i)); err == nil {
+			if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, tc.typ, uint64(100+i)); err == nil { //nolint:gosec
 				t.Errorf("TagSet.Add(%s, %d) didn't return an error", tc.typ.String(), 0)
 			} else if err.Error() != tc.wantErrorMsg {
 				t.Errorf("TagSet.Add(%s, %d) returned error msg %q, want %q", tc.typ.String(), 0, err, tc.wantErrorMsg)

--- a/valid.go
+++ b/valid.go
@@ -113,7 +113,7 @@ func (d *decoder) wellformedInternal(depth int, checkBuiltinTags bool) (int, err
 			}
 			return d.wellformedIndefiniteString(t, depth, checkBuiltinTags)
 		}
-		valInt := int(val)
+		valInt := int(val) //nolint:gosec
 		if valInt < 0 {
 			// Detect integer overflow
 			return 0, errors.New("cbor: " + t.String() + " length " + strconv.FormatUint(val, 10) + " is too large, causing integer overflow")
@@ -136,7 +136,7 @@ func (d *decoder) wellformedInternal(depth int, checkBuiltinTags bool) (int, err
 			return d.wellformedIndefiniteArrayOrMap(t, depth, checkBuiltinTags)
 		}
 
-		valInt := int(val)
+		valInt := int(val) //nolint:gosec
 		if valInt < 0 {
 			// Detect integer overflow
 			return 0, errors.New("cbor: " + t.String() + " length " + strconv.FormatUint(val, 10) + " is too large, it would cause integer overflow")
@@ -326,7 +326,7 @@ func (d *decoder) wellformedHead() (t cborType, ai byte, val uint64, err error) 
 		val = uint64(binary.BigEndian.Uint16(d.data[d.off : d.off+argumentSize]))
 		d.off += argumentSize
 		if t == cborTypePrimitives {
-			if err := d.acceptableFloat(float64(float16.Frombits(uint16(val)).Float32())); err != nil {
+			if err := d.acceptableFloat(float64(float16.Frombits(uint16(val)).Float32())); err != nil { //nolint:gosec
 				return 0, 0, 0, err
 			}
 		}
@@ -341,7 +341,7 @@ func (d *decoder) wellformedHead() (t cborType, ai byte, val uint64, err error) 
 		val = uint64(binary.BigEndian.Uint32(d.data[d.off : d.off+argumentSize]))
 		d.off += argumentSize
 		if t == cborTypePrimitives {
-			if err := d.acceptableFloat(float64(math.Float32frombits(uint32(val)))); err != nil {
+			if err := d.acceptableFloat(float64(math.Float32frombits(uint32(val)))); err != nil { //nolint:gosec
 				return 0, 0, 0, err
 			}
 		}


### PR DESCRIPTION
This PR fixes several issues related to `keyasint`.

These issues were identified and fixed while refactoring code and tests related to keyasint.

- DECODING: Previously, decoding a CBOR map integer key to a Go struct field using keyasint could overflow if the value is greater than math.MaxInt64.  This library never encodes such CBOR map keys by using keyasint, so this involves decoding CBOR data created by other means.

  This commit rejects CBOR map integer keys that exceed math.MaxInt64 when decoding to a struct field using keyasint.

- DECODING: Previously, decoding a CBOR map’s string key can match a Go struct field with the keyasint option if the text key matches the string representation of the integer key.  For example, CBOR map key "1" can match a struct field with tag `cbor:"1,keyasint"`.

  This commit prevents the string representation of an integer from matching the Go struct field tagged by keyasint by separating the keyasint field name and non-keyasint into separate namespaces.  CBOR map integer keys are matched to struct fields with the keyasint option, and CBOR map string keys are matched to struct fields without the keyasint option.

- ENCODING & DECODING: Previously, integer keys specified by keyasint tags were normalized after deduplication, allowing fields with the same normalized integer keys.  As a result, the CBOR map integer key matched the first field with the same normalized value.  Also, it was possible to encode duplicate keys with the same normalized values.

  This commit prevents duplicate integer keys by normalizing keyasint tag values before deduplication, and normalized duplicate keyasint fields are ignored.  This is the same way we currently handle duplicate string-key fields, which matches the behavior of encoding/json.

This PR also updated `.golangci.yml` to version 2.