### PR TITLE
Sync feature/stream-mode to release v2.9.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
+      time: "12:00"
+      timezone: "UTC"      
       
   - package-ecosystem: "gomod"
     directory: "/"

--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Install Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:

--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
     - name: Install Go
       uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:

--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:

--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Install Go
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
         go-version: 1.24
         check-latest: true

--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Install Go
-      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version: 1.24
         check-latest: true

--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Install Go
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         go-version: 1.24
         check-latest: true

--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Install Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:

--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install Go
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version: 1.24
         check-latest: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         check-latest: true
         
     - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         fetch-depth: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: ['1.20', 1.21, 1.22, 1.23, 1.24]
+        go-version: ['1.20', 1.21, 1.22, 1.23, 1.24, 1.25]
     steps:
     - name: Install Go
       uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         check-latest: true
         
     - name: Checkout code
-      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         fetch-depth: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         check-latest: true
         
     - name: Checkout code
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       with:
         fetch-depth: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         check-latest: true
         
     - name: Checkout code
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         go-version: ['1.20', 1.21, 1.22, 1.23, 1.24, 1.25]
     steps:
     - name: Install Go
-      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         go-version: ['1.20', 1.21, 1.22, 1.23, 1.24, 1.25]
     steps:
     - name: Install Go
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         go-version: ['1.20', 1.21, 1.22, 1.23, 1.24]
     steps:
     - name: Install Go
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         go-version: ['1.20', 1.21, 1.22, 1.23, 1.24, 1.25]
     steps:
     - name: Install Go
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.4
+      uses: github/codeql-action/init@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.4
+      uses: github/codeql-action/autobuild@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.4
+      uses: github/codeql-action/analyze@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.29.5
+      uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3 # v3.29.5
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.29.5
+      uses: github/codeql-action/autobuild@192325c86100d080feab897ff886c34abd4c83a3 # v3.29.5
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.29.5
+      uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.29.5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
+      uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
+      uses: github/codeql-action/autobuild@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
+      uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
+      uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
+      uses: github/codeql-action/autobuild@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
+      uses: github/codeql-action/analyze@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
+      uses: github/codeql-action/init@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4.31.4
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
+      uses: github/codeql-action/autobuild@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4.31.4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
+      uses: github/codeql-action/analyze@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4.31.4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
+      uses: github/codeql-action/init@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
+      uses: github/codeql-action/autobuild@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
+      uses: github/codeql-action/analyze@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
+      uses: github/codeql-action/init@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
+      uses: github/codeql-action/autobuild@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
+      uses: github/codeql-action/analyze@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+      uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.4
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+      uses: github/codeql-action/autobuild@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+      uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3 # v3.29.5
+      uses: github/codeql-action/init@303c0aef88fc2fe5ff6d63d3b1596bfd83dfa1f9 # v3.29.5
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@192325c86100d080feab897ff886c34abd4c83a3 # v3.29.5
+      uses: github/codeql-action/autobuild@303c0aef88fc2fe5ff6d63d3b1596bfd83dfa1f9 # v3.29.5
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.29.5
+      uses: github/codeql-action/analyze@303c0aef88fc2fe5ff6d63d3b1596bfd83dfa1f9 # v3.29.5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
+      uses: github/codeql-action/init@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
+      uses: github/codeql-action/autobuild@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
+      uses: github/codeql-action/analyze@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5
+      uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.5
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5
+      uses: github/codeql-action/autobuild@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.5
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5
+      uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@64d10c13136e1c5bce3e5fbde8d4906eeaafc885 # v3.29.5
+      uses: github/codeql-action/init@e296a935590eb16afc0c0108289f68c87e2a89a5 # v3.29.5
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@64d10c13136e1c5bce3e5fbde8d4906eeaafc885 # v3.29.5
+      uses: github/codeql-action/autobuild@e296a935590eb16afc0c0108289f68c87e2a89a5 # v3.29.5
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@64d10c13136e1c5bce3e5fbde8d4906eeaafc885 # v3.29.5
+      uses: github/codeql-action/analyze@e296a935590eb16afc0c0108289f68c87e2a89a5 # v3.29.5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+      uses: github/codeql-action/init@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+      uses: github/codeql-action/autobuild@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+      uses: github/codeql-action/analyze@16140ae1a102900babc80a33c44059580f687047 # v4.30.9

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
+      uses: github/codeql-action/init@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
+      uses: github/codeql-action/autobuild@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
+      uses: github/codeql-action/analyze@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
+      uses: github/codeql-action/init@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
+      uses: github/codeql-action/autobuild@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
+      uses: github/codeql-action/analyze@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e296a935590eb16afc0c0108289f68c87e2a89a5 # v3.29.5
+      uses: github/codeql-action/init@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@e296a935590eb16afc0c0108289f68c87e2a89a5 # v3.29.5
+      uses: github/codeql-action/autobuild@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e296a935590eb16afc0c0108289f68c87e2a89a5 # v3.29.5
+      uses: github/codeql-action/analyze@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.5
+      uses: github/codeql-action/init@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.29.5
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.5
+      uses: github/codeql-action/autobuild@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.29.5
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.5
+      uses: github/codeql-action/analyze@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.29.5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@303c0aef88fc2fe5ff6d63d3b1596bfd83dfa1f9 # v3.29.5
+      uses: github/codeql-action/init@64d10c13136e1c5bce3e5fbde8d4906eeaafc885 # v3.29.5
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@303c0aef88fc2fe5ff6d63d3b1596bfd83dfa1f9 # v3.29.5
+      uses: github/codeql-action/autobuild@64d10c13136e1c5bce3e5fbde8d4906eeaafc885 # v3.29.5
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@303c0aef88fc2fe5ff6d63d3b1596bfd83dfa1f9 # v3.29.5
+      uses: github/codeql-action/analyze@64d10c13136e1c5bce3e5fbde8d4906eeaafc885 # v3.29.5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
+      uses: github/codeql-action/init@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
+      uses: github/codeql-action/autobuild@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
+      uses: github/codeql-action/analyze@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4.31.4
+      uses: github/codeql-action/init@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4.31.4
+      uses: github/codeql-action/autobuild@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4.31.4
+      uses: github/codeql-action/analyze@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+      uses: github/codeql-action/init@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+      uses: github/codeql-action/autobuild@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+      uses: github/codeql-action/analyze@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+      uses: github/codeql-action/init@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+      uses: github/codeql-action/autobuild@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+      uses: github/codeql-action/analyze@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
+      uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
+      uses: github/codeql-action/autobuild@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
+      uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
+      uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
+      uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
+      uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+      uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+      uses: github/codeql-action/autobuild@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+      uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+      uses: github/codeql-action/init@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
       with:
         languages: ${{ matrix.language }}
 
@@ -44,7 +44,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+      uses: github/codeql-action/autobuild@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+      uses: github/codeql-action/analyze@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout source
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         fetch-depth: 1
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout source
-      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         fetch-depth: 1
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -33,7 +33,7 @@ jobs:
         fetch-depth: 1
 
     - name: Install Go and setup env
-      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version: 1.23
         check-latest: true

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -33,7 +33,7 @@ jobs:
         fetch-depth: 1
 
     - name: Install Go and setup env
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
         go-version: 1.23
         check-latest: true

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -33,7 +33,7 @@ jobs:
         fetch-depth: 1
 
     - name: Install Go and setup env
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         go-version: 1.23
         check-latest: true

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout source
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 1
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout source
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       with:
         fetch-depth: 1
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -33,7 +33,7 @@ jobs:
         fetch-depth: 1
 
     - name: Install Go and setup env
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version: 1.23
         check-latest: true

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout source
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout source
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout source
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -16,10 +16,10 @@ on:
     branches: [main, master]
 
 env:
-  GO_VERSION: '1.22'
-  GOLINTERS_VERSION: 1.59.1
+  GO_VERSION: '1.25'
+  GOLINTERS_VERSION: 2.10.1
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791
+  GOLINTERS_TGZ_DGST: dfa775874cf0561b404a02a8f4481fc69b28091da95aa697259820d429b09c99
   GOLINTERS_TIMEOUT: 15m
   OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,104 +1,116 @@
-# Do not delete linter settings. Linters like gocritic can be enabled on the command line.
-
-linters-settings:
-  depguard:
-    rules:
-      prevent_unmaintained_packages:
-        list-mode: strict
-        files:
-          - $all
-          - "!$test"
-        allow:
-          - $gostd
-          - github.com/x448/float16
-        deny:
-          - pkg: io/ioutil
-            desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 100
-    statements: 50
-  goconst:
-    ignore-tests: true
-    min-len: 2
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - commentedOutCode
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - paramTypeCombine
-      - whyNoLint
-  gofmt:
-    simplify: false
-  goimports:
-    local-prefixes: github.com/fxamacker/cbor
-  golint:
-    min-confidence: 0
-  govet:
-    check-shadowing: true
-  lll:
-    line-length: 140
-  maligned:
-    suggest-new: true
-  misspell:
-    locale: US
-  staticcheck:
-    checks: ["all"]
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bidichk
     - depguard
     - errcheck
-    - exportloopref
+    - forbidigo
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nilerr
     - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unused
-
+  settings:
+    depguard:
+      rules:
+        prevent_unmaintained_packages:
+          list-mode: strict
+          files:
+            - $all
+            - '!$test'
+          allow:
+            - $gostd
+            - github.com/x448/float16
+          deny:
+            - pkg: io/ioutil
+              desc: 'replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil'
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 100
+      statements: 50
+    goconst:
+      min-len: 2
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - commentedOutCode
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - paramTypeCombine
+        - whyNoLint
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: decode.go
+        text: string ` overflows ` has (\d+) occurrences, make it a constant
+      - path: decode.go
+        text: string ` \(range is \[` has (\d+) occurrences, make it a constant
+      - path: decode.go
+        text: string `, ` has (\d+) occurrences, make it a constant
+      - path: decode.go
+        text: string ` overflows Go's int64` has (\d+) occurrences, make it a constant
+      - path: decode.go
+        text: string `\]\)` has (\d+) occurrences, make it a constant
+      - path: valid.go
+        text: string ` for type ` has (\d+) occurrences, make it a constant
+      - path: valid.go
+        text: 'string `cbor: ` has (\d+) occurrences, make it a constant'
+      - linters:
+          - goconst
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # max-issues-per-linter default is 50.  Set to 0 to disable limit.
   max-issues-per-linter: 0
-  # max-same-issues default is 3.  Set to 0 to disable limit.
   max-same-issues: 0
-
-  exclude-rules:
-    - path: decode.go
-      text: "string ` overflows ` has (\\d+) occurrences, make it a constant"
-    - path: decode.go
-      text: "string ` \\(range is \\[` has (\\d+) occurrences, make it a constant"
-    - path: decode.go
-      text: "string `, ` has (\\d+) occurrences, make it a constant"
-    - path: decode.go
-      text: "string ` overflows Go's int64` has (\\d+) occurrences, make it a constant"
-    - path: decode.go
-      text: "string `\\]\\)` has (\\d+) occurrences, make it a constant"
-    - path: valid.go
-      text: "string ` for type ` has (\\d+) occurrences, make it a constant"
-    - path: valid.go
-      text: "string `cbor: ` has (\\d+) occurrences, make it a constant"
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false
+    goimports:
+      local-prefixes:
+        - github.com/fxamacker/cbor
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/README.md
+++ b/README.md
@@ -702,20 +702,19 @@ Default limits may need to be increased for systems handling very large data (e.
 
 ## Status
 
-[v2.9.0](https://github.com/fxamacker/cbor/releases/tag/v2.9.0) (Jul 13, 2025) improved interoperability/transcoding between CBOR & JSON, refactored tests, and improved docs.
-- Add opt-in support for `encoding.TextMarshaler` and `encoding.TextUnmarshaler` to encode and decode from CBOR text string.
-- Add opt-in support for `json.Marshaler` and `json.Unmarshaler` via user-provided transcoding function.
-- Update docs for TimeMode, Tag, RawTag, and add example for Embedded JSON Tag for CBOR.
+v2.9.1 (Mar 29-30, 2026) includes important bugfixes, defensive checks, improved code quality, and more tests.  Although not public, the fuzzer was also improved by adding more fuzz tests.
 
-v2.9.0 passed fuzz tests and is production quality.
+v2.9.1 passed fuzz tests and is production quality.
 
 The minimum version of Go required to build:
 - v2.8.0 and newer releases require go 1.20+.
 - v2.7.1 and older releases require go 1.17+.
 
-For more details, see [release notes](https://github.com/fxamacker/cbor/releases).
+For more details, see [v2.9.1 release notes](https://github.com/fxamacker/cbor/releases).
 
 ### Prior Releases
+
+[v2.9.0](https://github.com/fxamacker/cbor/releases/tag/v2.9.0) (Jul 13, 2025) improved interoperability/transcoding between CBOR & JSON, refactored tests, and improved docs.   It passed fuzz tests (billions of executions) and is production quality.
 
 [v2.8.0](https://github.com/fxamacker/cbor/releases/tag/v2.8.0) (March 30, 2025) is a small release primarily to add `omitzero` option to struct field tags and fix bugs.   It passed fuzz tests (billions of executions) and is production quality.
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -192,22 +192,22 @@ var decodeBenchmarks = []struct {
 		decodeToTypes: []reflect.Type{typeIntf, typeFloat64},
 	}, // float64(-4.1)
 	{
-		name:          "bytes",
+		name:          "byte string",
 		data:          mustHexDecode("581a0102030405060708090a0b0c0d0e0f101112131415161718191a"),
 		decodeToTypes: []reflect.Type{typeIntf, typeByteSlice},
 	}, // []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
 	{
-		name:          "bytes indef len",
+		name:          "indefinite-length byte string",
 		data:          mustHexDecode("5f410141024103410441054106410741084109410a410b410c410d410e410f4110411141124113411441154116411741184119411aff"),
 		decodeToTypes: []reflect.Type{typeIntf, typeByteSlice},
 	}, // []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
 	{
-		name:          "text",
+		name:          "text string",
 		data:          mustHexDecode("782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67"),
 		decodeToTypes: []reflect.Type{typeIntf, typeString},
 	}, // "The quick brown fox jumps over the lazy dog"
 	{
-		name:          "text indef len",
+		name:          "indefinite-length text string",
 		data:          mustHexDecode("7f61546168616561206171617561696163616b612061626172616f6177616e61206166616f61786120616a6175616d617061736120616f61766165617261206174616861656120616c6161617a617961206164616f6167ff"),
 		decodeToTypes: []reflect.Type{typeIntf, typeString},
 	}, // "The quick brown fox jumps over the lazy dog"
@@ -217,7 +217,7 @@ var decodeBenchmarks = []struct {
 		decodeToTypes: []reflect.Type{typeIntf, typeIntSlice},
 	}, // []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
 	{
-		name:          "array indef len",
+		name:          "indefinite-length array",
 		data:          mustHexDecode("9f0102030405060708090a0b0c0d0e0f101112131415161718181819181aff"),
 		decodeToTypes: []reflect.Type{typeIntf, typeIntSlice},
 	}, // []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
@@ -227,7 +227,7 @@ var decodeBenchmarks = []struct {
 		decodeToTypes: []reflect.Type{typeIntf, typeMapStringIntf, typeMapStringString},
 	}, // map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}}
 	{
-		name:          "map indef len",
+		name:          "indefinite-length map",
 		data:          mustHexDecode("bf616161416162614261636143616461446165614561666146616761476168614861696149616a614a616b614b616c614c616d614d616e614eff"),
 		decodeToTypes: []reflect.Type{typeIntf, typeMapStringIntf, typeMapStringString},
 	}, // map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}}

--- a/bench_test.go
+++ b/bench_test.go
@@ -986,13 +986,13 @@ func BenchmarkUnmarshalMapToStruct(b *testing.B) {
 			b.Fatalf("invalid test assumption: ManyFields expected to have no more than 255 fields, has %d", rt.NumField())
 		}
 		buf.WriteByte(0xb8)
-		buf.WriteByte(byte(rt.NumField()))
+		buf.WriteByte(byte(rt.NumField()))        //nolint:gosec
 		for i := rt.NumField() - 1; i >= 0; i-- { // backwards
 			f := rt.Field(i)
 			if len(f.Name) > 23 {
 				b.Fatalf("invalid test assumption: field name %q longer than 23 bytes", f.Name)
 			}
-			buf.WriteByte(byte(0x60 + len(f.Name)))
+			buf.WriteByte(byte(0x60 + len(f.Name))) //nolint:gosec
 			buf.WriteString(f.Name)
 			buf.WriteByte(0xf5) // true
 		}

--- a/bytestring_test.go
+++ b/bytestring_test.go
@@ -4,6 +4,7 @@
 package cbor
 
 import (
+	"bytes"
 	"io"
 	"strings"
 	"testing"
@@ -206,6 +207,38 @@ func TestUnmarshalByteStringOnBadData(t *testing.T) {
 				if !strings.HasPrefix(err.Error(), tc.errMsg) {
 					t.Errorf("Unmarshal(%x) returned error %q, want %q", tc.data, err.Error(), tc.errMsg)
 				}
+			}
+		})
+	}
+}
+
+func TestByteStringBytes(t *testing.T) {
+	testCases := []struct {
+		name string
+		bs   ByteString
+		want []byte
+	}{
+		{
+			name: "empty",
+			bs:   ByteString(""),
+			want: []byte{},
+		},
+		{
+			name: "non-empty",
+			bs:   ByteString("\x01\x02\x03\x04"),
+			want: []byte{0x01, 0x02, 0x03, 0x04},
+		},
+		{
+			name: "text content",
+			bs:   ByteString("hello"),
+			want: []byte("hello"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.bs.Bytes()
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("ByteString(%x).Bytes() = %x, want %x", string(tc.bs), got, tc.want)
 			}
 		})
 	}

--- a/bytestring_test.go
+++ b/bytestring_test.go
@@ -27,7 +27,7 @@ func TestByteString(t *testing.T) {
 	emptybs := ByteString("")
 	bs := ByteString("\x01\x02\x03\x04")
 
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			name:         "empty",
 			obj:          emptybs,
@@ -107,78 +107,78 @@ func TestByteString(t *testing.T) {
 
 func TestUnmarshalByteStringOnBadData(t *testing.T) {
 	testCases := []struct {
-		name   string
-		data   []byte
-		errMsg string
+		name         string
+		data         []byte
+		wantErrorMsg string
 	}{
 		// Empty data
 		{
-			name:   "nil data",
-			data:   nil,
-			errMsg: io.EOF.Error(),
+			name:         "nil data",
+			data:         nil,
+			wantErrorMsg: io.EOF.Error(),
 		},
 		{
-			name:   "empty data",
-			data:   []byte{},
-			errMsg: io.EOF.Error(),
+			name:         "empty data",
+			data:         []byte{},
+			wantErrorMsg: io.EOF.Error(),
 		},
 
 		// Wrong CBOR types
 		{
-			name:   "uint type",
-			data:   mustHexDecode("01"),
-			errMsg: "cbor: cannot unmarshal positive integer into Go value of type cbor.ByteString",
+			name:         "uint type",
+			data:         mustHexDecode("01"),
+			wantErrorMsg: "cbor: cannot unmarshal positive integer into Go value of type cbor.ByteString",
 		},
 		{
-			name:   "int type",
-			data:   mustHexDecode("20"),
-			errMsg: "cbor: cannot unmarshal negative integer into Go value of type cbor.ByteString",
+			name:         "int type",
+			data:         mustHexDecode("20"),
+			wantErrorMsg: "cbor: cannot unmarshal negative integer into Go value of type cbor.ByteString",
 		},
 		{
-			name:   "string type",
-			data:   mustHexDecode("60"),
-			errMsg: "cbor: cannot unmarshal UTF-8 text string into Go value of type cbor.ByteString",
+			name:         "string type",
+			data:         mustHexDecode("60"),
+			wantErrorMsg: "cbor: cannot unmarshal UTF-8 text string into Go value of type cbor.ByteString",
 		},
 		{
-			name:   "array type",
-			data:   mustHexDecode("80"),
-			errMsg: "cbor: cannot unmarshal array into Go value of type cbor.ByteString",
+			name:         "array type",
+			data:         mustHexDecode("80"),
+			wantErrorMsg: "cbor: cannot unmarshal array into Go value of type cbor.ByteString",
 		},
 		{
-			name:   "map type",
-			data:   mustHexDecode("a0"),
-			errMsg: "cbor: cannot unmarshal map into Go value of type cbor.ByteString",
+			name:         "map type",
+			data:         mustHexDecode("a0"),
+			wantErrorMsg: "cbor: cannot unmarshal map into Go value of type cbor.ByteString",
 		},
 		{
-			name:   "tag type",
-			data:   mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
-			errMsg: "cbor: cannot unmarshal tag into Go value of type cbor.ByteString",
+			name:         "tag type",
+			data:         mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			wantErrorMsg: "cbor: cannot unmarshal tag into Go value of type cbor.ByteString",
 		},
 		{
-			name:   "float type",
-			data:   mustHexDecode("f90000"),
-			errMsg: "cbor: cannot unmarshal primitives into Go value of type cbor.ByteString",
+			name:         "float type",
+			data:         mustHexDecode("f90000"),
+			wantErrorMsg: "cbor: cannot unmarshal primitives into Go value of type cbor.ByteString",
 		},
 
 		// Truncated CBOR data
 		{
-			name:   "truncated head",
-			data:   mustHexDecode("18"),
-			errMsg: io.ErrUnexpectedEOF.Error(),
+			name:         "truncated head",
+			data:         mustHexDecode("18"),
+			wantErrorMsg: io.ErrUnexpectedEOF.Error(),
 		},
 
 		// Truncated CBOR byte string
 		{
-			name:   "truncated byte string",
-			data:   mustHexDecode("44010203"),
-			errMsg: io.ErrUnexpectedEOF.Error(),
+			name:         "truncated byte string",
+			data:         mustHexDecode("44010203"),
+			wantErrorMsg: io.ErrUnexpectedEOF.Error(),
 		},
 
 		// Extraneous CBOR data
 		{
-			name:   "extraneous data",
-			data:   mustHexDecode("c074323031332d30332d32315432303a30343a30305a00"),
-			errMsg: "cbor: 1 bytes of extraneous data starting at index 22",
+			name:         "extraneous data",
+			data:         mustHexDecode("c074323031332d30332d32315432303a30343a30305a00"),
+			wantErrorMsg: "cbor: 1 bytes of extraneous data starting at index 22",
 		},
 	}
 
@@ -192,8 +192,8 @@ func TestUnmarshalByteStringOnBadData(t *testing.T) {
 				if err == nil {
 					t.Errorf("UnmarshalCBOR(%x) didn't return error", tc.data)
 				}
-				if !strings.HasPrefix(err.Error(), tc.errMsg) {
-					t.Errorf("UnmarshalCBOR(%x) returned error %q, want %q", tc.data, err.Error(), tc.errMsg)
+				if !strings.HasPrefix(err.Error(), tc.wantErrorMsg) {
+					t.Errorf("UnmarshalCBOR(%x) returned error %q, want %q", tc.data, err.Error(), tc.wantErrorMsg)
 				}
 			}
 			// Test Unmarshal(data, *ByteString), which calls ByteString.unmarshalCBOR() under the hood
@@ -204,8 +204,8 @@ func TestUnmarshalByteStringOnBadData(t *testing.T) {
 				if err == nil {
 					t.Errorf("Unmarshal(%x) didn't return error", tc.data)
 				}
-				if !strings.HasPrefix(err.Error(), tc.errMsg) {
-					t.Errorf("Unmarshal(%x) returned error %q, want %q", tc.data, err.Error(), tc.errMsg)
+				if !strings.HasPrefix(err.Error(), tc.wantErrorMsg) {
+					t.Errorf("Unmarshal(%x) returned error %q, want %q", tc.data, err.Error(), tc.wantErrorMsg)
 				}
 			}
 		})

--- a/cache.go
+++ b/cache.go
@@ -92,10 +92,11 @@ func newTypeInfo(t reflect.Type) *typeInfo {
 }
 
 type decodingStructType struct {
-	fields             fields
-	fieldIndicesByName map[string]int
-	err                error
-	toArray            bool
+	fields               fields
+	fieldIndicesByName   map[string]int
+	fieldIndicesByIntKey map[int64]int
+	err                  error
+	toArray              bool
 }
 
 func getDecodingStructType(t reflect.Type) *decodingStructType {
@@ -122,21 +123,29 @@ func getDecodingStructType(t reflect.Type) *decodingStructType {
 	}
 
 	fieldIndicesByName := make(map[string]int, len(flds))
+	var fieldIndicesByIntKey map[int64]int
 	for i, fld := range flds {
 		if _, ok := fieldIndicesByName[fld.name]; ok {
 			errs = append(errs, fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, fld.name))
 			continue
 		}
 		fieldIndicesByName[fld.name] = i
+		if fld.keyAsInt {
+			if fieldIndicesByIntKey == nil {
+				fieldIndicesByIntKey = make(map[int64]int, len(flds))
+			}
+			fieldIndicesByIntKey[fld.nameAsInt] = i
+		}
 	}
 
 	err := errors.Join(errs...)
 
 	structType := &decodingStructType{
-		fields:             flds,
-		fieldIndicesByName: fieldIndicesByName,
-		err:                err,
-		toArray:            toArray,
+		fields:               flds,
+		fieldIndicesByName:   fieldIndicesByName,
+		fieldIndicesByIntKey: fieldIndicesByIntKey,
+		err:                  err,
+		toArray:              toArray,
 	}
 	decodingStructTypeCache.Store(t, structType)
 	return structType

--- a/cache.go
+++ b/cache.go
@@ -92,9 +92,9 @@ func newTypeInfo(t reflect.Type) *typeInfo {
 }
 
 type decodingStructType struct {
-	fields               fields
-	fieldIndicesByName   map[string]int
-	fieldIndicesByIntKey map[int64]int
+	fields               decodingFields
+	fieldIndicesByName   map[string]int // Only populated if toArray is false
+	fieldIndicesByIntKey map[int64]int  // Only populated if toArray is false
 	err                  error
 	toArray              bool
 }
@@ -119,39 +119,43 @@ func getDecodingStructType(t reflect.Type) (*decodingStructType, error) {
 	fieldIndicesByName := make(map[string]int, len(flds))
 	var fieldIndicesByIntKey map[int64]int
 
-	for i := 0; i < len(flds); i++ {
-		if flds[i].keyAsInt {
-			nameAsInt, numErr := strconv.Atoi(flds[i].name)
+	decFlds := make(decodingFields, len(flds))
+	for i, f := range flds {
+		if f.keyAsInt {
+			nameAsInt, numErr := strconv.Atoi(f.name)
 			if numErr != nil {
 				structType := &decodingStructType{
-					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+					err: errors.New("cbor: failed to parse field name \"" + f.name + "\" to int (" + numErr.Error() + ")"),
 				}
 				decodingStructTypeCache.Store(t, structType)
 				return nil, structType.err
 			}
-			flds[i].nameAsInt = int64(nameAsInt)
+			f.nameAsInt = int64(nameAsInt)
 		}
 
-		if _, ok := fieldIndicesByName[flds[i].name]; ok {
+		if _, ok := fieldIndicesByName[f.name]; ok {
 			structType := &decodingStructType{
-				err: fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, flds[i].name),
+				err: fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, f.name),
 			}
 			decodingStructTypeCache.Store(t, structType)
 			return nil, structType.err
 		}
-		fieldIndicesByName[flds[i].name] = i
-		if flds[i].keyAsInt {
+		fieldIndicesByName[f.name] = i
+		if f.keyAsInt {
 			if fieldIndicesByIntKey == nil {
 				fieldIndicesByIntKey = make(map[int64]int, len(flds))
 			}
-			fieldIndicesByIntKey[flds[i].nameAsInt] = i
+			fieldIndicesByIntKey[f.nameAsInt] = i
 		}
 
-		flds[i].typInfo = getTypeInfo(flds[i].typ)
+		decFlds[i] = &decodingField{
+			field:   *f,
+			typInfo: getTypeInfo(f.typ),
+		}
 	}
 
 	structType := &decodingStructType{
-		fields:               flds,
+		fields:               decFlds,
 		fieldIndicesByName:   fieldIndicesByName,
 		fieldIndicesByIntKey: fieldIndicesByIntKey,
 	}
@@ -160,24 +164,28 @@ func getDecodingStructType(t reflect.Type) (*decodingStructType, error) {
 }
 
 func getDecodingStructToArrayType(t reflect.Type, flds fields) (*decodingStructType, error) {
-	for i := 0; i < len(flds); i++ {
+	decFlds := make(decodingFields, len(flds))
+	for i, f := range flds {
 		// nameAsInt is set in getFields() except for fields with an unparsable tagged name.
 		// Atoi() is called here to catch and save parsing errors.
-		if flds[i].keyAsInt && flds[i].nameAsInt == 0 {
-			if _, numErr := strconv.Atoi(flds[i].name); numErr != nil {
+		if f.keyAsInt && f.nameAsInt == 0 {
+			if _, numErr := strconv.Atoi(f.name); numErr != nil {
 				structType := &decodingStructType{
-					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+					err: errors.New("cbor: failed to parse field name \"" + f.name + "\" to int (" + numErr.Error() + ")"),
 				}
 				decodingStructTypeCache.Store(t, structType)
 				return nil, structType.err
 			}
 		}
 
-		flds[i].typInfo = getTypeInfo(flds[i].typ)
+		decFlds[i] = &decodingField{
+			field:   *f,
+			typInfo: getTypeInfo(f.typ),
+		}
 	}
 
 	structType := &decodingStructType{
-		fields:  flds,
+		fields:  decFlds,
 		toArray: true,
 	}
 	decodingStructTypeCache.Store(t, structType)
@@ -185,15 +193,15 @@ func getDecodingStructToArrayType(t reflect.Type, flds fields) (*decodingStructT
 }
 
 type encodingStructType struct {
-	fields             fields
-	bytewiseFields     fields
-	lengthFirstFields  fields
-	omitEmptyFieldsIdx []int
+	fields             encodingFields
+	bytewiseFields     encodingFields // Only populated if toArray is false
+	lengthFirstFields  encodingFields // Only populated if toArray is false
+	omitEmptyFieldsIdx []int          // Only populated if toArray is false
 	err                error
 	toArray            bool
 }
 
-func (st *encodingStructType) getFields(em *encMode) fields {
+func (st *encodingStructType) getFields(em *encMode) encodingFields {
 	switch em.sort {
 	case SortNone, SortFastShuffle:
 		return st.fields
@@ -205,7 +213,7 @@ func (st *encodingStructType) getFields(em *encMode) fields {
 }
 
 type bytewiseFieldSorter struct {
-	fields fields
+	fields encodingFields
 }
 
 func (x *bytewiseFieldSorter) Len() int {
@@ -221,7 +229,7 @@ func (x *bytewiseFieldSorter) Less(i, j int) bool {
 }
 
 type lengthFirstFieldSorter struct {
-	fields fields
+	fields encodingFields
 }
 
 func (x *lengthFirstFieldSorter) Len() int {
@@ -258,13 +266,18 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 	var hasKeyAsStr bool
 	var omitEmptyIdx []int
 
+	encFlds := make(encodingFields, len(flds))
+
 	e := getEncodeBuffer()
 	defer putEncodeBuffer(e)
 
-	for i := 0; i < len(flds); i++ {
+	for i, f := range flds {
+		encFlds[i] = &encodingField{field: *f}
+		ef := encFlds[i]
+
 		// Get field's encodeFunc
-		flds[i].ef, flds[i].ief, flds[i].izf = getEncodeFunc(flds[i].typ)
-		if flds[i].ef == nil {
+		ef.ef, ef.ief, ef.izf = getEncodeFunc(f.typ)
+		if ef.ef == nil {
 			structType := &encodingStructType{err: &UnsupportedTypeError{t}}
 			encodingStructTypeCache.Store(t, structType)
 			return nil, structType.err
@@ -287,51 +300,51 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 				n := nameAsInt*(-1) - 1
 				encodeHead(e, byte(cborTypeNegativeInt), uint64(n))
 			}
-			flds[i].cborName = make([]byte, e.Len())
-			copy(flds[i].cborName, e.Bytes())
+			ef.cborName = make([]byte, e.Len())
+			copy(ef.cborName, e.Bytes())
 			e.Reset()
 
 			hasKeyAsInt = true
 		} else {
-			encodeHead(e, byte(cborTypeTextString), uint64(len(flds[i].name)))
-			flds[i].cborName = make([]byte, e.Len()+len(flds[i].name))
-			n := copy(flds[i].cborName, e.Bytes())
-			copy(flds[i].cborName[n:], flds[i].name)
+			encodeHead(e, byte(cborTypeTextString), uint64(len(f.name)))
+			ef.cborName = make([]byte, e.Len()+len(f.name))
+			n := copy(ef.cborName, e.Bytes())
+			copy(ef.cborName[n:], f.name)
 			e.Reset()
 
 			// If cborName contains a text string, then cborNameByteString contains a
 			// string that has the byte string major type but is otherwise identical to
 			// cborName.
-			flds[i].cborNameByteString = make([]byte, len(flds[i].cborName))
-			copy(flds[i].cborNameByteString, flds[i].cborName)
+			ef.cborNameByteString = make([]byte, len(ef.cborName))
+			copy(ef.cborNameByteString, ef.cborName)
 			// Reset encoded CBOR type to byte string, preserving the "additional
 			// information" bits:
-			flds[i].cborNameByteString[0] = byte(cborTypeByteString) |
-				getAdditionalInformation(flds[i].cborNameByteString[0])
+			ef.cborNameByteString[0] = byte(cborTypeByteString) |
+				getAdditionalInformation(ef.cborNameByteString[0])
 
 			hasKeyAsStr = true
 		}
 
 		// Check if field can be omitted when empty
-		if flds[i].omitEmpty {
+		if f.omitEmpty {
 			omitEmptyIdx = append(omitEmptyIdx, i)
 		}
 	}
 
 	// Sort fields by canonical order
-	bytewiseFields := make(fields, len(flds))
-	copy(bytewiseFields, flds)
+	bytewiseFields := make(encodingFields, len(encFlds))
+	copy(bytewiseFields, encFlds)
 	sort.Sort(&bytewiseFieldSorter{bytewiseFields})
 
 	lengthFirstFields := bytewiseFields
 	if hasKeyAsInt && hasKeyAsStr {
-		lengthFirstFields = make(fields, len(flds))
-		copy(lengthFirstFields, flds)
+		lengthFirstFields = make(encodingFields, len(encFlds))
+		copy(lengthFirstFields, encFlds)
 		sort.Sort(&lengthFirstFieldSorter{lengthFirstFields})
 	}
 
 	structType := &encodingStructType{
-		fields:             flds,
+		fields:             encFlds,
 		bytewiseFields:     bytewiseFields,
 		lengthFirstFields:  lengthFirstFields,
 		omitEmptyFieldsIdx: omitEmptyIdx,
@@ -342,10 +355,11 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 }
 
 func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructType, error) {
-	for i := 0; i < len(flds); i++ {
-		// Get field's encodeFunc
-		flds[i].ef, flds[i].ief, flds[i].izf = getEncodeFunc(flds[i].typ)
-		if flds[i].ef == nil {
+	encFlds := make(encodingFields, len(flds))
+	for i, f := range flds {
+		encFlds[i] = &encodingField{field: *f}
+		encFlds[i].ef, encFlds[i].ief, encFlds[i].izf = getEncodeFunc(f.typ)
+		if encFlds[i].ef == nil {
 			structType := &encodingStructType{err: &UnsupportedTypeError{t}}
 			encodingStructTypeCache.Store(t, structType)
 			return nil, structType.err
@@ -353,7 +367,7 @@ func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructT
 	}
 
 	structType := &encodingStructType{
-		fields:  flds,
+		fields:  encFlds,
 		toArray: true,
 	}
 	encodingStructTypeCache.Store(t, structType)

--- a/cache.go
+++ b/cache.go
@@ -121,31 +121,41 @@ func getDecodingStructType(t reflect.Type) (*decodingStructType, error) {
 
 	decFlds := make(decodingFields, len(flds))
 	for i, f := range flds {
-		if f.keyAsInt {
-			nameAsInt, numErr := strconv.Atoi(f.name)
-			if numErr != nil {
+		// nameAsInt is set in getFields() except for fields with an unparsable tagged name.
+		// Atoi() is called here to catch and save parsing errors.
+		if f.keyAsInt && f.nameAsInt == 0 {
+			if _, numErr := strconv.Atoi(f.name); numErr != nil {
 				structType := &decodingStructType{
 					err: errors.New("cbor: failed to parse field name \"" + f.name + "\" to int (" + numErr.Error() + ")"),
 				}
 				decodingStructTypeCache.Store(t, structType)
 				return nil, structType.err
 			}
-			f.nameAsInt = int64(nameAsInt)
 		}
 
-		if _, ok := fieldIndicesByName[f.name]; ok {
-			structType := &decodingStructType{
-				err: fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, f.name),
-			}
-			decodingStructTypeCache.Store(t, structType)
-			return nil, structType.err
-		}
-		fieldIndicesByName[f.name] = i
 		if f.keyAsInt {
 			if fieldIndicesByIntKey == nil {
 				fieldIndicesByIntKey = make(map[int64]int, len(flds))
 			}
+			// The duplication check is only a safeguard, since getFields() already deduplicates fields.
+			if _, ok := fieldIndicesByIntKey[f.nameAsInt]; ok {
+				structType := &decodingStructType{
+					err: fmt.Errorf("cbor: two or more fields of %v have the same keyasint value %d", t, f.nameAsInt),
+				}
+				decodingStructTypeCache.Store(t, structType)
+				return nil, structType.err
+			}
 			fieldIndicesByIntKey[f.nameAsInt] = i
+		} else {
+			// The duplication check is only a safeguard, since getFields() already deduplicates fields.
+			if _, ok := fieldIndicesByName[f.name]; ok {
+				structType := &decodingStructType{
+					err: fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, f.name),
+				}
+				decodingStructTypeCache.Store(t, structType)
+				return nil, structType.err
+			}
+			fieldIndicesByName[f.name] = i
 		}
 
 		decFlds[i] = &decodingField{
@@ -284,16 +294,19 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 		}
 
 		// Encode field name
-		if flds[i].keyAsInt {
-			nameAsInt, numErr := strconv.Atoi(flds[i].name)
-			if numErr != nil {
-				structType := &encodingStructType{
-					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+		if f.keyAsInt {
+			if f.nameAsInt == 0 {
+				// nameAsInt is set in getFields() except for fields with an unparsable tagged name.
+				// Atoi() is called here to catch and save parsing errors.
+				if _, numErr := strconv.Atoi(f.name); numErr != nil {
+					structType := &encodingStructType{
+						err: errors.New("cbor: failed to parse field name \"" + f.name + "\" to int (" + numErr.Error() + ")"),
+					}
+					encodingStructTypeCache.Store(t, structType)
+					return nil, structType.err
 				}
-				encodingStructTypeCache.Store(t, structType)
-				return nil, structType.err
 			}
-			flds[i].nameAsInt = int64(nameAsInt)
+			nameAsInt := f.nameAsInt
 			if nameAsInt >= 0 {
 				encodeHead(e, byte(cborTypePositiveInt), uint64(nameAsInt))
 			} else {

--- a/cache.go
+++ b/cache.go
@@ -308,10 +308,10 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 			}
 			nameAsInt := f.nameAsInt
 			if nameAsInt >= 0 {
-				encodeHead(e, byte(cborTypePositiveInt), uint64(nameAsInt))
+				encodeHead(e, byte(cborTypePositiveInt), uint64(nameAsInt)) //nolint:gosec
 			} else {
 				n := nameAsInt*(-1) - 1
-				encodeHead(e, byte(cborTypeNegativeInt), uint64(n))
+				encodeHead(e, byte(cborTypeNegativeInt), uint64(n)) //nolint:gosec
 			}
 			ef.cborName = make([]byte, e.Len())
 			copy(ef.cborName, e.Bytes())

--- a/cache.go
+++ b/cache.go
@@ -99,56 +99,89 @@ type decodingStructType struct {
 	toArray              bool
 }
 
-func getDecodingStructType(t reflect.Type) *decodingStructType {
+func getDecodingStructType(t reflect.Type) (*decodingStructType, error) {
 	if v, _ := decodingStructTypeCache.Load(t); v != nil {
-		return v.(*decodingStructType)
+		structType := v.(*decodingStructType)
+		if structType.err != nil {
+			return nil, structType.err
+		}
+		return structType, nil
 	}
 
 	flds, structOptions := getFields(t)
 
 	toArray := hasToArrayOption(structOptions)
 
-	var errs []error
+	if toArray {
+		return getDecodingStructToArrayType(t, flds)
+	}
+
+	fieldIndicesByName := make(map[string]int, len(flds))
+	var fieldIndicesByIntKey map[int64]int
+
 	for i := 0; i < len(flds); i++ {
 		if flds[i].keyAsInt {
 			nameAsInt, numErr := strconv.Atoi(flds[i].name)
 			if numErr != nil {
-				errs = append(errs, errors.New("cbor: failed to parse field name \""+flds[i].name+"\" to int ("+numErr.Error()+")"))
-				break
+				structType := &decodingStructType{
+					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+				}
+				decodingStructTypeCache.Store(t, structType)
+				return nil, structType.err
 			}
 			flds[i].nameAsInt = int64(nameAsInt)
+		}
+
+		if _, ok := fieldIndicesByName[flds[i].name]; ok {
+			structType := &decodingStructType{
+				err: fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, flds[i].name),
+			}
+			decodingStructTypeCache.Store(t, structType)
+			return nil, structType.err
+		}
+		fieldIndicesByName[flds[i].name] = i
+		if flds[i].keyAsInt {
+			if fieldIndicesByIntKey == nil {
+				fieldIndicesByIntKey = make(map[int64]int, len(flds))
+			}
+			fieldIndicesByIntKey[flds[i].nameAsInt] = i
 		}
 
 		flds[i].typInfo = getTypeInfo(flds[i].typ)
 	}
 
-	fieldIndicesByName := make(map[string]int, len(flds))
-	var fieldIndicesByIntKey map[int64]int
-	for i, fld := range flds {
-		if _, ok := fieldIndicesByName[fld.name]; ok {
-			errs = append(errs, fmt.Errorf("cbor: two or more fields of %v have the same name %q", t, fld.name))
-			continue
-		}
-		fieldIndicesByName[fld.name] = i
-		if fld.keyAsInt {
-			if fieldIndicesByIntKey == nil {
-				fieldIndicesByIntKey = make(map[int64]int, len(flds))
-			}
-			fieldIndicesByIntKey[fld.nameAsInt] = i
-		}
-	}
-
-	err := errors.Join(errs...)
-
 	structType := &decodingStructType{
 		fields:               flds,
 		fieldIndicesByName:   fieldIndicesByName,
 		fieldIndicesByIntKey: fieldIndicesByIntKey,
-		err:                  err,
-		toArray:              toArray,
 	}
 	decodingStructTypeCache.Store(t, structType)
-	return structType
+	return structType, nil
+}
+
+func getDecodingStructToArrayType(t reflect.Type, flds fields) (*decodingStructType, error) {
+	for i := 0; i < len(flds); i++ {
+		// nameAsInt is set in getFields() except for fields with an unparsable tagged name.
+		// Atoi() is called here to catch and save parsing errors.
+		if flds[i].keyAsInt && flds[i].nameAsInt == 0 {
+			if _, numErr := strconv.Atoi(flds[i].name); numErr != nil {
+				structType := &decodingStructType{
+					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+				}
+				decodingStructTypeCache.Store(t, structType)
+				return nil, structType.err
+			}
+		}
+
+		flds[i].typInfo = getTypeInfo(flds[i].typ)
+	}
+
+	structType := &decodingStructType{
+		fields:  flds,
+		toArray: true,
+	}
+	decodingStructTypeCache.Store(t, structType)
+	return structType, nil
 }
 
 type encodingStructType struct {
@@ -209,7 +242,10 @@ func (x *lengthFirstFieldSorter) Less(i, j int) bool {
 func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 	if v, _ := encodingStructTypeCache.Load(t); v != nil {
 		structType := v.(*encodingStructType)
-		return structType, structType.err
+		if structType.err != nil {
+			return nil, structType.err
+		}
+		return structType, nil
 	}
 
 	flds, structOptions := getFields(t)
@@ -218,25 +254,31 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 		return getEncodingStructToArrayType(t, flds)
 	}
 
-	var err error
 	var hasKeyAsInt bool
 	var hasKeyAsStr bool
 	var omitEmptyIdx []int
+
 	e := getEncodeBuffer()
+	defer putEncodeBuffer(e)
+
 	for i := 0; i < len(flds); i++ {
 		// Get field's encodeFunc
 		flds[i].ef, flds[i].ief, flds[i].izf = getEncodeFunc(flds[i].typ)
 		if flds[i].ef == nil {
-			err = &UnsupportedTypeError{t}
-			break
+			structType := &encodingStructType{err: &UnsupportedTypeError{t}}
+			encodingStructTypeCache.Store(t, structType)
+			return nil, structType.err
 		}
 
 		// Encode field name
 		if flds[i].keyAsInt {
 			nameAsInt, numErr := strconv.Atoi(flds[i].name)
 			if numErr != nil {
-				err = errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")")
-				break
+				structType := &encodingStructType{
+					err: errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")"),
+				}
+				encodingStructTypeCache.Store(t, structType)
+				return nil, structType.err
 			}
 			flds[i].nameAsInt = int64(nameAsInt)
 			if nameAsInt >= 0 {
@@ -275,13 +317,6 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 			omitEmptyIdx = append(omitEmptyIdx, i)
 		}
 	}
-	putEncodeBuffer(e)
-
-	if err != nil {
-		structType := &encodingStructType{err: err}
-		encodingStructTypeCache.Store(t, structType)
-		return structType, structType.err
-	}
 
 	// Sort fields by canonical order
 	bytewiseFields := make(fields, len(flds))
@@ -303,7 +338,7 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 	}
 
 	encodingStructTypeCache.Store(t, structType)
-	return structType, structType.err
+	return structType, nil
 }
 
 func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructType, error) {
@@ -313,7 +348,7 @@ func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructT
 		if flds[i].ef == nil {
 			structType := &encodingStructType{err: &UnsupportedTypeError{t}}
 			encodingStructTypeCache.Store(t, structType)
-			return structType, structType.err
+			return nil, structType.err
 		}
 	}
 
@@ -322,7 +357,7 @@ func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructT
 		toArray: true,
 	}
 	encodingStructTypeCache.Store(t, structType)
-	return structType, structType.err
+	return structType, nil
 }
 
 func getEncodeFunc(t reflect.Type) (encodeFunc, isEmptyFunc, isZeroFunc) {

--- a/cache.go
+++ b/cache.go
@@ -98,21 +98,6 @@ type decodingStructType struct {
 	toArray            bool
 }
 
-// The stdlib errors.Join was introduced in Go 1.20, and we still support Go 1.17, so instead,
-// here's a very basic implementation of an aggregated error.
-type multierror []error
-
-func (m multierror) Error() string {
-	var sb strings.Builder
-	for i, err := range m {
-		sb.WriteString(err.Error())
-		if i < len(m)-1 {
-			sb.WriteString(", ")
-		}
-	}
-	return sb.String()
-}
-
 func getDecodingStructType(t reflect.Type) *decodingStructType {
 	if v, _ := decodingStructTypeCache.Load(t); v != nil {
 		return v.(*decodingStructType)
@@ -145,20 +130,7 @@ func getDecodingStructType(t reflect.Type) *decodingStructType {
 		fieldIndicesByName[fld.name] = i
 	}
 
-	var err error
-	{
-		var multi multierror
-		for _, each := range errs {
-			if each != nil {
-				multi = append(multi, each)
-			}
-		}
-		if len(multi) == 1 {
-			err = multi[0]
-		} else if len(multi) > 1 {
-			err = multi
-		}
-	}
+	err := errors.Join(errs...)
 
 	structType := &decodingStructType{
 		fields:             flds,

--- a/cache.go
+++ b/cache.go
@@ -175,7 +175,7 @@ func (x *bytewiseFieldSorter) Swap(i, j int) {
 }
 
 func (x *bytewiseFieldSorter) Less(i, j int) bool {
-	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) <= 0
+	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) < 0
 }
 
 type lengthFirstFieldSorter struct {
@@ -194,7 +194,7 @@ func (x *lengthFirstFieldSorter) Less(i, j int) bool {
 	if len(x.fields[i].cborName) != len(x.fields[j].cborName) {
 		return len(x.fields[i].cborName) < len(x.fields[j].cborName)
 	}
-	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) <= 0
+	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) < 0
 }
 
 func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {

--- a/decode.go
+++ b/decode.go
@@ -326,14 +326,14 @@ func (dmkm DupMapKeyMode) valid() bool {
 	return dmkm >= 0 && dmkm < maxDupMapKeyMode
 }
 
-// IndefLengthMode specifies whether to allow indefinite length items.
+// IndefLengthMode specifies whether to allow indefinite-length items.
 type IndefLengthMode int
 
 const (
-	// IndefLengthAllowed allows indefinite length items.
+	// IndefLengthAllowed allows indefinite-length items.
 	IndefLengthAllowed IndefLengthMode = iota
 
-	// IndefLengthForbidden disallows indefinite length items.
+	// IndefLengthForbidden disallows indefinite-length items.
 	IndefLengthForbidden
 
 	maxIndefLengthMode
@@ -811,7 +811,7 @@ type DecOptions struct {
 	// Default is 128*1024=131072 and it can be set to [16, 2147483647]
 	MaxMapPairs int
 
-	// IndefLength specifies whether to allow indefinite length CBOR items.
+	// IndefLength specifies whether to allow indefinite-length CBOR items.
 	IndefLength IndefLengthMode
 
 	// TagsMd specifies whether to allow CBOR tags (major type 6).
@@ -1149,8 +1149,8 @@ func (opts DecOptions) decMode() (*decMode, error) { //nolint:gocritic // ignore
 		unrecognizedTagToAny:      opts.UnrecognizedTagToAny,
 		timeTagToAny:              opts.TimeTagToAny,
 		simpleValues:              simpleValues,
-		nanDec:                    opts.NaN,
-		infDec:                    opts.Inf,
+		nan:                       opts.NaN,
+		inf:                       opts.Inf,
 		byteStringToTime:          opts.ByteStringToTime,
 		byteStringExpectedFormat:  opts.ByteStringExpectedFormat,
 		bignumTag:                 opts.BignumTag,
@@ -1230,8 +1230,8 @@ type decMode struct {
 	unrecognizedTagToAny      UnrecognizedTagToAnyMode
 	timeTagToAny              TimeTagToAnyMode
 	simpleValues              *SimpleValueRegistry
-	nanDec                    NaNMode
-	infDec                    InfMode
+	nan                       NaNMode
+	inf                       InfMode
 	byteStringToTime          ByteStringToTimeMode
 	byteStringExpectedFormat  ByteStringExpectedFormatMode
 	bignumTag                 BignumTagMode
@@ -1272,8 +1272,8 @@ func (dm *decMode) DecOptions() DecOptions {
 		UnrecognizedTagToAny:      dm.unrecognizedTagToAny,
 		TimeTagToAny:              dm.timeTagToAny,
 		SimpleValues:              simpleValues,
-		NaN:                       dm.nanDec,
-		Inf:                       dm.infDec,
+		NaN:                       dm.nan,
+		Inf:                       dm.inf,
 		ByteStringToTime:          dm.byteStringToTime,
 		ByteStringExpectedFormat:  dm.byteStringExpectedFormat,
 		BignumTag:                 dm.bignumTag,
@@ -2206,7 +2206,7 @@ func (d *decoder) parseByteString() ([]byte, bool) {
 		d.off += int(val)
 		return b, false
 	}
-	// Process indefinite length string chunks.
+	// Process indefinite-length string chunks.
 	b := []byte{}
 	for !d.foundBreak() {
 		_, _, val = d.getHead()
@@ -2307,7 +2307,7 @@ func (d *decoder) parseTextString() ([]byte, error) {
 		}
 		return b, nil
 	}
-	// Process indefinite length string chunks.
+	// Process indefinite-length string chunks.
 	b := []byte{}
 	for !d.foundBreak() {
 		_, _, val = d.getHead()

--- a/decode.go
+++ b/decode.go
@@ -16,7 +16,6 @@ import (
 	"math/big"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -2644,7 +2643,68 @@ func (d *decoder) parseArrayToStruct(v reflect.Value, tInfo *typeInfo) error {
 	return err
 }
 
-// parseMapToStruct needs to be fast so gocyclo can be ignored for now.
+// skipMapEntriesFromIndex skips remaining map entries starting from index i.
+func (d *decoder) skipMapEntriesFromIndex(i, count int, hasSize bool) {
+	for ; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
+		d.skip()
+		d.skip()
+	}
+}
+
+// skipMapForDupKey skips the current map value and all remaining map entries,
+// then returns a DupMapKeyError for the given key at map index i.
+func (d *decoder) skipMapForDupKey(dupKey any, i, count int, hasSize bool) error {
+	// Skip the value of the duplicate key.
+	d.skip()
+	// Skip all remaining map entries.
+	d.skipMapEntriesFromIndex(i+1, count, hasSize)
+	return &DupMapKeyError{dupKey, i}
+}
+
+// skipMapForUnknownField skips the current map value and all remaining map entries,
+// then returns a UnknownFieldError for the given key at map index i.
+func (d *decoder) skipMapForUnknownField(i, count int, hasSize bool) error {
+	// Skip the value of the unknown key.
+	d.skip()
+	// Skip all remaining map entries.
+	d.skipMapEntriesFromIndex(i+1, count, hasSize)
+	return &UnknownFieldError{i}
+}
+
+// decodeToStructField decodes the next CBOR value into the struct field f in v.
+// If the field cannot be resolved, the CBOR value is skipped.
+func (d *decoder) decodeToStructField(v reflect.Value, f *field, tInfo *typeInfo) error {
+	var fv reflect.Value
+
+	if len(f.idx) == 1 {
+		fv = v.Field(f.idx[0])
+	} else {
+		var err error
+		fv, err = getFieldValue(v, f.idx, func(v reflect.Value) (reflect.Value, error) {
+			// Return a new value for embedded field null pointer to point to, or return error.
+			if !v.CanSet() {
+				return reflect.Value{}, errors.New("cbor: cannot set embedded pointer to unexported struct: " + v.Type().String())
+			}
+			v.Set(reflect.New(v.Type().Elem()))
+			return v, nil
+		})
+		if !fv.IsValid() {
+			d.skip()
+			return err
+		}
+	}
+
+	err := d.parseToValue(fv, f.typInfo)
+	if err != nil {
+		if typeError, ok := err.(*UnmarshalTypeError); ok {
+			typeError.StructFieldName = tInfo.nonPtrType.String() + "." + f.name
+		}
+		return err
+	}
+
+	return nil
+}
+
 func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //nolint:gocyclo
 	structType := getDecodingStructType(tInfo.nonPtrType)
 	if structType.err != nil {
@@ -2661,14 +2721,12 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 		}
 	}
 
-	var err, lastErr error
-
 	// Get CBOR map size
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
 	count := int(val)
 
-	// Keeps track of matched struct fields
+	// Keep track of matched struct fields to detect duplicate map keys.
 	var foundFldIdx []bool
 	{
 		const maxStackFields = 128
@@ -2682,94 +2740,64 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 		}
 	}
 
-	// Keeps track of CBOR map keys to detect duplicate map key
-	keyCount := 0
-	var mapKeys map[any]struct{}
+	// Keep track of unmatched CBOR map keys to detect duplicate map keys.
+	var unmatchedMapKeys map[any]struct{}
 
-	errOnUnknownField := (d.dm.extraReturnErrors & ExtraDecErrorUnknownField) > 0
+	var err error
 
-MapEntryLoop:
-	for j := 0; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-		var f *field
+	caseInsensitive := d.dm.fieldNameMatching == FieldNameMatchingPreferCaseSensitive
 
-		// If duplicate field detection is enabled and the key at index j did not match any
-		// field, k will hold the map key.
-		var k any
-
+	for i := 0; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
 		t := d.nextCBORType()
-		if t == cborTypeTextString || (t == cborTypeByteString && d.dm.fieldNameByteString == FieldNameByteStringAllowed) {
+
+		// Reclassify disallowed byte string keys so they fall to the default case.
+		// keyType is only used for branch control.
+		keyType := t
+		if t == cborTypeByteString && d.dm.fieldNameByteString != FieldNameByteStringAllowed {
+			keyType = 0xff
+		}
+
+		switch keyType {
+		case cborTypeTextString, cborTypeByteString:
 			var keyBytes []byte
 			if t == cborTypeTextString {
-				keyBytes, lastErr = d.parseTextString()
-				if lastErr != nil {
+				var parseErr error
+				keyBytes, parseErr = d.parseTextString()
+				if parseErr != nil {
 					if err == nil {
-						err = lastErr
+						err = parseErr
 					}
-					d.skip() // skip value
+					d.skip() // Skip value
 					continue
 				}
 			} else { // cborTypeByteString
 				keyBytes, _ = d.parseByteString()
 			}
 
-			// Check for exact match on field name.
-			if i, ok := structType.fieldIndicesByName[string(keyBytes)]; ok {
-				fld := structType.fields[i]
+			// Find matching struct field (exact match, then case-insensitive fallback).
+			if fldIdx, ok := findStructFieldByKey(structType, keyBytes, caseInsensitive); ok {
+				fld := structType.fields[fldIdx]
 
-				if !foundFldIdx[i] {
-					f = fld
-					foundFldIdx[i] = true
-				} else if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
-					err = &DupMapKeyError{fld.name, j}
-					d.skip() // skip value
-					j++
-					// skip the rest of the map
-					for ; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-						d.skip()
-						d.skip()
+				switch checkDupField(d.dm, foundFldIdx, fldIdx) {
+				case mapActionParseValueAndContinue:
+					if fieldErr := d.decodeToStructField(v, fld, tInfo); fieldErr != nil && err == nil {
+						err = fieldErr
 					}
-					return err
-				} else {
-					// discard repeated match
+					continue
+				case mapActionSkipAllAndReturnError:
+					return d.skipMapForDupKey(string(keyBytes), i, count, hasSize)
+				case mapActionSkipValueAndContinue:
 					d.skip()
-					continue MapEntryLoop
+					continue
 				}
 			}
 
-			// Find field with case-insensitive match
-			if f == nil && d.dm.fieldNameMatching == FieldNameMatchingPreferCaseSensitive {
-				keyLen := len(keyBytes)
-				keyString := string(keyBytes)
-				for i := 0; i < len(structType.fields); i++ {
-					fld := structType.fields[i]
-					if len(fld.name) == keyLen && strings.EqualFold(fld.name, keyString) {
-						if !foundFldIdx[i] {
-							f = fld
-							foundFldIdx[i] = true
-						} else if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
-							err = &DupMapKeyError{keyString, j}
-							d.skip() // skip value
-							j++
-							// skip the rest of the map
-							for ; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-								d.skip()
-								d.skip()
-							}
-							return err
-						} else {
-							// discard repeated match
-							d.skip()
-							continue MapEntryLoop
-						}
-						break
-					}
-				}
+			// No matching struct field found.
+			if unmatchedErr := handleUnmatchedMapKey(d, string(keyBytes), i, count, hasSize, &unmatchedMapKeys); unmatchedErr != nil {
+				return unmatchedErr
 			}
 
-			if d.dm.dupMapKey == DupMapKeyEnforcedAPF && f == nil {
-				k = string(keyBytes)
-			}
-		} else if t <= cborTypeNegativeInt { // uint/int
+		case cborTypePositiveInt, cborTypeNegativeInt:
 			var nameAsInt int64
 
 			if t == cborTypePositiveInt {
@@ -2791,36 +2819,32 @@ MapEntryLoop:
 				nameAsInt = int64(-1) ^ int64(val)
 			}
 
-			// Find field
-			for i := 0; i < len(structType.fields); i++ {
-				fld := structType.fields[i]
-				if fld.keyAsInt && fld.nameAsInt == nameAsInt {
-					if !foundFldIdx[i] {
-						f = fld
-						foundFldIdx[i] = true
-					} else if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
-						err = &DupMapKeyError{nameAsInt, j}
-						d.skip() // skip value
-						j++
-						// skip the rest of the map
-						for ; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-							d.skip()
-							d.skip()
-						}
-						return err
-					} else {
-						// discard repeated match
-						d.skip()
-						continue MapEntryLoop
+			// Find field by integer key
+			if fldIdx, ok := structType.fieldIndicesByIntKey[nameAsInt]; ok {
+				fld := structType.fields[fldIdx]
+
+				switch checkDupField(d.dm, foundFldIdx, fldIdx) {
+				case mapActionParseValueAndContinue:
+					if fieldErr := d.decodeToStructField(v, fld, tInfo); fieldErr != nil && err == nil {
+						err = fieldErr
 					}
-					break
+					continue
+				case mapActionSkipAllAndReturnError:
+					return d.skipMapForDupKey(nameAsInt, i, count, hasSize)
+				case mapActionSkipValueAndContinue:
+					d.skip()
+					continue
 				}
 			}
 
-			if d.dm.dupMapKey == DupMapKeyEnforcedAPF && f == nil {
-				k = nameAsInt
+			// No matching struct field found.
+			if unmatchedErr := handleUnmatchedMapKey(d, nameAsInt, i, count, hasSize, &unmatchedMapKeys); unmatchedErr != nil {
+				return unmatchedErr
 			}
-		} else {
+
+		default:
+			// CBOR map keys that can't be matched to any struct field.
+
 			if err == nil {
 				err = &UnmarshalTypeError{
 					CBORType: t.String(),
@@ -2828,97 +2852,31 @@ MapEntryLoop:
 					errorMsg: "map key is of type " + t.String() + " and cannot be used to match struct field name",
 				}
 			}
+
+			var otherKey any
 			if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
 				// parse key
-				k, lastErr = d.parse(true)
-				if lastErr != nil {
+				var parseErr error
+				otherKey, parseErr = d.parse(true)
+				if parseErr != nil {
 					d.skip() // skip value
 					continue
 				}
 				// Detect if CBOR map key can be used as Go map key.
-				if !isHashableValue(reflect.ValueOf(k)) {
+				if !isHashableValue(reflect.ValueOf(otherKey)) {
 					d.skip() // skip value
 					continue
 				}
 			} else {
 				d.skip() // skip key
 			}
-		}
 
-		if f == nil {
-			if errOnUnknownField {
-				err = &UnknownFieldError{j}
-				d.skip() // Skip value
-				j++
-				// skip the rest of the map
-				for ; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-					d.skip()
-					d.skip()
-				}
-				return err
-			}
-
-			// Two map keys that match the same struct field are immediately considered
-			// duplicates. This check detects duplicates between two map keys that do
-			// not match a struct field. If unknown field errors are enabled, then this
-			// check is never reached.
-			if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
-				if mapKeys == nil {
-					mapKeys = make(map[any]struct{}, 1)
-				}
-				mapKeys[k] = struct{}{}
-				newKeyCount := len(mapKeys)
-				if newKeyCount == keyCount {
-					err = &DupMapKeyError{k, j}
-					d.skip() // skip value
-					j++
-					// skip the rest of the map
-					for ; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
-						d.skip()
-						d.skip()
-					}
-					return err
-				}
-				keyCount = newKeyCount
-			}
-
-			d.skip() // Skip value
-			continue
-		}
-
-		// Get field value by index
-		var fv reflect.Value
-		if len(f.idx) == 1 {
-			fv = v.Field(f.idx[0])
-		} else {
-			fv, lastErr = getFieldValue(v, f.idx, func(v reflect.Value) (reflect.Value, error) {
-				// Return a new value for embedded field null pointer to point to, or return error.
-				if !v.CanSet() {
-					return reflect.Value{}, errors.New("cbor: cannot set embedded pointer to unexported struct: " + v.Type().String())
-				}
-				v.Set(reflect.New(v.Type().Elem()))
-				return v, nil
-			})
-			if lastErr != nil && err == nil {
-				err = lastErr
-			}
-			if !fv.IsValid() {
-				d.skip()
-				continue
-			}
-		}
-
-		if lastErr = d.parseToValue(fv, f.typInfo); lastErr != nil {
-			if err == nil {
-				if typeError, ok := lastErr.(*UnmarshalTypeError); ok {
-					typeError.StructFieldName = tInfo.nonPtrType.String() + "." + f.name
-					err = typeError
-				} else {
-					err = lastErr
-				}
+			if unmatchedErr := handleUnmatchedMapKey(d, otherKey, i, count, hasSize, &unmatchedMapKeys); unmatchedErr != nil {
+				return unmatchedErr
 			}
 		}
 	}
+
 	return err
 }
 

--- a/decode.go
+++ b/decode.go
@@ -2572,9 +2572,9 @@ func (d *decoder) parseMapToMap(v reflect.Value, tInfo *typeInfo) error { //noli
 }
 
 func (d *decoder) parseArrayToStruct(v reflect.Value, tInfo *typeInfo) error {
-	structType := getDecodingStructType(tInfo.nonPtrType)
-	if structType.err != nil {
-		return structType.err
+	structType, structTypeErr := getDecodingStructType(tInfo.nonPtrType)
+	if structTypeErr != nil {
+		return structTypeErr
 	}
 
 	if !structType.toArray {
@@ -2706,9 +2706,9 @@ func (d *decoder) decodeToStructField(v reflect.Value, f *field, tInfo *typeInfo
 }
 
 func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //nolint:gocyclo
-	structType := getDecodingStructType(tInfo.nonPtrType)
-	if structType.err != nil {
-		return structType.err
+	structType, structTypeErr := getDecodingStructType(tInfo.nonPtrType)
+	if structTypeErr != nil {
+		return structTypeErr
 	}
 
 	if structType.toArray {

--- a/decode.go
+++ b/decode.go
@@ -2673,7 +2673,7 @@ func (d *decoder) skipMapForUnknownField(i, count int, hasSize bool) error {
 
 // decodeToStructField decodes the next CBOR value into the struct field f in v.
 // If the field cannot be resolved, the CBOR value is skipped.
-func (d *decoder) decodeToStructField(v reflect.Value, f *field, tInfo *typeInfo) error {
+func (d *decoder) decodeToStructField(v reflect.Value, f *decodingField, tInfo *typeInfo) error {
 	var fv reflect.Value
 
 	if len(f.idx) == 1 {

--- a/decode.go
+++ b/decode.go
@@ -377,6 +377,7 @@ const (
 	// - int64 if value fits
 	// - big.Int or *big.Int (see BigIntDecMode) if value < math.MinInt64
 	// - return UnmarshalTypeError if value > math.MaxInt64
+	//
 	// Deprecated: IntDecConvertSigned should not be used.
 	// Please use other options, such as IntDecConvertSignedOrError, IntDecConvertSignedOrBigInt, IntDecConvertNone.
 	IntDecConvertSigned
@@ -1683,6 +1684,7 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 		} else if tInfo.nonPtrKind == reflect.Struct {
 			return d.parseArrayToStruct(v, tInfo)
 		}
+
 		d.skip()
 		return &UnmarshalTypeError{CBORType: t.String(), GoType: tInfo.nonPtrType.String()}
 
@@ -2802,6 +2804,17 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 
 			if t == cborTypePositiveInt {
 				_, _, val := d.getHead()
+				if val > math.MaxInt64 {
+					if err == nil {
+						err = &UnmarshalTypeError{
+							CBORType: t.String(),
+							GoType:   reflect.TypeOf(int64(0)).String(),
+							errorMsg: strconv.FormatUint(val, 10) + " overflows Go's int64",
+						}
+					}
+					d.skip() // skip value
+					continue
+				}
 				nameAsInt = int64(val)
 			} else {
 				_, _, val := d.getHead()

--- a/decode.go
+++ b/decode.go
@@ -1055,7 +1055,7 @@ func (opts DecOptions) decMode() (*decMode, error) { //nolint:gocritic // ignore
 	}
 
 	if !opts.ExtraReturnErrors.valid() {
-		return nil, errors.New("cbor: invalid ExtraReturnErrors " + strconv.Itoa(int(opts.ExtraReturnErrors)))
+		return nil, errors.New("cbor: invalid ExtraReturnErrors " + strconv.Itoa(int(opts.ExtraReturnErrors))) //nolint:gosec
 	}
 
 	if opts.DefaultMapType != nil && opts.DefaultMapType.Kind() != reflect.Map {
@@ -1583,11 +1583,11 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 		_, ai, val := d.getHead()
 		switch ai {
 		case additionalInformationAsFloat16:
-			f := float64(float16.Frombits(uint16(val)).Float32())
+			f := float64(float16.Frombits(uint16(val)).Float32()) //nolint:gosec
 			return fillFloat(t, f, v)
 
 		case additionalInformationAsFloat32:
-			f := float64(math.Float32frombits(uint32(val)))
+			f := float64(math.Float32frombits(uint32(val))) //nolint:gosec
 			return fillFloat(t, f, v)
 
 		case additionalInformationAsFloat64:
@@ -1595,10 +1595,10 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 			return fillFloat(t, f, v)
 
 		default: // ai <= 24
-			if d.dm.simpleValues.rejected[SimpleValue(val)] {
+			if d.dm.simpleValues.rejected[SimpleValue(val)] { //nolint:gosec
 				return &UnacceptableDataItemError{
 					CBORType: t.String(),
-					Message:  "simple value " + strconv.FormatInt(int64(val), 10) + " is not recognized",
+					Message:  "simple value " + strconv.FormatInt(int64(val), 10) + " is not recognized", //nolint:gosec
 				}
 			}
 
@@ -1677,11 +1677,12 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 		return d.parseToValue(v, tInfo)
 
 	case cborTypeArray:
-		if tInfo.nonPtrKind == reflect.Slice {
+		switch tInfo.nonPtrKind {
+		case reflect.Slice:
 			return d.parseArrayToSlice(v, tInfo)
-		} else if tInfo.nonPtrKind == reflect.Array {
+		case reflect.Array:
 			return d.parseArrayToArray(v, tInfo)
-		} else if tInfo.nonPtrKind == reflect.Struct {
+		case reflect.Struct:
 			return d.parseArrayToStruct(v, tInfo)
 		}
 
@@ -1689,9 +1690,10 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 		return &UnmarshalTypeError{CBORType: t.String(), GoType: tInfo.nonPtrType.String()}
 
 	case cborTypeMap:
-		if tInfo.nonPtrKind == reflect.Struct {
+		switch tInfo.nonPtrKind {
+		case reflect.Struct:
 			return d.parseMapToStruct(v, tInfo)
-		} else if tInfo.nonPtrKind == reflect.Map {
+		case reflect.Map:
 			return d.parseMapToMap(v, tInfo)
 		}
 		d.skip()
@@ -1746,8 +1748,8 @@ func (d *decoder) parseToTime() (time.Time, bool, error) {
 			// Read tag number
 			_, _, tagNum := d.getHead()
 			if tagNum != 0 && tagNum != 1 {
-				d.skip() // skip tag content
-				return time.Time{}, false, errors.New("cbor: wrong tag number for time.Time, got " + strconv.Itoa(int(tagNum)) + ", expect 0 or 1")
+				d.skip()                                                                                                                            // skip tag content
+				return time.Time{}, false, errors.New("cbor: wrong tag number for time.Time, got " + strconv.Itoa(int(tagNum)) + ", expect 0 or 1") //nolint:gosec
 			}
 		}
 	} else {
@@ -1816,10 +1818,10 @@ func (d *decoder) parseToTime() (time.Time, bool, error) {
 		var f float64
 		switch ai {
 		case additionalInformationAsFloat16:
-			f = float64(float16.Frombits(uint16(val)).Float32())
+			f = float64(float16.Frombits(uint16(val)).Float32()) //nolint:gosec
 
 		case additionalInformationAsFloat32:
-			f = float64(math.Float32frombits(uint32(val)))
+			f = float64(math.Float32frombits(uint32(val))) //nolint:gosec
 
 		case additionalInformationAsFloat64:
 			f = math.Float64frombits(val)
@@ -2153,14 +2155,14 @@ func (d *decoder) parse(skipSelfDescribedTag bool) (any, error) { //nolint:gocyc
 
 	case cborTypePrimitives:
 		_, ai, val := d.getHead()
-		if ai <= 24 && d.dm.simpleValues.rejected[SimpleValue(val)] {
+		if ai <= 24 && d.dm.simpleValues.rejected[SimpleValue(val)] { //nolint:gosec
 			return nil, &UnacceptableDataItemError{
 				CBORType: t.String(),
-				Message:  "simple value " + strconv.FormatInt(int64(val), 10) + " is not recognized",
+				Message:  "simple value " + strconv.FormatInt(int64(val), 10) + " is not recognized", //nolint:gosec
 			}
 		}
 		if ai < 20 || ai == 24 {
-			return SimpleValue(val), nil
+			return SimpleValue(val), nil //nolint:gosec
 		}
 
 		switch ai {
@@ -2173,11 +2175,11 @@ func (d *decoder) parse(skipSelfDescribedTag bool) (any, error) { //nolint:gocyc
 			return nil, nil
 
 		case additionalInformationAsFloat16:
-			f := float64(float16.Frombits(uint16(val)).Float32())
+			f := float64(float16.Frombits(uint16(val)).Float32()) //nolint:gosec
 			return f, nil
 
 		case additionalInformationAsFloat32:
-			f := float64(math.Float32frombits(uint32(val)))
+			f := float64(math.Float32frombits(uint32(val))) //nolint:gosec
 			return f, nil
 
 		case additionalInformationAsFloat64:
@@ -2210,16 +2212,16 @@ func (d *decoder) parse(skipSelfDescribedTag bool) (any, error) { //nolint:gocyc
 func (d *decoder) parseByteString() ([]byte, bool) {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	if !indefiniteLength {
-		b := d.data[d.off : d.off+int(val)]
-		d.off += int(val)
+		b := d.data[d.off : d.off+int(val)] //nolint:gosec
+		d.off += int(val)                   //nolint:gosec
 		return b, false
 	}
 	// Process indefinite-length string chunks.
 	b := []byte{}
 	for !d.foundBreak() {
 		_, _, val = d.getHead()
-		b = append(b, d.data[d.off:d.off+int(val)]...)
-		d.off += int(val)
+		b = append(b, d.data[d.off:d.off+int(val)]...) //nolint:gosec
+		d.off += int(val)                              //nolint:gosec
 	}
 	return b, true
 }
@@ -2308,8 +2310,8 @@ func (d *decoder) applyByteStringTextConversion(
 func (d *decoder) parseTextString() ([]byte, error) {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	if !indefiniteLength {
-		b := d.data[d.off : d.off+int(val)]
-		d.off += int(val)
+		b := d.data[d.off : d.off+int(val)] //nolint:gosec
+		d.off += int(val)                   //nolint:gosec
 		if d.dm.utf8 == UTF8RejectInvalid && !utf8.Valid(b) {
 			return nil, &SemanticError{"cbor: invalid UTF-8 string"}
 		}
@@ -2319,8 +2321,8 @@ func (d *decoder) parseTextString() ([]byte, error) {
 	b := []byte{}
 	for !d.foundBreak() {
 		_, _, val = d.getHead()
-		x := d.data[d.off : d.off+int(val)]
-		d.off += int(val)
+		x := d.data[d.off : d.off+int(val)] //nolint:gosec
+		d.off += int(val)                   //nolint:gosec
 		if d.dm.utf8 == UTF8RejectInvalid && !utf8.Valid(x) {
 			for !d.foundBreak() {
 				d.skip() // Skip remaining chunk on error
@@ -2335,7 +2337,7 @@ func (d *decoder) parseTextString() ([]byte, error) {
 func (d *decoder) parseArray() ([]any, error) {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	if !hasSize {
 		count = d.numOfItemsUntilBreak() // peek ahead to get array size to preallocate slice for better performance
 	}
@@ -2357,7 +2359,7 @@ func (d *decoder) parseArray() ([]any, error) {
 func (d *decoder) parseArrayToSlice(v reflect.Value, tInfo *typeInfo) error {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	if !hasSize {
 		count = d.numOfItemsUntilBreak() // peek ahead to get array size to preallocate slice for better performance
 	}
@@ -2379,7 +2381,7 @@ func (d *decoder) parseArrayToSlice(v reflect.Value, tInfo *typeInfo) error {
 func (d *decoder) parseArrayToArray(v reflect.Value, tInfo *typeInfo) error {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	gi := 0
 	vLen := v.Len()
 	var err error
@@ -2408,7 +2410,7 @@ func (d *decoder) parseArrayToArray(v reflect.Value, tInfo *typeInfo) error {
 func (d *decoder) parseMap() (any, error) {
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	m := make(map[any]any)
 	var k, e any
 	var err, lastErr error
@@ -2473,7 +2475,7 @@ func (d *decoder) parseMap() (any, error) {
 func (d *decoder) parseMapToMap(v reflect.Value, tInfo *typeInfo) error { //nolint:gocyclo
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	if v.IsNil() {
 		mapsize := count
 		if !hasSize {
@@ -2592,7 +2594,7 @@ func (d *decoder) parseArrayToStruct(v reflect.Value, tInfo *typeInfo) error {
 	start := d.off
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 	if !hasSize {
 		count = d.numOfItemsUntilBreak() // peek ahead to get array size
 	}
@@ -2726,7 +2728,7 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 	// Get CBOR map size
 	_, _, val, indefiniteLength := d.getHeadWithIndefiniteLengthFlag()
 	hasSize := !indefiniteLength
-	count := int(val)
+	count := int(val) //nolint:gosec
 
 	// Keep track of matched struct fields to detect duplicate map keys.
 	var foundFldIdx []bool
@@ -2815,7 +2817,7 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 					d.skip() // skip value
 					continue
 				}
-				nameAsInt = int64(val)
+				nameAsInt = int64(val) //nolint:gosec
 			} else {
 				_, _, val := d.getHead()
 				if val > math.MaxInt64 {
@@ -2829,7 +2831,7 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 					d.skip() // skip value
 					continue
 				}
-				nameAsInt = int64(-1) ^ int64(val)
+				nameAsInt = int64(-1) ^ int64(val) //nolint:gosec
 			}
 
 			// Find field by integer key
@@ -2936,15 +2938,15 @@ func (d *decoder) skip() {
 
 	switch t {
 	case cborTypeByteString, cborTypeTextString:
-		d.off += int(val)
+		d.off += int(val) //nolint:gosec
 
 	case cborTypeArray:
-		for i := 0; i < int(val); i++ {
+		for i := 0; i < int(val); i++ { //nolint:gosec
 			d.skip()
 		}
 
 	case cborTypeMap:
-		for i := 0; i < int(val)*2; i++ {
+		for i := 0; i < int(val)*2; i++ { //nolint:gosec
 			d.skip()
 		}
 

--- a/decode.go
+++ b/decode.go
@@ -1832,6 +1832,13 @@ func (d *decoder) parseToTime() (time.Time, bool, error) {
 			return time.Time{}, true, nil
 		}
 		seconds, fractional := math.Modf(f)
+		if seconds > math.MaxInt64 || seconds < math.MinInt64 {
+			return time.Time{}, false, &UnmarshalTypeError{
+				CBORType: t.String(),
+				GoType:   typeTime.String(),
+				errorMsg: fmt.Sprintf("%v overflows Go's int64", f),
+			}
+		}
 		return time.Unix(int64(seconds), int64(fractional*1e9)), true, nil
 
 	default:

--- a/decode_map_utils.go
+++ b/decode_map_utils.go
@@ -49,17 +49,17 @@ func findStructFieldByKey(
 
 // findFieldCaseInsensitive returns the index of the first field whose name
 // case-insensitively matches key, or -1 and false if no field matches.
-func findFieldCaseInsensitive(flds fields, key string) (int, bool) {
+func findFieldCaseInsensitive(flds decodingFields, key string) (int, bool) {
 	keyLen := len(key)
-	for i := 0; i < len(flds); i++ {
-		if len(flds[i].name) == keyLen && strings.EqualFold(flds[i].name, key) {
+	for i, f := range flds {
+		if len(f.name) == keyLen && strings.EqualFold(f.name, key) {
 			return i, true
 		}
 	}
 	return -1, false
 }
 
-// handleUnmatchedMapKey handles a map entry whose key doesn not match any struct
+// handleUnmatchedMapKey handles a map entry whose key does not match any struct
 // field. It can return UnknownFieldError or DupMapKeyError.
 // handleUnmatchedMapKey consumes the CBOR value, so the caller doesn't need to skip any values.
 // If an error is returned, the caller should abort parsing the map and return the error.
@@ -70,7 +70,8 @@ func handleUnmatchedMapKey(
 	i int,
 	count int,
 	hasSize bool,
-	uks *map[any]struct{},
+	// *map[any]struct{} is used here because we use lazy initialization for uks
+	uks *map[any]struct{}, //nolint:gocritic
 ) error {
 	errOnUnknownField := (d.dm.extraReturnErrors & ExtraDecErrorUnknownField) > 0
 

--- a/decode_map_utils.go
+++ b/decode_map_utils.go
@@ -1,0 +1,94 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import "strings"
+
+// mapAction represents the next action during decoding a CBOR map to a Go struct.
+type mapAction int
+
+const (
+	mapActionParseValueAndContinue mapAction = iota // The caller should process the map value.
+	mapActionSkipValueAndContinue                   // The caller should skip the map value.
+	mapActionSkipAllAndReturnError                  // The caller should skip the rest of the map and return an error.
+)
+
+// checkDupField checks if a struct field at index i has already been matched and returns the next action.
+// If not matched, it marks the field as matched and returns mapActionParseValueAndContinue.
+// If matched and DupMapKeyEnforcedAPF is specified in the given dm, it returns mapActionSkipAllAndReturnError.
+// If matched and DupMapKeyEnforcedAPF is not specified in the given dm, it returns mapActionSkipValueAndContinue.
+func checkDupField(dm *decMode, foundFldIdx []bool, i int) mapAction {
+	if !foundFldIdx[i] {
+		foundFldIdx[i] = true
+		return mapActionParseValueAndContinue
+	}
+	if dm.dupMapKey == DupMapKeyEnforcedAPF {
+		return mapActionSkipAllAndReturnError
+	}
+	return mapActionSkipValueAndContinue
+}
+
+// findStructFieldByKey finds a struct field matching keyBytes by name.
+// It tries an exact match first. If no exact match is found and
+// caseInsensitive is true, it falls back to a case-insensitive search.
+// findStructFieldByKey returns the field index and true, or -1 and false.
+func findStructFieldByKey(
+	structType *decodingStructType,
+	keyBytes []byte,
+	caseInsensitive bool,
+) (int, bool) {
+	if fldIdx, ok := structType.fieldIndicesByName[string(keyBytes)]; ok {
+		return fldIdx, true
+	}
+	if caseInsensitive {
+		return findFieldCaseInsensitive(structType.fields, string(keyBytes))
+	}
+	return -1, false
+}
+
+// findFieldCaseInsensitive returns the index of the first field whose name
+// case-insensitively matches key, or -1 and false if no field matches.
+func findFieldCaseInsensitive(flds fields, key string) (int, bool) {
+	keyLen := len(key)
+	for i := 0; i < len(flds); i++ {
+		if len(flds[i].name) == keyLen && strings.EqualFold(flds[i].name, key) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// handleUnmatchedMapKey handles a map entry whose key doesn not match any struct
+// field. It can return UnknownFieldError or DupMapKeyError.
+// handleUnmatchedMapKey consumes the CBOR value, so the caller doesn't need to skip any values.
+// If an error is returned, the caller should abort parsing the map and return the error.
+// If no error is returned, the caller should continue to process the next map pair.
+func handleUnmatchedMapKey(
+	d *decoder,
+	key any,
+	i int,
+	count int,
+	hasSize bool,
+	uks *map[any]struct{},
+) error {
+	errOnUnknownField := (d.dm.extraReturnErrors & ExtraDecErrorUnknownField) > 0
+
+	if errOnUnknownField {
+		return d.skipMapForUnknownField(i, count, hasSize)
+	}
+
+	if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
+		if *uks == nil {
+			*uks = make(map[any]struct{})
+		}
+		if _, dup := (*uks)[key]; dup {
+			return d.skipMapForDupKey(key, i, count, hasSize)
+		}
+		(*uks)[key] = struct{}{}
+	}
+
+	// Skip value.
+	d.skip()
+	return nil
+}

--- a/decode_map_utils.go
+++ b/decode_map_utils.go
@@ -52,6 +52,9 @@ func findStructFieldByKey(
 func findFieldCaseInsensitive(flds decodingFields, key string) (int, bool) {
 	keyLen := len(key)
 	for i, f := range flds {
+		if f.keyAsInt {
+			continue
+		}
 		if len(f.name) == keyLen && strings.EqualFold(f.name, key) {
 			return i, true
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -2085,8 +2085,8 @@ var unmarshalFloatTests = []unmarshalFloatTest{
 	},
 	{
 		data:               mustHexDecode("f98000"),
-		wantInterfaceValue: float64(-0.0),                       //nolint:staticcheck // we know -0.0 is 0.0 in Go
-		wantValues:         []any{float32(-0.0), float64(-0.0)}, //nolint:staticcheck // we know -0.0 is 0.0 in Go
+		wantInterfaceValue: math.Copysign(0, -1),
+		wantValues:         []any{float32(math.Copysign(0, -1)), math.Copysign(0, -1)},
 	},
 	{
 		data:               mustHexDecode("f93c00"),

--- a/decode_test.go
+++ b/decode_test.go
@@ -4137,25 +4137,25 @@ func TestDecodeTime(t *testing.T) {
 			name:            "time without fractional seconds", // positive integer
 			cborRFC3339Time: mustHexDecode("74323031332d30332d32315432303a30343a30305a"),
 			cborUnixTime:    mustHexDecode("1a514b67b0"),
-			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
 		},
 		{
 			name:            "time with fractional seconds", // float
 			cborRFC3339Time: mustHexDecode("7819313937302d30312d30315432313a34363a34302d30363a3030"),
 			cborUnixTime:    mustHexDecode("fa47c35000"),
-			wantTime:        parseTime(time.RFC3339Nano, "1970-01-01T21:46:40-06:00"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "1970-01-01T21:46:40-06:00"),
 		},
 		{
 			name:            "time with fractional seconds", // float
 			cborRFC3339Time: mustHexDecode("76323031332d30332d32315432303a30343a30302e355a"),
 			cborUnixTime:    mustHexDecode("fb41d452d9ec200000"),
-			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5Z"),
 		},
 		{
 			name:            "time before January 1, 1970 UTC without fractional seconds", // negative integer
 			cborRFC3339Time: mustHexDecode("74313936392d30332d32315432303a30343a30305a"),
 			cborUnixTime:    mustHexDecode("3a0177f2cf"),
-			wantTime:        parseTime(time.RFC3339Nano, "1969-03-21T20:04:00Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "1969-03-21T20:04:00Z"),
 		},
 	}
 	for _, tc := range testCases {
@@ -4187,19 +4187,19 @@ func TestDecodeTimeWithTag(t *testing.T) {
 			name:            "time without fractional seconds", // positive integer
 			cborRFC3339Time: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
 			cborUnixTime:    mustHexDecode("c11a514b67b0"),
-			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
 		},
 		{
 			name:            "time with fractional seconds", // float
 			cborRFC3339Time: mustHexDecode("c076323031332d30332d32315432303a30343a30302e355a"),
 			cborUnixTime:    mustHexDecode("c1fb41d452d9ec200000"),
-			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5Z"),
 		},
 		{
 			name:            "time before January 1, 1970 UTC without fractional seconds", // negative integer
 			cborRFC3339Time: mustHexDecode("c074313936392d30332d32315432303a30343a30305a"),
 			cborUnixTime:    mustHexDecode("c13a0177f2cf"),
-			wantTime:        parseTime(time.RFC3339Nano, "1969-03-21T20:04:00Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "1969-03-21T20:04:00Z"),
 		},
 	}
 	for _, tc := range testCases {
@@ -4570,14 +4570,14 @@ func TestDecTimeTagOption(t *testing.T) {
 			cborRFC3339Time: mustHexDecode("74323031332d30332d32315432303a30343a30305a"),
 			cborUnixTime:    mustHexDecode("1a514b67b0"),
 			decMode:         timeTagIgnoredDecMode,
-			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
 		},
 		{
 			name:            "not-tagged data with timeTagOptionalDecMode option",
 			cborRFC3339Time: mustHexDecode("74323031332d30332d32315432303a30343a30305a"),
 			cborUnixTime:    mustHexDecode("1a514b67b0"),
 			decMode:         timeTagOptionalDecMode,
-			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
 		},
 		{
 			name:            "not-tagged data with timeTagRequiredDecMode option",
@@ -4592,21 +4592,21 @@ func TestDecTimeTagOption(t *testing.T) {
 			cborRFC3339Time: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
 			cborUnixTime:    mustHexDecode("c11a514b67b0"),
 			decMode:         timeTagIgnoredDecMode,
-			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
 		},
 		{
 			name:            "tagged data with timeTagOptionalDecMode option",
 			cborRFC3339Time: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
 			cborUnixTime:    mustHexDecode("c11a514b67b0"),
 			decMode:         timeTagOptionalDecMode,
-			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
 		},
 		{
 			name:            "tagged data with timeTagRequiredDecMode option",
 			cborRFC3339Time: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
 			cborUnixTime:    mustHexDecode("c11a514b67b0"),
 			decMode:         timeTagRequiredDecMode,
-			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
 		},
 		// mis-tagged time CBOR data
 		{
@@ -4614,7 +4614,7 @@ func TestDecTimeTagOption(t *testing.T) {
 			cborRFC3339Time: mustHexDecode("c8c974323031332d30332d32315432303a30343a30305a"),
 			cborUnixTime:    mustHexDecode("c8c91a514b67b0"),
 			decMode:         timeTagIgnoredDecMode,
-			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+			wantTime:        mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
 		},
 		{
 			name:            "mis-tagged data with timeTagOptionalDecMode option",

--- a/decode_test.go
+++ b/decode_test.go
@@ -3404,12 +3404,12 @@ var invalidCBORUnmarshalTestCases = []struct {
 		wantErrorMsg: "cbor: wrong element type byte string for indefinite-length UTF-8 text string",
 	},
 	{
-		name:         "indefinite-length string chunks not definite-length",
+		name:         "indefinite-length string chunks not definite length",
 		data:         mustHexDecode("5f5f4100ffff"),
 		wantErrorMsg: "cbor: indefinite-length byte string chunk is not definite-length",
 	},
 	{
-		name:         "indefinite-length string chunks not definite-length",
+		name:         "indefinite-length string chunks not definite length",
 		data:         mustHexDecode("7f7f6100ffff"),
 		wantErrorMsg: "cbor: indefinite-length UTF-8 text string chunk is not definite-length",
 	},
@@ -6208,13 +6208,13 @@ func TestUnmarshalDupMapKeyToStruct(t *testing.T) {
 		},
 		{
 			name: "keyasint duplicate key does not overwrite previous value",
-			data: mustHexDecode("a36131616901614961616141"), // {"1": "i", 1: "I", "a": "A"}
+			data: mustHexDecode("a301616901614961616141"), // {1: "i", 1: "I", "a": "A"}
 			want: s{I: "i", A: "A"},
 		},
 		{
 			name:    "keyasint duplicate key triggers error",
 			opts:    DecOptions{DupMapKey: DupMapKeyEnforcedAPF},
-			data:    mustHexDecode("a36131616901614961616141"), // {"1": "i", 1: "I", "a": "A"}
+			data:    mustHexDecode("a301616901614961616141"), // {1: "i", 1: "I", "a": "A"}
 			want:    s{I: "i"},
 			wantErr: &DupMapKeyError{Key: int64(1), Index: 1},
 		},
@@ -8149,7 +8149,7 @@ func (f *IntFoo) Foo() string {
 type ByteFoo []byte
 
 func (f *ByteFoo) Foo() string {
-	return fmt.Sprint(*f)
+	return string(*f)
 }
 
 type StringFoo string
@@ -10981,6 +10981,217 @@ func TestJSONUnmarshalerTranscoder(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+// TestKeyAsIntTextKeyDoesNotMatchKeyAsIntField verifies that a CBOR text string
+// key does not match a struct field with the keyasint tag option, even if the
+// text content is the string representation of the integer key.
+func TestKeyAsIntTextKeyDoesNotMatchKeyAsIntField(t *testing.T) {
+	type s struct {
+		ID int `cbor:"1,keyasint"`
+	}
+
+	testCases := []struct {
+		name    string
+		opts    DecOptions
+		data    []byte
+		want    any
+		wantErr *UnknownFieldError
+	}{
+		{
+			name: "default options",
+			opts: defaultDecMode.DecOptions(),
+			data: mustHexDecode("a1613101"), // {"1": 1}
+			want: s{},
+		},
+		{
+			name:    "unknown field error options",
+			opts:    DecOptions{ExtraReturnErrors: ExtraDecErrorUnknownField},
+			data:    mustHexDecode("a1613101"), // {"1": 1}
+			want:    s{},
+			wantErr: &UnknownFieldError{Index: 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dm, err := tc.opts.DecMode()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var v s
+			err = dm.Unmarshal(tc.data, &v)
+			if err != nil {
+				if !reflect.DeepEqual(err, tc.wantErr) {
+					t.Errorf("got error: %v, wanted: %v", err, tc.wantErr)
+				}
+			} else {
+				if tc.wantErr != nil {
+					t.Errorf("got nil error, wanted: %v", tc.wantErr)
+				}
+			}
+
+			if !reflect.DeepEqual(v, tc.want) {
+				t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", tc.data, v, v, tc.want, tc.want)
+			}
+		})
+	}
+}
+
+// TestKeyAsIntNormalizedDuplicateFields verifies that struct fields with
+// keyasint tag values that are identical after integer normalization (e.g., "01"
+// and "1") are eliminated during field deduplication, matching the behavior of
+// two string-keyed fields with the same name.
+func TestKeyAsIntNormalizedDuplicateFields(t *testing.T) {
+	type s struct {
+		ID  int `cbor:"01,keyasint"`
+		ID2 int `cbor:"1,keyasint"`
+		ID3 int `cbor:"+1,keyasint"`
+	}
+
+	testCases := []struct {
+		name    string
+		opts    DecOptions
+		data    []byte
+		want    any
+		wantErr *UnknownFieldError
+	}{
+		{
+			name: "default options",
+			opts: defaultDecMode.DecOptions(),
+			data: mustHexDecode("a10101"), // {1: 1}
+			want: s{},
+		},
+		{
+			name:    "unknown field error options",
+			opts:    DecOptions{ExtraReturnErrors: ExtraDecErrorUnknownField},
+			data:    mustHexDecode("a10101"), // {1: 1}
+			want:    s{},
+			wantErr: &UnknownFieldError{Index: 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dm, err := tc.opts.DecMode()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var v s
+			err = dm.Unmarshal(tc.data, &v)
+			if err != nil {
+				if !reflect.DeepEqual(err, tc.wantErr) {
+					t.Errorf("got error: %v, wanted: %v", err, tc.wantErr)
+				}
+			} else {
+				if tc.wantErr != nil {
+					t.Errorf("got nil error, wanted: %v", tc.wantErr)
+				}
+			}
+
+			if !reflect.DeepEqual(v, tc.want) {
+				t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", tc.data, v, v, tc.want, tc.want)
+			}
+		})
+	}
+
+	v := s{ID: 1, ID2: 2, ID3: 3}
+	want := mustHexDecode("a0")
+
+	b, err := Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal() returned an error %v", err)
+	}
+	if !bytes.Equal(b, want) {
+		t.Errorf("Marshal() returned 0x%x, want 0x%x", b, want)
+	}
+}
+
+// TestKeyAsIntAndStringFieldsWithSameName verifies that a struct with both a
+// keyasint field and a string-keyed field with the same tag name (e.g.
+// cbor:"1,keyasint" and cbor:"1") can decode CBOR maps with integer and text
+// keys independently.
+func TestKeyAsIntAndStringFieldsWithSameName(t *testing.T) {
+	type s struct {
+		ID        int `cbor:"1,keyasint"`
+		AnotherID int `cbor:"1"`
+	}
+
+	data := mustHexDecode("a20101613102") // {1: 1, "1": 2}
+	want := s{
+		ID:        1,
+		AnotherID: 2,
+	}
+
+	var v s
+	err := Unmarshal(data, &v)
+	if err != nil {
+		t.Errorf("Unmarshal returned unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Unmarshal(0x%x) returned %+v, want %+v", data, v, want)
+	}
+
+	// Roundtrip
+	b, err := Marshal(want)
+	if err != nil {
+		t.Errorf("Marshal returned unexpected error: %v", err)
+	}
+	if !bytes.Equal(b, data) {
+		t.Errorf("Marshal(%+v) returned 0x%x, want 0x%x", want, b, data)
+	}
+}
+
+// TestMapKeyOverflowStructKeyAsInt verifies that a CBOR integer map
+// key that is outside the range of math.MinInt64 and math.MaxInt64
+// is rejected with an UnmarshalTypeError.
+func TestMapKeyOverflowStructKeyAsInt(t *testing.T) {
+	type s struct {
+		ID int `cbor:"-1,keyasint"`
+	}
+
+	testCases := []struct {
+		name    string
+		data    []byte
+		wantErr *UnmarshalTypeError
+	}{
+		{
+			name: "map key < math.MinInt64",
+			data: mustHexDecode("a13bffffffffffffffff01"), // {-18446744073709551616: 1}
+			wantErr: &UnmarshalTypeError{
+				CBORType: cborTypeNegativeInt.String(),
+				GoType:   "int64",
+				errorMsg: "-1-18446744073709551615 overflows Go's int64",
+			},
+		},
+		{
+			name: "map key > math.MaxInt64",
+			data: mustHexDecode("a11bffffffffffffffff01"), // {18446744073709551615: 1}
+			wantErr: &UnmarshalTypeError{
+				CBORType: cborTypePositiveInt.String(),
+				GoType:   "int64",
+				errorMsg: "18446744073709551615 overflows Go's int64",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v s
+			err := Unmarshal(tc.data, &v)
+			if err != nil {
+				if !reflect.DeepEqual(err, tc.wantErr) {
+					t.Errorf("got error: %v, wanted: %v", err, tc.wantErr)
+				}
+			} else {
+				if tc.wantErr != nil {
+					t.Errorf("got nil error, wanted: %v", tc.wantErr)
+				}
+			}
 		})
 	}
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -4377,6 +4377,18 @@ func TestDecodeInvalidTagTime(t *testing.T) {
 			wantErrorMsg:  "cbor: cannot unmarshal negative integer into Go value of type time.Time (-18446744073709551616 overflows Go's int64)",
 		},
 		{
+			name:          "tag 1 with positive float64 overflow",
+			data:          mustHexDecode("c1fb4415af1d78b58c40"), // 1(1e+20)
+			decodeToTypes: []reflect.Type{typeIntf, typeTime},
+			wantErrorMsg:  "overflows Go's int64",
+		},
+		{
+			name:          "tag 1 with negative float64 overflow",
+			data:          mustHexDecode("c1fbc415af1d78b58c40"), // 1(-1e+20)
+			decodeToTypes: []reflect.Type{typeIntf, typeTime},
+			wantErrorMsg:  "overflows Go's int64",
+		},
+		{
 			name:          "tag 1 with string content",
 			data:          mustHexDecode("c174323031332d30332d32315432303a30343a30305a"),
 			decodeToTypes: []reflect.Type{typeIntf, typeTime},

--- a/decode_test.go
+++ b/decode_test.go
@@ -3499,6 +3499,17 @@ var invalidCBORUnmarshalTests = []struct {
 		data:         mustHexDecode("00830102"),
 		wantErrorMsg: "cbor: 3 bytes of extraneous data starting at index 1",
 	},
+	// Indefinite-length map
+	{
+		name:         "Indefinite-length map with one key and no value",
+		data:         []byte{0xbf, 0x61, 'a', 0xff},
+		wantErrorMsg: `cbor: unexpected "break" code`,
+	},
+	{
+		name:         "Indefinite-length map with two keys and one value",
+		data:         []byte{0xbf, 0x61, 'a', 0x01, 0x61, 'b', 0xff},
+		wantErrorMsg: `cbor: unexpected "break" code`,
+	},
 }
 
 func TestInvalidCBORUnmarshal(t *testing.T) {
@@ -3621,6 +3632,30 @@ func TestInvalidUTF8String(t *testing.T) {
 			data:    mustHexDecode("7f62e6b061b4ff"),
 			dm:      dmDecodeInvalidUTF8,
 			wantObj: string([]byte{0xe6, 0xb0, 0xb4}),
+		},
+		{
+			name: "indefinite-length invalid UTF-8 in the second chunk with UTF8RejectInvalid",
+			data: []byte{
+				0x7f,
+				0x62, 'a', 'b', // valid UTF-8
+				0x62, 0x80, 0x81, // invalid UTF-8
+				0x62, 'c', 'd', // valid UTF-8
+				0xff,
+			},
+			dm:           dmRejectInvalidUTF8,
+			wantErrorMsg: invalidUTF8ErrorMsg,
+		},
+		{
+			name: "indefinite-length invalid UTF-8 in the second chunk with dmDecodeInvalidUTF8",
+			data: []byte{
+				0x7f,
+				0x62, 'a', 'b', // valid UTF-8
+				0x62, 0x80, 0x81, // invalid UTF-8
+				0x62, 'c', 'd', // valid UTF-8
+				0xff,
+			},
+			dm:      dmDecodeInvalidUTF8,
+			wantObj: string([]byte{'a', 'b', 0x80, 0x81, 'c', 'd'}),
 		},
 	}
 
@@ -5799,6 +5834,9 @@ func TestUnmarshalStructKeyAsIntNumError(t *testing.T) {
 	type T2 struct {
 		F1 int `cbor:"-18446744073709551616,keyasint"`
 	}
+	type T3 struct {
+		F1 int `cbor:"99999999999999999999,keyasint"`
+	}
 	testCases := []struct {
 		name         string
 		data         []byte
@@ -5812,10 +5850,16 @@ func TestUnmarshalStructKeyAsIntNumError(t *testing.T) {
 			wantErrorMsg: "cbor: failed to parse field name \"a\" to int",
 		},
 		{
-			name:         "out of range int as key",
+			name:         "int key < math.MinInt",
 			data:         mustHexDecode("a13bffffffffffffffff01"),
 			obj:          T2{},
 			wantErrorMsg: "cbor: failed to parse field name \"-18446744073709551616\" to int",
+		},
+		{
+			name:         "int key > math.MaxInt",
+			data:         mustHexDecode("a10001"),
+			obj:          T3{},
+			wantErrorMsg: "cbor: failed to parse field name \"99999999999999999999\" to int",
 		},
 	}
 	for _, tc := range testCases {
@@ -6879,13 +6923,13 @@ func TestExceedMaxMapPairs(t *testing.T) {
 		wantErrorMsg string
 	}{
 		{
-			name:         "array",
+			name:         "map",
 			opts:         DecOptions{MaxMapPairs: 16},
 			data:         mustHexDecode("b101010101010101010101010101010101010101010101010101010101010101010101"),
 			wantErrorMsg: "cbor: exceeded max number of key-value pairs 16 for CBOR map",
 		},
 		{
-			name:         "indefinite length array",
+			name:         "indefinite length map",
 			opts:         DecOptions{MaxMapPairs: 16},
 			data:         mustHexDecode("bf01010101010101010101010101010101010101010101010101010101010101010101ff"),
 			wantErrorMsg: "cbor: exceeded max number of key-value pairs 16 for CBOR map",
@@ -10528,6 +10572,24 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			in:      []byte{0x42, 'f', 'f'},
 			want:    []byte{0xff},
 		},
+		{
+			name: "tag 21 wrapping tag 22",
+			opts: DecOptions{
+				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
+			},
+			dstType: reflect.TypeOf(""),
+			in:      []byte{0xd5, 0xd6, 0x42, 0x01, 0x02}, // 21(22(h'0102'))
+			want:    "AQI=",                               // base64 of [0x01, 0x02] with padding
+		},
+		{
+			name: "tag 22 wrapping tag 21",
+			opts: DecOptions{
+				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
+			},
+			dstType: reflect.TypeOf(""),
+			in:      []byte{0xd6, 0xd5, 0x42, 0x01, 0x02}, // 22(21(h'0102'))
+			want:    "AQI",                                // base64 of [0x01, 0x02] without padding
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dm, err := tc.opts.DecMode()
@@ -10908,5 +10970,23 @@ func TestJSONUnmarshalerTranscoder(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestByteStringExpectedFormatErrorUnwrap(t *testing.T) {
+	innerErr := errors.New("test error")
+	err := newByteStringExpectedFormatError(ByteStringExpectedBase64URL, innerErr)
+	if unwrapped := err.Unwrap(); unwrapped != innerErr {
+		t.Errorf("Unwrap() = %v, want %v", unwrapped, innerErr)
+	}
+}
+
+func TestByteStringExpectedFormatErrorDefaultCase(t *testing.T) {
+	innerErr := errors.New("test error")
+	err := &ByteStringExpectedFormatError{expectedFormatOption: 99, err: innerErr}
+	got := err.Error()
+	want := "cbor: failed to decode byte string in expected format 99: test error"
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
 	}
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -5276,11 +5276,11 @@ func TestUnmarshalArrayToStructWrongFieldTypeError(t *testing.T) {
 func TestUnmarshalArrayToStructCannotSetEmbeddedPointerError(t *testing.T) {
 	type (
 		s1 struct {
-			x int //nolint:unused,structcheck
+			x int //nolint:unused
 			X int
 		}
 		S2 struct {
-			y int //nolint:unused,structcheck
+			y int //nolint:unused
 			Y int
 		}
 		S struct {

--- a/decode_test.go
+++ b/decode_test.go
@@ -40,14 +40,14 @@ var (
 	typeMapStringIntf   = reflect.TypeOf(map[string]any{})
 )
 
-type unmarshalTest struct {
+type unmarshalTestCase struct {
 	data               []byte
 	wantInterfaceValue any
 	wantValues         []any
 	wrongTypes         []reflect.Type
 }
 
-var unmarshalTests = []unmarshalTest{
+var unmarshalTestCases = []unmarshalTestCase{
 	// CBOR test data are from https://tools.ietf.org/html/rfc7049#appendix-A.
 
 	// unsigned integer
@@ -1885,7 +1885,7 @@ var unmarshalTests = []unmarshalTest{
 
 	// More testcases not covered by https://tools.ietf.org/html/rfc7049#appendix-A.
 	{
-		data:               mustHexDecode("5fff"), // empty indefinite length byte string
+		data:               mustHexDecode("5fff"), // empty indefinite-length byte string
 		wantInterfaceValue: []byte{},
 		wantValues: []any{
 			[]byte{},
@@ -1914,7 +1914,7 @@ var unmarshalTests = []unmarshalTest{
 		},
 	},
 	{
-		data:               mustHexDecode("7fff"), // empty indefinite length text string
+		data:               mustHexDecode("7fff"), // empty indefinite-length text string
 		wantInterfaceValue: "",
 		wantValues:         []any{""},
 		wrongTypes: []reflect.Type{
@@ -1940,7 +1940,7 @@ var unmarshalTests = []unmarshalTest{
 		},
 	},
 	{
-		data:               mustHexDecode("bfff"), // empty indefinite length map
+		data:               mustHexDecode("bfff"), // empty indefinite-length map
 		wantInterfaceValue: map[any]any{},
 		wantValues: []any{
 			map[any]any{},
@@ -2042,7 +2042,7 @@ var unmarshalTests = []unmarshalTest{
 	},
 }
 
-type unmarshalFloatTest struct {
+type unmarshalFloatTestCase struct {
 	data               []byte
 	wantInterfaceValue any
 	wantValues         []any
@@ -2071,10 +2071,10 @@ var unmarshalFloatWrongTypes = []reflect.Type{
 	typeSimpleValue,
 }
 
-// unmarshalFloatTests includes test values for float16, float32, and float64.
+// unmarshalFloatTestCases includes test values for float16, float32, and float64.
 // Note: the function for float16 to float32 conversion was tested with all
 // 65536 values, which is too many to include here.
-var unmarshalFloatTests = []unmarshalFloatTest{
+var unmarshalFloatTestCases = []unmarshalFloatTestCase{
 	// CBOR test data are from https://tools.ietf.org/html/rfc7049#appendix-A.
 
 	// float16
@@ -2295,7 +2295,7 @@ func mustBigInt(s string) big.Int {
 }
 
 func TestUnmarshalToEmptyInterface(t *testing.T) {
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		var v any
 		if err := Unmarshal(tc.data, &v); err != nil {
 			t.Errorf("Unmarshal(0x%x) returned error %v", tc.data, err)
@@ -2306,7 +2306,7 @@ func TestUnmarshalToEmptyInterface(t *testing.T) {
 }
 
 func TestUnmarshalToRawMessage(t *testing.T) {
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		testUnmarshalToRawMessage(t, tc.data)
 	}
 }
@@ -2357,7 +2357,7 @@ func testUnmarshalToRawMessage(t *testing.T, data []byte) {
 }
 
 func TestUnmarshalToCompatibleTypes(t *testing.T) {
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		for _, wantValue := range tc.wantValues {
 			testUnmarshalToCompatibleType(t, tc.data, wantValue, func(gotValue any) {
 				compareNonFloats(t, tc.data, gotValue, wantValue)
@@ -2422,7 +2422,7 @@ func testUnmarshalToCompatibleType(t *testing.T, data []byte, wantValue any, com
 }
 
 func TestUnmarshalToIncompatibleTypes(t *testing.T) {
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		for _, wrongType := range tc.wrongTypes {
 			testUnmarshalToIncompatibleType(t, tc.data, wrongType)
 		}
@@ -2485,7 +2485,7 @@ func compareNonFloats(t *testing.T, data []byte, got any, want any) {
 }
 
 func TestUnmarshalFloatToEmptyInterface(t *testing.T) {
-	for _, tc := range unmarshalFloatTests {
+	for _, tc := range unmarshalFloatTestCases {
 		var v any
 		if err := Unmarshal(tc.data, &v); err != nil {
 			t.Errorf("Unmarshal(0x%x) returned error %v", tc.data, err)
@@ -2496,13 +2496,13 @@ func TestUnmarshalFloatToEmptyInterface(t *testing.T) {
 }
 
 func TestUnmarshalFloatToRawMessage(t *testing.T) {
-	for _, tc := range unmarshalFloatTests {
+	for _, tc := range unmarshalFloatTestCases {
 		testUnmarshalToRawMessage(t, tc.data)
 	}
 }
 
 func TestUnmarshalFloatToCompatibleTypes(t *testing.T) {
-	for _, tc := range unmarshalFloatTests {
+	for _, tc := range unmarshalFloatTestCases {
 		for _, wantValue := range tc.wantValues {
 			testUnmarshalToCompatibleType(t, tc.data, wantValue, func(gotValue any) {
 				compareFloats(t, tc.data, gotValue, wantValue, tc.equalityThreshold)
@@ -2512,7 +2512,7 @@ func TestUnmarshalFloatToCompatibleTypes(t *testing.T) {
 }
 
 func TestUnmarshalFloatToIncompatibleTypes(t *testing.T) {
-	for _, tc := range unmarshalFloatTests {
+	for _, tc := range unmarshalFloatTestCases {
 		for _, wrongType := range unmarshalFloatWrongTypes {
 			testUnmarshalToIncompatibleType(t, tc.data, wrongType)
 		}
@@ -2960,7 +2960,7 @@ func TestUnmarshalNil(t *testing.T) {
 	}
 }
 
-var invalidUnmarshalTests = []struct {
+var invalidUnmarshalTestCases = []struct {
 	name         string
 	v            any
 	wantErrorMsg string
@@ -2985,7 +2985,7 @@ var invalidUnmarshalTests = []struct {
 func TestInvalidUnmarshal(t *testing.T) {
 	data := []byte{0x00}
 
-	for _, tc := range invalidUnmarshalTests {
+	for _, tc := range invalidUnmarshalTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := Unmarshal(data, tc.v)
 			if err == nil {
@@ -2999,521 +2999,521 @@ func TestInvalidUnmarshal(t *testing.T) {
 	}
 }
 
-var invalidCBORUnmarshalTests = []struct {
+var invalidCBORUnmarshalTestCases = []struct {
 	name         string
 	data         []byte
 	wantErrorMsg string
 }{
 	{
-		name:         "Nil data",
+		name:         "nil data",
 		data:         []byte(nil),
 		wantErrorMsg: "EOF",
 	},
 	{
-		name:         "Empty data",
+		name:         "empty data",
 		data:         []byte{},
 		wantErrorMsg: "EOF",
 	},
 	{
-		name:         "Tag number not followed by tag content",
+		name:         "tag number not followed by tag content",
 		data:         []byte{0xc0},
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Indefinite length byte string with tagged chunk",
+		name:         "indefinite-length byte string with tagged chunk",
 		data:         mustHexDecode("5fc64401020304ff"),
 		wantErrorMsg: "cbor: wrong element type tag for indefinite-length byte string",
 	},
 	{
-		name:         "Indefinite length text string with tagged chunk",
+		name:         "indefinite-length text string with tagged chunk",
 		data:         mustHexDecode("7fc06161ff"),
 		wantErrorMsg: "cbor: wrong element type tag for indefinite-length UTF-8 text string",
 	},
 	{
-		name:         "Indefinite length strings with truncated text string",
+		name:         "indefinite-length strings with truncated text string",
 		data:         mustHexDecode("7f61"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Invalid nested tag number",
+		name:         "invalid nested tag number",
 		data:         mustHexDecode("d864dc1a514b67b0"),
 		wantErrorMsg: "cbor: invalid additional information 28 for type tag",
 	},
 	// Data from 7049bis G.1
 	// Premature end of the input
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("18"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("19"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("1a"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("1b"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("1901"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("1a0102"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("1b01020304050607"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("38"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("58"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("78"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("98"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("9a01ff00"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("b8"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("d8"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("f8"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("f900"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("fa0000"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("fb000000"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Definite length strings with short data",
+		name:         "definite-length strings with short data",
 		data:         mustHexDecode("41"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Definite length strings with short data",
+		name:         "definite-length strings with short data",
 		data:         mustHexDecode("61"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Definite length strings with short data",
+		name:         "definite-length strings with short data",
 		data:         mustHexDecode("5affffffff00"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Definite length strings with short data",
+		name:         "definite-length strings with short data",
 		data:         mustHexDecode("5bffffffffffffffff010203"),
 		wantErrorMsg: "cbor: byte string length 18446744073709551615 is too large, causing integer overflow",
 	},
 	{
-		name:         "Definite length strings with short data",
+		name:         "definite-length strings with short data",
 		data:         mustHexDecode("7affffffff00"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Definite length strings with short data",
+		name:         "definite-length strings with short data",
 		data:         mustHexDecode("7b7fffffffffffffff010203"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Definite length maps and arrays not closed with enough items",
+		name:         "definite-length maps and arrays not closed with enough items",
 		data:         mustHexDecode("81"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Definite length maps and arrays not closed with enough items",
+		name:         "definite-length maps and arrays not closed with enough items",
 		data:         mustHexDecode("818181818181818181"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Definite length maps and arrays not closed with enough items",
+		name:         "definite-length maps and arrays not closed with enough items",
 		data:         mustHexDecode("8200"),
 		wantErrorMsg: "unexpected EOF",
 	},
 
 	{
-		name:         "Definite length maps and arrays not closed with enough items",
+		name:         "definite-length maps and arrays not closed with enough items",
 		data:         mustHexDecode("a1"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Definite length maps and arrays not closed with enough items",
+		name:         "definite-length maps and arrays not closed with enough items",
 		data:         mustHexDecode("a20102"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Definite length maps and arrays not closed with enough items",
+		name:         "definite-length maps and arrays not closed with enough items",
 		data:         mustHexDecode("a100"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Definite length maps and arrays not closed with enough items",
+		name:         "definite-length maps and arrays not closed with enough items",
 		data:         mustHexDecode("a2000000"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Indefinite length strings not closed by a break stop code",
+		name:         "indefinite-length strings not closed by a break stop code",
 		data:         mustHexDecode("5f4100"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Indefinite length strings not closed by a break stop code",
+		name:         "indefinite-length strings not closed by a break stop code",
 		data:         mustHexDecode("7f6100"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Indefinite length maps and arrays not closed by a break stop code",
+		name:         "indefinite-length maps and arrays not closed by a break stop code",
 		data:         mustHexDecode("9f"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Indefinite length maps and arrays not closed by a break stop code",
+		name:         "indefinite-length maps and arrays not closed by a break stop code",
 		data:         mustHexDecode("9f0102"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Indefinite length maps and arrays not closed by a break stop code",
+		name:         "indefinite-length maps and arrays not closed by a break stop code",
 		data:         mustHexDecode("bf"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Indefinite length maps and arrays not closed by a break stop code",
+		name:         "indefinite-length maps and arrays not closed by a break stop code",
 		data:         mustHexDecode("bf01020102"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Indefinite length maps and arrays not closed by a break stop code",
+		name:         "indefinite-length maps and arrays not closed by a break stop code",
 		data:         mustHexDecode("819f"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Indefinite length maps and arrays not closed by a break stop code",
+		name:         "indefinite-length maps and arrays not closed by a break stop code",
 		data:         mustHexDecode("9f8000"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Indefinite length maps and arrays not closed by a break stop code",
+		name:         "indefinite-length maps and arrays not closed by a break stop code",
 		data:         mustHexDecode("9f9f9f9f9fffffffff"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "Indefinite length maps and arrays not closed by a break stop code",
+		name:         "indefinite-length maps and arrays not closed by a break stop code",
 		data:         mustHexDecode("9f819f819f9fffffff"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	// Five subkinds of well-formedness error kind 3 (syntax error)
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("3e"),
 		wantErrorMsg: "cbor: invalid additional information 30 for type negative integer",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("5c"),
 		wantErrorMsg: "cbor: invalid additional information 28 for type byte string",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("5d"),
 		wantErrorMsg: "cbor: invalid additional information 29 for type byte string",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("5e"),
 		wantErrorMsg: "cbor: invalid additional information 30 for type byte string",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("7c"),
 		wantErrorMsg: "cbor: invalid additional information 28 for type UTF-8 text string",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("7d"),
 		wantErrorMsg: "cbor: invalid additional information 29 for type UTF-8 text string",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("7e"),
 		wantErrorMsg: "cbor: invalid additional information 30 for type UTF-8 text string",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("9c"),
 		wantErrorMsg: "cbor: invalid additional information 28 for type array",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("9d"),
 		wantErrorMsg: "cbor: invalid additional information 29 for type array",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("9e"),
 		wantErrorMsg: "cbor: invalid additional information 30 for type array",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("bc"),
 		wantErrorMsg: "cbor: invalid additional information 28 for type map",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("bd"),
 		wantErrorMsg: "cbor: invalid additional information 29 for type map",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("be"),
 		wantErrorMsg: "cbor: invalid additional information 30 for type map",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("dc"),
 		wantErrorMsg: "cbor: invalid additional information 28 for type tag",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("dd"),
 		wantErrorMsg: "cbor: invalid additional information 29 for type tag",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("de"),
 		wantErrorMsg: "cbor: invalid additional information 30 for type tag",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("fc"),
 		wantErrorMsg: "cbor: invalid additional information 28 for type primitives",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("fd"),
 		wantErrorMsg: "cbor: invalid additional information 29 for type primitives",
 	},
 	{
-		name:         "Reserved additional information values",
+		name:         "reserved additional information values",
 		data:         mustHexDecode("fe"),
 		wantErrorMsg: "cbor: invalid additional information 30 for type primitives",
 	},
 	{
-		name:         "Reserved two-byte encodings of simple types",
+		name:         "reserved two-byte encodings of simple types",
 		data:         mustHexDecode("f800"),
 		wantErrorMsg: "cbor: invalid simple value 0 for type primitives",
 	},
 	{
-		name:         "Reserved two-byte encodings of simple types",
+		name:         "reserved two-byte encodings of simple types",
 		data:         mustHexDecode("f801"),
 		wantErrorMsg: "cbor: invalid simple value 1 for type primitives",
 	},
 	{
-		name:         "Reserved two-byte encodings of simple types",
+		name:         "reserved two-byte encodings of simple types",
 		data:         mustHexDecode("f818"),
 		wantErrorMsg: "cbor: invalid simple value 24 for type primitives",
 	},
 	{
-		name:         "Reserved two-byte encodings of simple types",
+		name:         "reserved two-byte encodings of simple types",
 		data:         mustHexDecode("f81f"),
 		wantErrorMsg: "cbor: invalid simple value 31 for type primitives",
 	},
 	{
-		name:         "Indefinite length string chunks not of the correct type",
+		name:         "indefinite-length string chunks not of the correct type",
 		data:         mustHexDecode("5f00ff"),
 		wantErrorMsg: "cbor: wrong element type positive integer for indefinite-length byte string",
 	},
 	{
-		name:         "Indefinite length string chunks not of the correct type",
+		name:         "indefinite-length string chunks not of the correct type",
 		data:         mustHexDecode("5f21ff"),
 		wantErrorMsg: "cbor: wrong element type negative integer for indefinite-length byte string",
 	},
 	{
-		name:         "Indefinite length string chunks not of the correct type",
+		name:         "indefinite-length string chunks not of the correct type",
 		data:         mustHexDecode("5f6100ff"),
 		wantErrorMsg: "cbor: wrong element type UTF-8 text string for indefinite-length byte string",
 	},
 	{
-		name:         "Indefinite length string chunks not of the correct type",
+		name:         "indefinite-length string chunks not of the correct type",
 		data:         mustHexDecode("5f80ff"),
 		wantErrorMsg: "cbor: wrong element type array for indefinite-length byte string",
 	},
 	{
-		name:         "Indefinite length string chunks not of the correct type",
+		name:         "indefinite-length string chunks not of the correct type",
 		data:         mustHexDecode("5fa0ff"),
 		wantErrorMsg: "cbor: wrong element type map for indefinite-length byte string",
 	},
 	{
-		name:         "Indefinite length string chunks not of the correct type",
+		name:         "indefinite-length string chunks not of the correct type",
 		data:         mustHexDecode("5fc000ff"),
 		wantErrorMsg: "cbor: wrong element type tag for indefinite-length byte string",
 	},
 	{
-		name:         "Indefinite length string chunks not of the correct type",
+		name:         "indefinite-length string chunks not of the correct type",
 		data:         mustHexDecode("5fe0ff"),
 		wantErrorMsg: "cbor: wrong element type primitives for indefinite-length byte string",
 	},
 	{
-		name:         "Indefinite length string chunks not of the correct type",
+		name:         "indefinite-length string chunks not of the correct type",
 		data:         mustHexDecode("7f4100ff"),
 		wantErrorMsg: "cbor: wrong element type byte string for indefinite-length UTF-8 text string",
 	},
 	{
-		name:         "Indefinite length string chunks not definite length",
+		name:         "indefinite-length string chunks not definite-length",
 		data:         mustHexDecode("5f5f4100ffff"),
 		wantErrorMsg: "cbor: indefinite-length byte string chunk is not definite-length",
 	},
 	{
-		name:         "Indefinite length string chunks not definite length",
+		name:         "indefinite-length string chunks not definite-length",
 		data:         mustHexDecode("7f7f6100ffff"),
 		wantErrorMsg: "cbor: indefinite-length UTF-8 text string chunk is not definite-length",
 	},
 	{
-		name:         "Break occurring on its own outside of an indefinite length item",
+		name:         "break occurring on its own outside of an indefinite-length item",
 		data:         mustHexDecode("ff"),
 		wantErrorMsg: "cbor: unexpected \"break\" code",
 	},
 	{
-		name:         "Break occurring in a definite length array or map or a tag",
+		name:         "break occurring in a definite-length array or map or a tag",
 		data:         mustHexDecode("81ff"),
 		wantErrorMsg: "cbor: unexpected \"break\" code",
 	},
 	{
-		name:         "Break occurring in a definite length array or map or a tag",
+		name:         "break occurring in a definite-length array or map or a tag",
 		data:         mustHexDecode("8200ff"),
 		wantErrorMsg: "cbor: unexpected \"break\" code",
 	},
 	{
-		name:         "Break occurring in a definite length array or map or a tag",
+		name:         "break occurring in a definite-length array or map or a tag",
 		data:         mustHexDecode("a1ff"),
 		wantErrorMsg: "cbor: unexpected \"break\" code",
 	},
 	{
-		name:         "Break occurring in a definite length array or map or a tag",
+		name:         "break occurring in a definite-length array or map or a tag",
 		data:         mustHexDecode("a1ff00"),
 		wantErrorMsg: "cbor: unexpected \"break\" code",
 	},
 	{
-		name:         "Break occurring in a definite length array or map or a tag",
+		name:         "break occurring in a definite-length array or map or a tag",
 		data:         mustHexDecode("a100ff"),
 		wantErrorMsg: "cbor: unexpected \"break\" code",
 	},
 	{
-		name:         "Break occurring in a definite length array or map or a tag",
+		name:         "break occurring in a definite-length array or map or a tag",
 		data:         mustHexDecode("a20000ff"),
 		wantErrorMsg: "cbor: unexpected \"break\" code",
 	},
 	{
-		name:         "Break occurring in a definite length array or map or a tag",
+		name:         "break occurring in a definite-length array or map or a tag",
 		data:         mustHexDecode("9f81ff"),
 		wantErrorMsg: "cbor: unexpected \"break\" code",
 	},
 	{
-		name:         "Break occurring in a definite length array or map or a tag",
+		name:         "break occurring in a definite-length array or map or a tag",
 		data:         mustHexDecode("9f829f819f9fffffffff"),
 		wantErrorMsg: "cbor: unexpected \"break\" code",
 	},
 	{
-		name:         "Break in indefinite length map would lead to odd number of items (break in a value position)",
+		name:         "break in indefinite-length map would lead to odd number of items (break in a value position)",
 		data:         mustHexDecode("bf00ff"),
 		wantErrorMsg: "cbor: unexpected \"break\" code",
 	},
 	{
-		name:         "Break in indefinite length map would lead to odd number of items (break in a value position)",
+		name:         "break in indefinite-length map would lead to odd number of items (break in a value position)",
 		data:         mustHexDecode("bf000000ff"),
 		wantErrorMsg: "cbor: unexpected \"break\" code",
 	},
 	{
-		name:         "Major type 0 with additional information 31",
+		name:         "major type 0 with additional information 31",
 		data:         mustHexDecode("1f"),
 		wantErrorMsg: "cbor: invalid additional information 31 for type positive integer",
 	},
 	{
-		name:         "Major type 1 with additional information 31",
+		name:         "major type 1 with additional information 31",
 		data:         mustHexDecode("3f"),
 		wantErrorMsg: "cbor: invalid additional information 31 for type negative integer",
 	},
 	{
-		name:         "Major type 6 with additional information 31",
+		name:         "major type 6 with additional information 31",
 		data:         mustHexDecode("df"),
 		wantErrorMsg: "cbor: invalid additional information 31 for type tag",
 	},
 	// Extraneous data
 	{
-		name:         "Two ints",
+		name:         "two ints",
 		data:         mustHexDecode("0001"),
 		wantErrorMsg: "cbor: 1 bytes of extraneous data starting at index 1",
 	},
 	{
-		name:         "Two arrays",
+		name:         "two arrays",
 		data:         mustHexDecode("830102038104"),
 		wantErrorMsg: "cbor: 2 bytes of extraneous data starting at index 4",
 	},
 	{
-		name:         "Int and partial array",
+		name:         "int and partial array",
 		data:         mustHexDecode("00830102"),
 		wantErrorMsg: "cbor: 3 bytes of extraneous data starting at index 1",
 	},
 	// Indefinite-length map
 	{
-		name:         "Indefinite-length map with one key and no value",
+		name:         "indefinite-length map with one key and no value",
 		data:         []byte{0xbf, 0x61, 'a', 0xff},
 		wantErrorMsg: `cbor: unexpected "break" code`,
 	},
 	{
-		name:         "Indefinite-length map with two keys and one value",
+		name:         "indefinite-length map with two keys and one value",
 		data:         []byte{0xbf, 0x61, 'a', 0x01, 0x61, 'b', 0xff},
 		wantErrorMsg: `cbor: unexpected "break" code`,
 	},
 }
 
 func TestInvalidCBORUnmarshal(t *testing.T) {
-	for _, tc := range invalidCBORUnmarshalTests {
+	for _, tc := range invalidCBORUnmarshalTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var i any
 			err := Unmarshal(tc.data, &i)
@@ -3555,13 +3555,13 @@ func TestValidUTF8String(t *testing.T) {
 			wantObj: "streaming",
 		},
 		{
-			name:    "indef length with UTF8RejectInvalid",
+			name:    "indefinite-length with UTF8RejectInvalid",
 			data:    mustHexDecode("7f657374726561646d696e67ff"),
 			dm:      dmRejectInvalidUTF8,
 			wantObj: "streaming",
 		},
 		{
-			name:    "indef length with UTF8DecodeInvalid",
+			name:    "indefinite-length with UTF8DecodeInvalid",
 			data:    mustHexDecode("7f657374726561646d696e67ff"),
 			dm:      dmDecodeInvalidUTF8,
 			wantObj: "streaming",
@@ -3622,13 +3622,13 @@ func TestInvalidUTF8String(t *testing.T) {
 			wantObj: string([]byte{0xfe}),
 		},
 		{
-			name:         "indef length with UTF8RejectInvalid",
+			name:         "indefinite-length with UTF8RejectInvalid",
 			data:         mustHexDecode("7f62e6b061b4ff"),
 			dm:           dmRejectInvalidUTF8,
 			wantErrorMsg: invalidUTF8ErrorMsg,
 		},
 		{
-			name:    "indef length with UTF8DecodeInvalid",
+			name:    "indefinite-length with UTF8DecodeInvalid",
 			data:    mustHexDecode("7f62e6b061b4ff"),
 			dm:      dmDecodeInvalidUTF8,
 			wantObj: string([]byte{0xe6, 0xb0, 0xb4}),
@@ -3666,7 +3666,7 @@ func TestInvalidUTF8String(t *testing.T) {
 			err = tc.dm.Unmarshal(tc.data, &v)
 			if tc.wantErrorMsg != "" {
 				if err == nil {
-					t.Errorf("Unmarshal(0x%x) didn't return error", tc.data)
+					t.Errorf("Unmarshal(0x%x) didn't return an error", tc.data)
 				} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
 					t.Errorf("Unmarshal(0x%x) error %q, want %q", tc.data, err.Error(), tc.wantErrorMsg)
 				}
@@ -3684,7 +3684,7 @@ func TestInvalidUTF8String(t *testing.T) {
 			err = tc.dm.Unmarshal(tc.data, &s)
 			if tc.wantErrorMsg != "" {
 				if err == nil {
-					t.Errorf("Unmarshal(0x%x) didn't return error", tc.data)
+					t.Errorf("Unmarshal(0x%x) didn't return an error", tc.data)
 				} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
 					t.Errorf("Unmarshal(0x%x) error %q, want %q", tc.data, err.Error(), tc.wantErrorMsg)
 				}
@@ -3743,7 +3743,7 @@ func TestUnmarshalStruct(t *testing.T) {
 		unexportedField:   0,
 	}
 
-	tests := []struct {
+	testCases := []struct {
 		name string
 		data []byte
 		want any
@@ -3759,7 +3759,7 @@ func TestUnmarshalStruct(t *testing.T) {
 			want: want,
 		},
 	}
-	for _, tc := range tests {
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var v outer
 			if err := Unmarshal(tc.data, &v); err != nil {
@@ -4341,55 +4341,55 @@ func TestDecodeInvalidTagTime(t *testing.T) {
 		wantErrorMsg  string
 	}{
 		{
-			name:          "Tag 0 with invalid RFC3339 time string",
+			name:          "tag 0 with invalid RFC3339 time string",
 			data:          mustHexDecode("c07f657374726561646d696e67ff"),
 			decodeToTypes: []reflect.Type{typeIntf, typeTime},
 			wantErrorMsg:  "cbor: cannot set streaming for time.Time",
 		},
 		{
-			name:          "Tag 0 with invalid UTF-8 string",
+			name:          "tag 0 with invalid UTF-8 string",
 			data:          mustHexDecode("c07f62e6b061b4ff"),
 			decodeToTypes: []reflect.Type{typeIntf, typeTime},
 			wantErrorMsg:  "cbor: invalid UTF-8 string",
 		},
 		{
-			name:          "Tag 0 with integer content",
+			name:          "tag 0 with integer content",
 			data:          mustHexDecode("c01a514b67b0"),
 			decodeToTypes: []reflect.Type{typeIntf, typeTime},
 			wantErrorMsg:  "cbor: tag number 0 must be followed by text string, got positive integer",
 		},
 		{
-			name:          "Tag 0 with byte string content",
+			name:          "tag 0 with byte string content",
 			data:          mustHexDecode("c04f013030303030303030e03031ed3030"),
 			decodeToTypes: []reflect.Type{typeIntf, typeTime},
 			wantErrorMsg:  "cbor: tag number 0 must be followed by text string, got byte string",
 		},
 		{
-			name:          "Tag 0 with integer content as array element",
+			name:          "tag 0 with integer content as array element",
 			data:          mustHexDecode("81c01a514b67b0"),
 			decodeToTypes: []reflect.Type{typeIntf, typeTimeSlice},
 			wantErrorMsg:  "cbor: tag number 0 must be followed by text string, got positive integer",
 		},
 		{
-			name:          "Tag 1 with negative integer overflow",
+			name:          "tag 1 with negative integer overflow",
 			data:          mustHexDecode("c13bffffffffffffffff"),
 			decodeToTypes: []reflect.Type{typeIntf, typeTime},
 			wantErrorMsg:  "cbor: cannot unmarshal negative integer into Go value of type time.Time (-18446744073709551616 overflows Go's int64)",
 		},
 		{
-			name:          "Tag 1 with string content",
+			name:          "tag 1 with string content",
 			data:          mustHexDecode("c174323031332d30332d32315432303a30343a30305a"),
 			decodeToTypes: []reflect.Type{typeIntf, typeTime},
 			wantErrorMsg:  "cbor: tag number 1 must be followed by integer or floating-point number, got UTF-8 text string",
 		},
 		{
-			name:          "Tag 1 with simple value",
+			name:          "tag 1 with simple value",
 			data:          mustHexDecode("d801f6"), // 1(null)
 			decodeToTypes: []reflect.Type{typeIntf, typeTime},
 			wantErrorMsg:  "cbor: tag number 1 must be followed by integer or floating-point number, got primitive",
 		},
 		{
-			name:          "Tag 1 with string content as array element",
+			name:          "tag 1 with string content as array element",
 			data:          mustHexDecode("81c174323031332d30332d32315432303a30343a30305a"),
 			decodeToTypes: []reflect.Type{typeIntf, typeTimeSlice},
 			wantErrorMsg:  "cbor: tag number 1 must be followed by integer or floating-point number, got UTF-8 text string",
@@ -4401,7 +4401,7 @@ func TestDecodeInvalidTagTime(t *testing.T) {
 			t.Run(tc.name+" decode to "+decodeToType.String(), func(t *testing.T) {
 				v := reflect.New(decodeToType)
 				if err := dm.Unmarshal(tc.data, v.Interface()); err == nil {
-					t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", tc.data, tc.wantErrorMsg)
+					t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", tc.data, tc.wantErrorMsg)
 				} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
 					t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.data, err, tc.wantErrorMsg)
 				}
@@ -4432,7 +4432,7 @@ func TestDecodeTag0Error(t *testing.T) {
 			// Decode to interface{}
 			var v any
 			if err := tc.dm.Unmarshal(data, &v); err == nil {
-				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", data, wantErrorMsg)
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", data, wantErrorMsg)
 			} else if !strings.Contains(err.Error(), wantErrorMsg) {
 				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", data, err, wantErrorMsg)
 			}
@@ -4440,7 +4440,7 @@ func TestDecodeTag0Error(t *testing.T) {
 			// Decode to time.Time
 			var tm time.Time
 			if err := tc.dm.Unmarshal(data, &tm); err == nil {
-				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", data, wantErrorMsg)
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", data, wantErrorMsg)
 			} else if !strings.Contains(err.Error(), wantErrorMsg) {
 				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", data, err, wantErrorMsg)
 			}
@@ -4448,7 +4448,7 @@ func TestDecodeTag0Error(t *testing.T) {
 			// Decode to uint64
 			var ui uint64
 			if err := tc.dm.Unmarshal(data, &ui); err == nil {
-				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", data, wantErrorMsg)
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", data, wantErrorMsg)
 			} else if !strings.Contains(err.Error(), wantErrorMsg) {
 				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", data, err, wantErrorMsg)
 			}
@@ -4478,7 +4478,7 @@ func TestDecodeTag1Error(t *testing.T) {
 			// Decode to interface{}
 			var v any
 			if err := tc.dm.Unmarshal(data, &v); err == nil {
-				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", data, wantErrorMsg)
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", data, wantErrorMsg)
 			} else if !strings.Contains(err.Error(), wantErrorMsg) {
 				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", data, err, wantErrorMsg)
 			}
@@ -4486,7 +4486,7 @@ func TestDecodeTag1Error(t *testing.T) {
 			// Decode to time.Time
 			var tm time.Time
 			if err := tc.dm.Unmarshal(data, &tm); err == nil {
-				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", data, wantErrorMsg)
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", data, wantErrorMsg)
 			} else if !strings.Contains(err.Error(), wantErrorMsg) {
 				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", data, err, wantErrorMsg)
 			}
@@ -4494,7 +4494,7 @@ func TestDecodeTag1Error(t *testing.T) {
 			// Decode to string
 			var s string
 			if err := tc.dm.Unmarshal(data, &s); err == nil {
-				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", data, wantErrorMsg)
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", data, wantErrorMsg)
 			} else if !strings.Contains(err.Error(), wantErrorMsg) {
 				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", data, err, wantErrorMsg)
 			}
@@ -4554,7 +4554,7 @@ func TestDecodeTimeStreaming(t *testing.T) {
 		err := dec.Decode(&v)
 		if tc.wantErrorMsg != "" {
 			if err == nil {
-				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", tc.data, tc.wantErrorMsg)
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", tc.data, tc.wantErrorMsg)
 			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
 				t.Errorf("Unmarshal(0x%x) returned error msg %q, want %q", tc.data, err, tc.wantErrorMsg)
 			}
@@ -4672,7 +4672,7 @@ func TestDecTimeTagOption(t *testing.T) {
 			err := tc.decMode.Unmarshal(tc.cborRFC3339Time, &tm)
 			if tc.wantErrorMsg != "" {
 				if err == nil {
-					t.Errorf("Unmarshal(0x%x) didn't return error", tc.cborRFC3339Time)
+					t.Errorf("Unmarshal(0x%x) didn't return an error", tc.cborRFC3339Time)
 				} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
 					t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", tc.cborRFC3339Time, err.Error(), tc.wantErrorMsg)
 				}
@@ -4686,7 +4686,7 @@ func TestDecTimeTagOption(t *testing.T) {
 			err = tc.decMode.Unmarshal(tc.cborUnixTime, &tm)
 			if tc.wantErrorMsg != "" {
 				if err == nil {
-					t.Errorf("Unmarshal(0x%x) didn't return error", tc.cborRFC3339Time)
+					t.Errorf("Unmarshal(0x%x) didn't return an error", tc.cborRFC3339Time)
 				} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
 					t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", tc.cborRFC3339Time, err.Error(), tc.wantErrorMsg)
 				}
@@ -4840,7 +4840,7 @@ func (n marshalBinaryError) MarshalBinary() (data []byte, err error) {
 }
 
 func TestBinaryMarshalerUnmarshaler(t *testing.T) {
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			name:         "primitive obj",
 			obj:          number(1234567890),
@@ -4948,7 +4948,7 @@ func (n marshalCBORError) MarshalCBOR() (data []byte, err error) {
 }
 
 func TestMarshalerUnmarshaler(t *testing.T) {
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			name:         "primitive obj",
 			obj:          number2(1),
@@ -5081,11 +5081,11 @@ func TestUnmarshalArrayToStruct(t *testing.T) {
 		data []byte
 	}{
 		{
-			name: "definite length array",
+			name: "definite-length array",
 			data: mustHexDecode("83010203"),
 		},
 		{
-			name: "indefinite length array",
+			name: "indefinite-length array",
 			data: mustHexDecode("9f010203ff"),
 		},
 	}
@@ -5565,13 +5565,13 @@ func TestDecOptions(t *testing.T) {
 	}
 }
 
-type roundTripTest struct {
+type roundTripTestCase struct {
 	name         string
 	obj          any
 	wantCborData []byte
 }
 
-func testRoundTrip(t *testing.T, testCases []roundTripTest, em EncMode, dm DecMode) {
+func testRoundTrip(t *testing.T, testCases []roundTripTestCase, em EncMode, dm DecMode) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			b, err := em.Marshal(tc.obj)
@@ -6896,7 +6896,7 @@ func TestExceedMaxArrayElements(t *testing.T) {
 			wantErrorMsg: "cbor: exceeded max number of elements 16 for CBOR array",
 		},
 		{
-			name:         "indefinite length array",
+			name:         "indefinite-length array",
 			opts:         DecOptions{MaxArrayElements: 16},
 			data:         mustHexDecode("9f0101010101010101010101010101010101ff"),
 			wantErrorMsg: "cbor: exceeded max number of elements 16 for CBOR array",
@@ -6929,7 +6929,7 @@ func TestExceedMaxMapPairs(t *testing.T) {
 			wantErrorMsg: "cbor: exceeded max number of key-value pairs 16 for CBOR map",
 		},
 		{
-			name:         "indefinite length map",
+			name:         "indefinite-length map",
 			opts:         DecOptions{MaxMapPairs: 16},
 			data:         mustHexDecode("bf01010101010101010101010101010101010101010101010101010101010101010101ff"),
 			wantErrorMsg: "cbor: exceeded max number of key-value pairs 16 for CBOR map",
@@ -6974,7 +6974,7 @@ func TestDecIndefiniteLengthOption(t *testing.T) {
 			wantErrorMsg: "cbor: indefinite-length array isn't allowed",
 		},
 		{
-			name:         "indefinite length array",
+			name:         "indefinite-length array",
 			opts:         DecOptions{IndefLength: IndefLengthForbidden},
 			data:         mustHexDecode("bfff"),
 			wantErrorMsg: "cbor: indefinite-length map isn't allowed",
@@ -6982,7 +6982,7 @@ func TestDecIndefiniteLengthOption(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Default option allows indefinite length items
+			// Default option allows indefinite-length items
 			var v any
 			if err := Unmarshal(tc.data, &v); err != nil {
 				t.Errorf("Unmarshal(0x%x) returned an error %v", tc.data, err)
@@ -7543,7 +7543,7 @@ func TestStreamExtraErrorCondUnknownField(t *testing.T) {
 func TestUnmarshalTagNum55799(t *testing.T) {
 	tagNum55799 := mustHexDecode("d9d9f7")
 
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		// Prefix tag number 55799 to CBOR test data
 		data := make([]byte, len(tc.data)+6)
 		copy(data, tagNum55799)
@@ -7609,7 +7609,7 @@ func TestUnmarshalTagNum55799(t *testing.T) {
 func TestUnmarshalFloatWithTagNum55799(t *testing.T) {
 	tagNum55799 := mustHexDecode("d9d9f7")
 
-	for _, tc := range unmarshalFloatTests {
+	for _, tc := range unmarshalFloatTestCases {
 		// Prefix tag number 55799 to CBOR test data
 		data := make([]byte, len(tc.data)+3)
 		copy(data, tagNum55799)
@@ -7819,7 +7819,7 @@ func TestUnmarshalNestedTagNum55799ToTime(t *testing.T) {
 
 	var v time.Time
 	if err := Unmarshal(data, &v); err == nil {
-		t.Errorf("Unmarshal(0x%x) didn't return error", data)
+		t.Errorf("Unmarshal(0x%x) didn't return an error", data)
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
 		t.Errorf("Unmarshal(0x%x) returned error %s, want %s", data, err.Error(), wantErrorMsg)
 	}
@@ -7843,7 +7843,7 @@ func TestUnmarshalNestedTagNum55799ToUnmarshaler(t *testing.T) {
 
 	var v number3
 	if err := Unmarshal(data, &v); err == nil {
-		t.Errorf("Unmarshal(0x%x) didn't return error", data)
+		t.Errorf("Unmarshal(0x%x) didn't return an error", data)
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
 		t.Errorf("Unmarshal(0x%x) returned error %s, want %s", data, err.Error(), wantErrorMsg)
 	}
@@ -7865,7 +7865,7 @@ func TestUnmarshalNestedTagNum55799ToRegisteredGoType(t *testing.T) {
 
 	var v myInt
 	if err := dm.Unmarshal(data, &v); err == nil {
-		t.Errorf("Unmarshal() didn't return error")
+		t.Errorf("Unmarshal() didn't return an error")
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
 		t.Errorf("Unmarshal(0x%x) returned error %s, want %s", data, err.Error(), wantErrorMsg)
 	}
@@ -8086,19 +8086,19 @@ func TestUnmarshalInvalidTagBignum(t *testing.T) {
 		wantErrorMsg  string
 	}{
 		{
-			name:          "Tag 2 with string",
+			name:          "tag 2 with string",
 			data:          mustHexDecode("c27f657374726561646d696e67ff"),
 			decodeToTypes: []reflect.Type{typeIntf, typeBigInt},
 			wantErrorMsg:  "cbor: tag number 2 or 3 must be followed by byte string, got UTF-8 text string",
 		},
 		{
-			name:          "Tag 3 with string",
+			name:          "tag 3 with string",
 			data:          mustHexDecode("c37f657374726561646d696e67ff"),
 			decodeToTypes: []reflect.Type{typeIntf, typeBigInt},
 			wantErrorMsg:  "cbor: tag number 2 or 3 must be followed by byte string, got UTF-8 text string",
 		},
 		{
-			name:          "Tag 3 with negavtive int",
+			name:          "tag 3 with negative integer",
 			data:          mustHexDecode("81C330"), // [3(-17)]
 			decodeToTypes: []reflect.Type{typeIntf, typeBigIntSlice},
 			wantErrorMsg:  "cbor: tag number 2 or 3 must be followed by byte string, got negative integer",
@@ -8109,7 +8109,7 @@ func TestUnmarshalInvalidTagBignum(t *testing.T) {
 			t.Run(tc.name+" decode to "+decodeToType.String(), func(t *testing.T) {
 				v := reflect.New(decodeToType)
 				if err := Unmarshal(tc.data, v.Interface()); err == nil {
-					t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", tc.data, tc.wantErrorMsg)
+					t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", tc.data, tc.wantErrorMsg)
 				} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
 					t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.data, err, tc.wantErrorMsg)
 				}
@@ -8637,7 +8637,7 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 }
 
 func TestUnmarshalFirstNoTrailing(t *testing.T) {
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		var v any
 		if rest, err := UnmarshalFirst(tc.data, &v); err != nil {
 			t.Errorf("UnmarshalFirst(0x%x) returned error %v", tc.data, err)
@@ -8660,7 +8660,7 @@ func TestUnmarshalFirstNoTrailing(t *testing.T) {
 func TestUnmarshalfirstTrailing(t *testing.T) {
 	// Random trailing data
 	trailingData := mustHexDecode("4a6b0f4718c73f391091ea1c")
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		data := make([]byte, 0, len(tc.data)+len(trailingData))
 		data = append(data, tc.data...)
 		data = append(data, trailingData...)
@@ -8938,37 +8938,37 @@ func TestUnmarshalDefaultByteStringType(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		opts DecOptions
-		in   []byte
+		data []byte
 		want any
 	}{
 		{
 			name: "default to []byte",
 			opts: DecOptions{},
-			in:   mustHexDecode("43414243"),
+			data: mustHexDecode("43414243"),
 			want: []byte("ABC"),
 		},
 		{
 			name: "explicitly []byte",
 			opts: DecOptions{DefaultByteStringType: reflect.TypeOf([]byte(nil))},
-			in:   mustHexDecode("43414243"),
+			data: mustHexDecode("43414243"),
 			want: []byte("ABC"),
 		},
 		{
 			name: "string",
 			opts: DecOptions{DefaultByteStringType: reflect.TypeOf("")},
-			in:   mustHexDecode("43414243"),
+			data: mustHexDecode("43414243"),
 			want: "ABC",
 		},
 		{
 			name: "ByteString",
 			opts: DecOptions{DefaultByteStringType: reflect.TypeOf(ByteString(""))},
-			in:   mustHexDecode("43414243"),
+			data: mustHexDecode("43414243"),
 			want: ByteString("ABC"),
 		},
 		{
 			name: "named []byte type",
 			opts: DecOptions{DefaultByteStringType: reflect.TypeOf(namedByteSliceType(nil))},
-			in:   mustHexDecode("43414243"),
+			data: mustHexDecode("43414243"),
 			want: namedByteSliceType("ABC"),
 		},
 	} {
@@ -8979,7 +8979,7 @@ func TestUnmarshalDefaultByteStringType(t *testing.T) {
 			}
 
 			var got any
-			if err := dm.Unmarshal(tc.in, &got); err != nil {
+			if err := dm.Unmarshal(tc.data, &got); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 
@@ -9144,19 +9144,19 @@ func TestUnmarshalWithUnrecognizedTagToAnyMode(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		opts DecOptions
-		in   []byte
+		data []byte
 		want any
 	}{
 		{
 			name: "default to value of type Tag",
 			opts: DecOptions{},
-			in:   mustHexDecode("d8ff00"),
+			data: mustHexDecode("d8ff00"),
 			want: Tag{Number: uint64(255), Content: uint64(0)},
 		},
 		{
 			name: "Tag's content",
 			opts: DecOptions{UnrecognizedTagToAny: UnrecognizedTagContentToAny},
-			in:   mustHexDecode("d8ff00"),
+			data: mustHexDecode("d8ff00"),
 			want: uint64(0),
 		},
 	} {
@@ -9167,7 +9167,7 @@ func TestUnmarshalWithUnrecognizedTagToAnyMode(t *testing.T) {
 			}
 
 			var got any
-			if err := dm.Unmarshal(tc.in, &got); err != nil {
+			if err := dm.Unmarshal(tc.data, &got); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 
@@ -9182,55 +9182,55 @@ func TestUnmarshalWithUnrecognizedTagToAnyModeForSupportedTags(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		opts DecOptions
-		in   []byte
+		data []byte
 		want any
 	}{
 		{
 			name: "Unmarshal with tag number 0 when UnrecognizedTagContentToAny option is not set",
 			opts: DecOptions{},
-			in:   mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			data: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
 			want: time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
 		},
 		{
 			name: "Unmarshal with tag number 0 when UnrecognizedTagContentToAny option is set",
 			opts: DecOptions{UnrecognizedTagToAny: UnrecognizedTagContentToAny},
-			in:   mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			data: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
 			want: time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
 		},
 		{
 			name: "Unmarshal with tag number 1 when UnrecognizedTagContentToAny option is not set",
 			opts: DecOptions{},
-			in:   mustHexDecode("c11a514b67b0"),
+			data: mustHexDecode("c11a514b67b0"),
 			want: time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
 		},
 		{
 			name: "Unmarshal with tag number 1 when UnrecognizedTagContentToAny option is set",
 			opts: DecOptions{UnrecognizedTagToAny: UnrecognizedTagContentToAny},
-			in:   mustHexDecode("c11a514b67b0"),
+			data: mustHexDecode("c11a514b67b0"),
 			want: time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
 		},
 		{
 			name: "Unmarshal with tag number 2 when UnrecognizedTagContentToAny option is not set",
 			opts: DecOptions{},
-			in:   mustHexDecode("c249010000000000000000"),
+			data: mustHexDecode("c249010000000000000000"),
 			want: mustBigInt("18446744073709551616"),
 		},
 		{
 			name: "Unmarshal with tag number 2 when UnrecognizedTagContentToAny option is set",
 			opts: DecOptions{UnrecognizedTagToAny: UnrecognizedTagContentToAny},
-			in:   mustHexDecode("c249010000000000000000"),
+			data: mustHexDecode("c249010000000000000000"),
 			want: mustBigInt("18446744073709551616"),
 		},
 		{
 			name: "Unmarshal with tag number 3 when UnrecognizedTagContentToAny option is not set",
 			opts: DecOptions{},
-			in:   mustHexDecode("c349010000000000000000"),
+			data: mustHexDecode("c349010000000000000000"),
 			want: mustBigInt("-18446744073709551617"),
 		},
 		{
 			name: "Unmarshal with tag number 3 when UnrecognizedTagContentToAny option is set",
 			opts: DecOptions{UnrecognizedTagToAny: UnrecognizedTagContentToAny},
-			in:   mustHexDecode("c349010000000000000000"),
+			data: mustHexDecode("c349010000000000000000"),
 			want: mustBigInt("-18446744073709551617"),
 		},
 	} {
@@ -9241,11 +9241,11 @@ func TestUnmarshalWithUnrecognizedTagToAnyModeForSupportedTags(t *testing.T) {
 			}
 
 			var got any
-			if err := dm.Unmarshal(tc.in, &got); err != nil {
+			if err := dm.Unmarshal(tc.data, &got); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			compareNonFloats(t, tc.in, got, tc.want)
+			compareNonFloats(t, tc.data, got, tc.want)
 
 		})
 	}
@@ -9264,19 +9264,19 @@ func TestUnmarshalWithUnrecognizedTagToAnyModeForSharedTag(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		opts DecOptions
-		in   []byte
+		data []byte
 		want any
 	}{
 		{
 			name: "Unmarshal with a shared tag when UnrecognizedTagContentToAny option is not set",
 			opts: DecOptions{},
-			in:   mustHexDecode("d9d9f7d87d01"), // 55799(125(1))
+			data: mustHexDecode("d9d9f7d87d01"), // 55799(125(1))
 			want: myInt(1),
 		},
 		{
 			name: "Unmarshal with a shared tag when UnrecognizedTagContentToAny option is set",
 			opts: DecOptions{UnrecognizedTagToAny: UnrecognizedTagContentToAny},
-			in:   mustHexDecode("d9d9f7d87d01"), // 55799(125(1))
+			data: mustHexDecode("d9d9f7d87d01"), // 55799(125(1))
 			want: myInt(1),
 		},
 	} {
@@ -9288,11 +9288,11 @@ func TestUnmarshalWithUnrecognizedTagToAnyModeForSharedTag(t *testing.T) {
 
 			var got any
 
-			if err := dm.Unmarshal(tc.in, &got); err != nil {
+			if err := dm.Unmarshal(tc.data, &got); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			compareNonFloats(t, tc.in, got, tc.want)
+			compareNonFloats(t, tc.data, got, tc.want)
 
 		})
 	}
@@ -9347,7 +9347,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
 		fns           []func(*SimpleValueRegistry) error
-		in            []byte
+		data          []byte
 		into          reflect.Type
 		want          any
 		assertOnError func(t *testing.T, e error)
@@ -9355,7 +9355,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 		{
 			name:          "default false into interface{}",
 			fns:           nil,
-			in:            []byte{0xf4},
+			data:          []byte{0xf4},
 			into:          typeIntf,
 			want:          false,
 			assertOnError: assertNilError,
@@ -9363,7 +9363,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 		{
 			name:          "default false into bool",
 			fns:           nil,
-			in:            []byte{0xf4},
+			data:          []byte{0xf4},
 			into:          typeBool,
 			want:          false,
 			assertOnError: assertNilError,
@@ -9371,7 +9371,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 		{
 			name:          "default true into interface{}",
 			fns:           nil,
-			in:            []byte{0xf5},
+			data:          []byte{0xf5},
 			into:          typeIntf,
 			want:          true,
 			assertOnError: assertNilError,
@@ -9379,7 +9379,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 		{
 			name:          "default true into bool",
 			fns:           nil,
-			in:            []byte{0xf5},
+			data:          []byte{0xf5},
 			into:          typeBool,
 			want:          true,
 			assertOnError: assertNilError,
@@ -9387,7 +9387,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 		{
 			name:          "default null into interface{}",
 			fns:           nil,
-			in:            []byte{0xf6},
+			data:          []byte{0xf6},
 			into:          typeIntf,
 			want:          nil,
 			assertOnError: assertNilError,
@@ -9395,7 +9395,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 		{
 			name:          "default undefined into interface{}",
 			fns:           nil,
-			in:            []byte{0xf7},
+			data:          []byte{0xf7},
 			into:          typeIntf,
 			want:          nil,
 			assertOnError: assertNilError,
@@ -9403,7 +9403,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 		{
 			name: "reject undefined into interface{}",
 			fns:  []func(*SimpleValueRegistry) error{WithRejectedSimpleValue(23)},
-			in:   []byte{0xf7},
+			data: []byte{0xf7},
 			into: typeIntf,
 			want: nil,
 			assertOnError: assertExactError(&UnacceptableDataItemError{
@@ -9414,7 +9414,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 		{
 			name: "reject true into bool",
 			fns:  []func(*SimpleValueRegistry) error{WithRejectedSimpleValue(21)},
-			in:   []byte{0xf5},
+			data: []byte{0xf5},
 			into: typeBool,
 			want: false,
 			assertOnError: assertExactError(&UnacceptableDataItemError{
@@ -9425,7 +9425,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 		{
 			name:          "default unrecognized into uint64",
 			fns:           nil,
-			in:            []byte{0xf8, 0xc8},
+			data:          []byte{0xf8, 0xc8},
 			into:          typeUint64,
 			want:          uint64(200),
 			assertOnError: assertNilError,
@@ -9443,7 +9443,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 			}
 
 			dst := reflect.New(tc.into)
-			err = decMode.Unmarshal(tc.in, dst.Interface())
+			err = decMode.Unmarshal(tc.data, dst.Interface())
 			tc.assertOnError(t, err)
 
 			if got := dst.Elem().Interface(); !reflect.DeepEqual(tc.want, got) {
@@ -9487,71 +9487,71 @@ func TestDecModeInvalidTimeTagToAnyMode(t *testing.T) {
 
 func TestDecModeTimeTagToAny(t *testing.T) {
 	for _, tc := range []struct {
-		name           string
-		opts           DecOptions
-		in             []byte
-		want           any
-		wantErrMessage string
+		name         string
+		opts         DecOptions
+		data         []byte
+		want         any
+		wantErrorMsg string
 	}{
 		{
 			name: "Unmarshal tag 0 data to time.Time when TimeTagToAny is not set",
 			opts: DecOptions{},
-			in:   mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			data: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
 			want: time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
 		},
 		{
 			name: "Unmarshal tag 1 data to time.Time when TimeTagToAny is not set",
 			opts: DecOptions{},
-			in:   mustHexDecode("c11a514b67b0"),
+			data: mustHexDecode("c11a514b67b0"),
 			want: time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
 		},
 		{
 			name: "Unmarshal tag 0 data to RFC3339 string when TimeTagToAny is set",
 			opts: DecOptions{TimeTagToAny: TimeTagToRFC3339},
-			in:   mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			data: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
 			want: "2013-03-21T20:04:00Z",
 		},
 		{
 			name: "Unmarshal tag 1 data to RFC3339 string when TimeTagToAny is set",
 			opts: DecOptions{TimeTagToAny: TimeTagToRFC3339},
-			in:   mustHexDecode("c11a514b67b0"),
+			data: mustHexDecode("c11a514b67b0"),
 			want: "2013-03-21T20:04:00Z",
 		},
 		{
 			name: "Unmarshal tag 0 data to RFC3339Nano string when TimeTagToAny is set",
 			opts: DecOptions{TimeTagToAny: TimeTagToRFC3339Nano},
-			in:   mustHexDecode("c076323031332d30332d32315432303a30343a30302e355a"),
+			data: mustHexDecode("c076323031332d30332d32315432303a30343a30302e355a"),
 			want: "2013-03-21T20:04:00.5Z",
 		},
 		{
 			name: "Unmarshal tag 1 data to RFC3339Nano string when TimeTagToAny is set",
 			opts: DecOptions{TimeTagToAny: TimeTagToRFC3339Nano},
-			in:   mustHexDecode("c1fb41d452d9ec200000"),
+			data: mustHexDecode("c1fb41d452d9ec200000"),
 			want: "2013-03-21T20:04:00.5Z",
 		},
 		{
-			name:           "error under TimeTagToRFC3339 when tag 0 contains an invalid RFC3339 timestamp",
-			opts:           DecOptions{TimeTagToAny: TimeTagToRFC3339},
-			in:             mustHexDecode("c07731303030302D30332D32315432303A30343A30302E355A"), // 0("10000-03-21T20:04:00.5Z")
-			wantErrMessage: `cbor: cannot set 10000-03-21T20:04:00.5Z for time.Time: parsing time "10000-03-21T20:04:00.5Z" as "2006-01-02T15:04:05Z07:00": cannot parse "0-03-21T20:04:00.5Z" as "-"`,
+			name:         "error under TimeTagToRFC3339 when tag 0 contains an invalid RFC3339 timestamp",
+			opts:         DecOptions{TimeTagToAny: TimeTagToRFC3339},
+			data:         mustHexDecode("c07731303030302D30332D32315432303A30343A30302E355A"), // 0("10000-03-21T20:04:00.5Z")
+			wantErrorMsg: `cbor: cannot set 10000-03-21T20:04:00.5Z for time.Time: parsing time "10000-03-21T20:04:00.5Z" as "2006-01-02T15:04:05Z07:00": cannot parse "0-03-21T20:04:00.5Z" as "-"`,
 		},
 		{
-			name:           "error under TimeTagToRFC3339Nano when tag 0 contains an invalid RFC3339 timestamp",
-			opts:           DecOptions{TimeTagToAny: TimeTagToRFC3339Nano},
-			in:             mustHexDecode("c07731303030302D30332D32315432303A30343A30302E355A"), // 0("10000-03-21T20:04:00.5Z")
-			wantErrMessage: `cbor: cannot set 10000-03-21T20:04:00.5Z for time.Time: parsing time "10000-03-21T20:04:00.5Z" as "2006-01-02T15:04:05Z07:00": cannot parse "0-03-21T20:04:00.5Z" as "-"`,
+			name:         "error under TimeTagToRFC3339Nano when tag 0 contains an invalid RFC3339 timestamp",
+			opts:         DecOptions{TimeTagToAny: TimeTagToRFC3339Nano},
+			data:         mustHexDecode("c07731303030302D30332D32315432303A30343A30302E355A"), // 0("10000-03-21T20:04:00.5Z")
+			wantErrorMsg: `cbor: cannot set 10000-03-21T20:04:00.5Z for time.Time: parsing time "10000-03-21T20:04:00.5Z" as "2006-01-02T15:04:05Z07:00": cannot parse "0-03-21T20:04:00.5Z" as "-"`,
 		},
 		{
-			name:           "error under TimeTagToRFC3339 when tag 1 represents a time that can't be represented by valid RFC3339",
-			opts:           DecOptions{TimeTagToAny: TimeTagToRFC3339},
-			in:             mustHexDecode("c11b0000003afff44181"), // 1(253402300801)
-			wantErrMessage: "cbor: decoded time cannot be represented in RFC3339 format: Time.MarshalText: year outside of range [0,9999]",
+			name:         "error under TimeTagToRFC3339 when tag 1 represents a time that can't be represented by valid RFC3339",
+			opts:         DecOptions{TimeTagToAny: TimeTagToRFC3339},
+			data:         mustHexDecode("c11b0000003afff44181"), // 1(253402300801)
+			wantErrorMsg: "cbor: decoded time cannot be represented in RFC3339 format: Time.MarshalText: year outside of range [0,9999]",
 		},
 		{
-			name:           "error under TimeTagToRFC3339Nano when tag 1 represents a time that can't be represented by valid RFC3339",
-			opts:           DecOptions{TimeTagToAny: TimeTagToRFC3339Nano},
-			in:             mustHexDecode("c11b0000003afff44181"), // 1(253402300801)
-			wantErrMessage: "cbor: decoded time cannot be represented in RFC3339 format with sub-second precision: Time.MarshalText: year outside of range [0,9999]",
+			name:         "error under TimeTagToRFC3339Nano when tag 1 represents a time that can't be represented by valid RFC3339",
+			opts:         DecOptions{TimeTagToAny: TimeTagToRFC3339Nano},
+			data:         mustHexDecode("c11b0000003afff44181"), // 1(253402300801)
+			wantErrorMsg: "cbor: decoded time cannot be represented in RFC3339 format with sub-second precision: Time.MarshalText: year outside of range [0,9999]",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -9561,17 +9561,17 @@ func TestDecModeTimeTagToAny(t *testing.T) {
 			}
 
 			var got any
-			if err := dm.Unmarshal(tc.in, &got); err != nil {
-				if tc.wantErrMessage == "" {
+			if err := dm.Unmarshal(tc.data, &got); err != nil {
+				if tc.wantErrorMsg == "" {
 					t.Fatalf("unexpected error: %v", err)
-				} else if gotErrMessage := err.Error(); tc.wantErrMessage != gotErrMessage {
-					t.Fatalf("want error %q, got %q", tc.wantErrMessage, gotErrMessage)
+				} else if gotErrMessage := err.Error(); tc.wantErrorMsg != gotErrMessage {
+					t.Fatalf("want error %q, got %q", tc.wantErrorMsg, gotErrMessage)
 				}
-			} else if tc.wantErrMessage != "" {
-				t.Fatalf("got nil error, want %q", tc.wantErrMessage)
+			} else if tc.wantErrorMsg != "" {
+				t.Fatalf("got nil error, want %q", tc.wantErrorMsg)
 			}
 
-			compareNonFloats(t, tc.in, got, tc.want)
+			compareNonFloats(t, tc.data, got, tc.want)
 
 		})
 	}
@@ -9787,7 +9787,7 @@ func TestNaNDecMode(t *testing.T) {
 			if got := dm.Unmarshal(tc.src, tc.dst); got != nil {
 				if tc.reject {
 					if !reflect.DeepEqual(want, got) {
-						t.Errorf("want error: %v, got error: %v", want, got)
+						t.Errorf("Unmarshal() returned error %v, want %v", got, want)
 					}
 				} else {
 					t.Errorf("unexpected error: %v", got)
@@ -10081,7 +10081,7 @@ func TestInfDecMode(t *testing.T) {
 			if got := dm.Unmarshal(tc.src, tc.dst); got != nil {
 				if tc.reject {
 					if !reflect.DeepEqual(want, got) {
-						t.Errorf("want error: %v, got error: %v", want, got)
+						t.Errorf("Unmarshal() returned error %v, want %v", got, want)
 					}
 				} else {
 					t.Errorf("unexpected error: %v", got)
@@ -10125,38 +10125,38 @@ func TestDecModeByteStringToTime(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		opts         DecOptions
-		in           []byte
+		data         []byte
 		want         time.Time
 		wantErrorMsg string
 	}{
 		{
 			name:         "Unmarshal byte string to time.Time when ByteStringToTime is not set",
 			opts:         DecOptions{},
-			in:           mustHexDecode("54323031332D30332D32315432303A30343A30305A"), // '2013-03-21T20:04:00Z'
+			data:         mustHexDecode("54323031332D30332D32315432303A30343A30305A"), // '2013-03-21T20:04:00Z'
 			wantErrorMsg: "cbor: cannot unmarshal byte string into Go value of type time.Time",
 		},
 		{
 			name: "Unmarshal byte string to time.Time when ByteStringToTime is set to ByteStringToTimeAllowed",
 			opts: DecOptions{ByteStringToTime: ByteStringToTimeAllowed},
-			in:   mustHexDecode("54323031332D30332D32315432303A30343A30305A"), // '2013-03-21T20:04:00Z'
+			data: mustHexDecode("54323031332D30332D32315432303A30343A30305A"), // '2013-03-21T20:04:00Z'
 			want: time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
 		},
 		{
 			name: "Unmarshal byte string to time.Time with nano when ByteStringToTime is set to ByteStringToTimeAllowed",
 			opts: DecOptions{ByteStringToTime: ByteStringToTimeAllowed},
-			in:   mustHexDecode("56323031332D30332D32315432303A30343A30302E355A"), // '2013-03-21T20:04:00.5Z'
+			data: mustHexDecode("56323031332D30332D32315432303A30343A30302E355A"), // '2013-03-21T20:04:00.5Z'
 			want: time.Date(2013, 3, 21, 20, 4, 0, 500000000, time.UTC),
 		},
 		{
 			name:         "Unmarshal a byte string that is not a valid RFC3339 timestamp to time.Time when ByteStringToTime is set to ByteStringToTimeAllowed",
 			opts:         DecOptions{ByteStringToTime: ByteStringToTimeAllowed},
-			in:           mustHexDecode("4B696E76616C696454657874"), // 'invalidText'
+			data:         mustHexDecode("4B696E76616C696454657874"), // 'invalidText'
 			wantErrorMsg: `cbor: cannot set "invalidText" for time.Time: parsing time "invalidText" as "2006-01-02T15:04:05Z07:00": cannot parse "invalidText" as "2006"`,
 		},
 		{
 			name:         "Unmarshal a byte string that is not a valid utf8 sequence to time.Time when ByteStringToTime is set to ByteStringToTimeAllowed",
 			opts:         DecOptions{ByteStringToTime: ByteStringToTimeAllowed},
-			in:           mustHexDecode("54323031338030332D32315432303A30343A30305A"), // "2013\x8003-21T20:04:00Z" -- the first hyphen of a valid RFC3339 string is replaced by a continuation byte
+			data:         mustHexDecode("54323031338030332D32315432303A30343A30305A"), // "2013\x8003-21T20:04:00Z" -- the first hyphen of a valid RFC3339 string is replaced by a continuation byte
 			wantErrorMsg: `cbor: cannot set "2013\x8003-21T20:04:00Z" for time.Time: parsing time "2013\x8003-21T20:04:00Z" as "2006-01-02T15:04:05Z07:00": cannot parse "\x8003-21T20:04:00Z" as "-"`,
 		},
 	} {
@@ -10167,12 +10167,12 @@ func TestDecModeByteStringToTime(t *testing.T) {
 			}
 
 			var got time.Time
-			if err := dm.Unmarshal(tc.in, &got); err != nil {
+			if err := dm.Unmarshal(tc.data, &got); err != nil {
 				if tc.wantErrorMsg != err.Error() {
 					t.Errorf("unexpected error: got %v want %v", err, tc.wantErrorMsg)
 				}
 			} else {
-				compareNonFloats(t, tc.in, got, tc.want)
+				compareNonFloats(t, tc.data, got, tc.want)
 			}
 		})
 	}
@@ -10210,10 +10210,10 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 	type empty struct{}
 
 	for _, tc := range []struct {
-		name    string
-		opts    DecOptions
-		tags    func(TagSet) error
-		wantErr string
+		name         string
+		opts         DecOptions
+		tags         func(TagSet) error
+		wantErrorMsg string
 	}{
 		{
 			name: "base64url encoding tag ignored by default",
@@ -10221,7 +10221,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			tags: func(tags TagSet) error {
 				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 21)
 			},
-			wantErr: "",
+			wantErrorMsg: "",
 		},
 		{
 			name: "base64url encoding tag conflicts in ByteStringToStringAllowedWithExpectedLaterEncoding mode",
@@ -10229,7 +10229,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			tags: func(tags TagSet) error {
 				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 21)
 			},
-			wantErr: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 21 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
+			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 21 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
 		{
 			name: "base64url encoding tag conflicts with non-default ByteSliceExpectedEncoding option",
@@ -10237,7 +10237,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			tags: func(tags TagSet) error {
 				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 21)
 			},
-			wantErr: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 21 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
+			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 21 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
 		{
 			name: "base64 encoding tag ignored by default",
@@ -10245,7 +10245,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			tags: func(tags TagSet) error {
 				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 22)
 			},
-			wantErr: "",
+			wantErrorMsg: "",
 		},
 		{
 			name: "base64 encoding tag conflicts in ByteStringToStringAllowedWithExpectedLaterEncoding mode",
@@ -10253,7 +10253,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			tags: func(tags TagSet) error {
 				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 22)
 			},
-			wantErr: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 22 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
+			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 22 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
 		{
 			name: "base64 encoding tag conflicts with non-default ByteSliceExpectedEncoding option",
@@ -10261,7 +10261,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			tags: func(tags TagSet) error {
 				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 22)
 			},
-			wantErr: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 22 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
+			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 22 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
 		{
 			name: "base16 encoding tag ignored by default",
@@ -10269,7 +10269,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			tags: func(tags TagSet) error {
 				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 23)
 			},
-			wantErr: "",
+			wantErrorMsg: "",
 		},
 		{
 			name: "base16 encoding tag conflicts in ByteStringToStringAllowedWithExpectedLaterEncoding mode",
@@ -10277,7 +10277,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			tags: func(tags TagSet) error {
 				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 23)
 			},
-			wantErr: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 23 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
+			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 23 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
 		{
 			name: "base16 encoding tag conflicts with non-default ByteSliceExpectedEncoding option",
@@ -10285,7 +10285,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			tags: func(tags TagSet) error {
 				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 23)
 			},
-			wantErr: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 23 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
+			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 23 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -10295,24 +10295,24 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			}
 
 			if _, err := tc.opts.DecModeWithTags(tags); err == nil {
-				if tc.wantErr != "" {
-					t.Errorf("got nil error from DecModeWithTags, want %q", tc.wantErr)
+				if tc.wantErrorMsg != "" {
+					t.Errorf("got nil error from DecModeWithTags, want %q", tc.wantErrorMsg)
 				}
-			} else if got := err.Error(); got != tc.wantErr {
-				if tc.wantErr != "" {
-					t.Errorf("unexpected error from DecModeWithTags, got %q want %q", got, tc.wantErr)
+			} else if got := err.Error(); got != tc.wantErrorMsg {
+				if tc.wantErrorMsg != "" {
+					t.Errorf("unexpected error from DecModeWithTags, got %q want %q", got, tc.wantErrorMsg)
 				} else {
 					t.Errorf("want nil error from DecModeWithTags, got %q", got)
 				}
 			}
 
 			if _, err := tc.opts.DecModeWithSharedTags(tags); err == nil {
-				if tc.wantErr != "" {
-					t.Errorf("got nil error from DecModeWithSharedTags, want %q", tc.wantErr)
+				if tc.wantErrorMsg != "" {
+					t.Errorf("got nil error from DecModeWithSharedTags, want %q", tc.wantErrorMsg)
 				}
-			} else if got := err.Error(); got != tc.wantErr {
-				if tc.wantErr != "" {
-					t.Errorf("unexpected error from DecModeWithSharedTags, got %q want %q", got, tc.wantErr)
+			} else if got := err.Error(); got != tc.wantErrorMsg {
+				if tc.wantErrorMsg != "" {
+					t.Errorf("unexpected error from DecModeWithSharedTags, got %q want %q", got, tc.wantErrorMsg)
 				} else {
 					t.Errorf("want nil error from DecModeWithSharedTags, got %q", got)
 				}
@@ -10323,53 +10323,53 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 
 func TestUnmarshalByteStringTextConversionError(t *testing.T) {
 	for _, tc := range []struct {
-		name    string
-		opts    DecOptions
-		dstType reflect.Type
-		in      []byte
-		wantErr string
+		name         string
+		opts         DecOptions
+		dstType      reflect.Type
+		data         []byte
+		wantErrorMsg string
 	}{
 		{
-			name:    "reject untagged byte string containing invalid base64url",
-			opts:    DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64URL},
-			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0x41, 0x00},
-			wantErr: "cbor: failed to decode base64url from byte string: illegal base64 data at input byte 0",
+			name:         "reject untagged byte string containing invalid base64url",
+			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64URL},
+			dstType:      reflect.TypeOf([]byte{}),
+			data:         []byte{0x41, 0x00},
+			wantErrorMsg: "cbor: failed to decode base64url from byte string: illegal base64 data at input byte 0",
 		},
 		{
-			name:    "reject untagged byte string containing invalid base64url",
-			opts:    DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64},
-			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0x41, 0x00},
-			wantErr: "cbor: failed to decode base64 from byte string: illegal base64 data at input byte 0",
+			name:         "reject untagged byte string containing invalid base64url",
+			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64},
+			dstType:      reflect.TypeOf([]byte{}),
+			data:         []byte{0x41, 0x00},
+			wantErrorMsg: "cbor: failed to decode base64 from byte string: illegal base64 data at input byte 0",
 		},
 		{
-			name:    "reject untagged byte string containing invalid base16",
-			opts:    DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase16},
-			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0x41, 0x00},
-			wantErr: "cbor: failed to decode hex from byte string: encoding/hex: invalid byte: U+0000",
+			name:         "reject untagged byte string containing invalid base16",
+			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase16},
+			dstType:      reflect.TypeOf([]byte{}),
+			data:         []byte{0x41, 0x00},
+			wantErrorMsg: "cbor: failed to decode hex from byte string: encoding/hex: invalid byte: U+0000",
 		},
 		{
-			name:    "accept tagged byte string containing invalid base64url",
-			opts:    DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64URL},
-			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0xd5, 0x41, 0x00},
-			wantErr: "",
+			name:         "accept tagged byte string containing invalid base64url",
+			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64URL},
+			dstType:      reflect.TypeOf([]byte{}),
+			data:         []byte{0xd5, 0x41, 0x00},
+			wantErrorMsg: "",
 		},
 		{
-			name:    "accept tagged byte string containing invalid base64url",
-			opts:    DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64},
-			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0xd5, 0x41, 0x00},
-			wantErr: "",
+			name:         "accept tagged byte string containing invalid base64url",
+			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64},
+			dstType:      reflect.TypeOf([]byte{}),
+			data:         []byte{0xd5, 0x41, 0x00},
+			wantErrorMsg: "",
 		},
 		{
-			name:    "accept tagged byte string containing invalid base16",
-			opts:    DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase16},
-			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0xd5, 0x41, 0x00},
-			wantErr: "",
+			name:         "accept tagged byte string containing invalid base16",
+			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase16},
+			dstType:      reflect.TypeOf([]byte{}),
+			data:         []byte{0xd5, 0x41, 0x00},
+			wantErrorMsg: "",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -10378,15 +10378,15 @@ func TestUnmarshalByteStringTextConversionError(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := dm.Unmarshal(tc.in, reflect.New(tc.dstType).Interface()); err == nil {
-				if tc.wantErr != "" {
-					t.Errorf("got nil error, want %q", tc.wantErr)
+			if err := dm.Unmarshal(tc.data, reflect.New(tc.dstType).Interface()); err == nil {
+				if tc.wantErrorMsg != "" {
+					t.Errorf("got nil error, want %q", tc.wantErrorMsg)
 				}
-			} else if got := err.Error(); got != tc.wantErr {
-				if tc.wantErr == "" {
+			} else if got := err.Error(); got != tc.wantErrorMsg {
+				if tc.wantErrorMsg == "" {
 					t.Errorf("expected nil error, got %q", got)
 				} else {
-					t.Errorf("unexpected error, got %q want %q", got, tc.wantErr)
+					t.Errorf("unexpected error, got %q want %q", got, tc.wantErrorMsg)
 				}
 			}
 		})
@@ -10398,7 +10398,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 		name    string
 		opts    DecOptions
 		dstType reflect.Type
-		in      []byte
+		data    []byte
 		want    any
 	}{
 		{
@@ -10407,7 +10407,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0x41, 0xff}, // h'ff'
+			data:    []byte{0x41, 0xff}, // h'ff'
 			want:    "\xff",
 		},
 		{
@@ -10416,7 +10416,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0xd5, 0x41, 0xff}, // 21(h'ff')
+			data:    []byte{0xd5, 0x41, 0xff}, // 21(h'ff')
 			want:    "_w",
 		},
 		{
@@ -10425,7 +10425,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0xd5, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 21(55799(h'ff'))
+			data:    []byte{0xd5, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 21(55799(h'ff'))
 			want:    "_w",
 		},
 		{
@@ -10434,7 +10434,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowed,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0xd5, 0x41, 0xff}, // 21(h'ff')
+			data:    []byte{0xd5, 0x41, 0xff}, // 21(h'ff')
 			want:    "\xff",
 		},
 		{
@@ -10443,7 +10443,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringExpectedFormat: ByteStringExpectedBase64URL,
 			},
 			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0xd5, 0x41, 0xff}, // 21(h'ff')
+			data:    []byte{0xd5, 0x41, 0xff}, // 21(h'ff')
 			want:    []byte{0xff},
 		},
 		{
@@ -10452,7 +10452,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringExpectedFormat: ByteStringExpectedBase64URL,
 			},
 			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0xd5, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 21(55799(h'ff'))
+			data:    []byte{0xd5, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 21(55799(h'ff'))
 			want:    []byte{0xff},
 		},
 		{
@@ -10461,7 +10461,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringExpectedFormat: ByteStringExpectedBase64URL,
 			},
 			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0x42, '_', 'w'}, // '_w'
+			data:    []byte{0x42, '_', 'w'}, // '_w'
 			want:    []byte{0xff},
 		},
 		{
@@ -10470,7 +10470,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0xd6, 0x41, 0xff}, // 22(h'ff')
+			data:    []byte{0xd6, 0x41, 0xff}, // 22(h'ff')
 			want:    "/w==",
 		},
 		{
@@ -10479,7 +10479,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0xd6, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 22(55799(h'ff'))
+			data:    []byte{0xd6, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 22(55799(h'ff'))
 			want:    "/w==",
 		},
 		{
@@ -10488,7 +10488,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowed,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0xd6, 0x41, 0xff}, // 22(h'ff')
+			data:    []byte{0xd6, 0x41, 0xff}, // 22(h'ff')
 			want:    "\xff",
 		},
 		{
@@ -10497,7 +10497,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringExpectedFormat: ByteStringExpectedBase64,
 			},
 			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0xd6, 0x41, 0xff}, // 22(h'ff')
+			data:    []byte{0xd6, 0x41, 0xff}, // 22(h'ff')
 			want:    []byte{0xff},
 		},
 		{
@@ -10506,7 +10506,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringExpectedFormat: ByteStringExpectedBase64,
 			},
 			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0xd6, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 22(55799(h'ff'))
+			data:    []byte{0xd6, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 22(55799(h'ff'))
 			want:    []byte{0xff},
 		},
 		{
@@ -10515,7 +10515,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringExpectedFormat: ByteStringExpectedBase64,
 			},
 			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0x44, '/', 'w', '=', '='}, // '/w=='
+			data:    []byte{0x44, '/', 'w', '=', '='}, // '/w=='
 			want:    []byte{0xff},
 		},
 		{
@@ -10524,7 +10524,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0xd7, 0x41, 0xff}, // 23(h'ff')
+			data:    []byte{0xd7, 0x41, 0xff}, // 23(h'ff')
 			want:    "ff",
 		},
 		{
@@ -10533,7 +10533,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0xd7, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 23(55799(h'ff'))
+			data:    []byte{0xd7, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 23(55799(h'ff'))
 			want:    "ff",
 		},
 		{
@@ -10542,7 +10542,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowed,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0xd7, 0x41, 0xff}, // 23(h'ff')
+			data:    []byte{0xd7, 0x41, 0xff}, // 23(h'ff')
 			want:    "\xff",
 		},
 		{
@@ -10551,7 +10551,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringExpectedFormat: ByteStringExpectedBase16,
 			},
 			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0xd7, 0x41, 0xff}, // 23(h'ff')
+			data:    []byte{0xd7, 0x41, 0xff}, // 23(h'ff')
 			want:    []byte{0xff},
 		},
 		{
@@ -10560,7 +10560,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringExpectedFormat: ByteStringExpectedBase16,
 			},
 			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0xd7, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 23(55799(h'ff'))
+			data:    []byte{0xd7, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 23(55799(h'ff'))
 			want:    []byte{0xff},
 		},
 		{
@@ -10569,7 +10569,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringExpectedFormat: ByteStringExpectedBase16,
 			},
 			dstType: reflect.TypeOf([]byte{}),
-			in:      []byte{0x42, 'f', 'f'},
+			data:    []byte{0x42, 'f', 'f'},
 			want:    []byte{0xff},
 		},
 		{
@@ -10578,7 +10578,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0xd5, 0xd6, 0x42, 0x01, 0x02}, // 21(22(h'0102'))
+			data:    []byte{0xd5, 0xd6, 0x42, 0x01, 0x02}, // 21(22(h'0102'))
 			want:    "AQI=",                               // base64 of [0x01, 0x02] with padding
 		},
 		{
@@ -10587,7 +10587,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
 			dstType: reflect.TypeOf(""),
-			in:      []byte{0xd6, 0xd5, 0x42, 0x01, 0x02}, // 22(21(h'0102'))
+			data:    []byte{0xd6, 0xd5, 0x42, 0x01, 0x02}, // 22(21(h'0102'))
 			want:    "AQI",                                // base64 of [0x01, 0x02] without padding
 		},
 	} {
@@ -10598,7 +10598,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			}
 
 			dstVal := reflect.New(tc.dstType)
-			if err := dm.Unmarshal(tc.in, dstVal.Interface()); err != nil {
+			if err := dm.Unmarshal(tc.data, dstVal.Interface()); err != nil {
 				t.Fatal(err)
 			}
 
@@ -10648,25 +10648,25 @@ func TestBinaryUnmarshalerMode(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		opts DecOptions
-		in   []byte
+		data []byte
 		want any
 	}{
 		{
 			name: "UnmarshalBinary is called by default",
 			opts: DecOptions{},
-			in:   []byte("\x45hello"), // 'hello'
+			data: []byte("\x45hello"), // 'hello'
 			want: testBinaryUnmarshaler("UnmarshalBinary"),
 		},
 		{
 			name: "UnmarshalBinary is called with BinaryUnmarshalerByteString",
 			opts: DecOptions{BinaryUnmarshaler: BinaryUnmarshalerByteString},
-			in:   []byte("\x45hello"), // 'hello'
+			data: []byte("\x45hello"), // 'hello'
 			want: testBinaryUnmarshaler("UnmarshalBinary"),
 		},
 		{
 			name: "default byte slice unmarshaling behavior is used with BinaryUnmarshalerNone",
 			opts: DecOptions{BinaryUnmarshaler: BinaryUnmarshalerNone},
-			in:   []byte("\x45hello"), // 'hello'
+			data: []byte("\x45hello"), // 'hello'
 			want: testBinaryUnmarshaler("hello"),
 		},
 	} {
@@ -10677,7 +10677,7 @@ func TestBinaryUnmarshalerMode(t *testing.T) {
 			}
 
 			gotrv := reflect.New(reflect.TypeOf(tc.want))
-			if err := dm.Unmarshal(tc.in, gotrv.Interface()); err != nil {
+			if err := dm.Unmarshal(tc.data, gotrv.Interface()); err != nil {
 				t.Fatal(err)
 			}
 
@@ -10719,10 +10719,10 @@ func TestDecModeInvalidBignumTag(t *testing.T) {
 
 func TestBignumTagMode(t *testing.T) {
 	for _, tc := range []struct {
-		name           string
-		opt            DecOptions
-		input          []byte
-		wantErrMessage string // if "" then expect nil error
+		name         string
+		opt          DecOptions
+		input        []byte
+		wantErrorMsg string // if "" then expect nil error
 	}{
 		{
 			name:  "default options decode unsigned bignum without error",
@@ -10735,16 +10735,16 @@ func TestBignumTagMode(t *testing.T) {
 			input: mustHexDecode("c340"), // 3(0) i.e. negative bignum -1
 		},
 		{
-			name:           "BignumTagForbidden returns UnacceptableDataItemError on unsigned bignum",
-			opt:            DecOptions{BignumTag: BignumTagForbidden},
-			input:          mustHexDecode("c240"), // 2(0) i.e. unsigned bignum 0
-			wantErrMessage: "cbor: data item of cbor type tag is not accepted by protocol: bignum",
+			name:         "BignumTagForbidden returns UnacceptableDataItemError on unsigned bignum",
+			opt:          DecOptions{BignumTag: BignumTagForbidden},
+			input:        mustHexDecode("c240"), // 2(0) i.e. unsigned bignum 0
+			wantErrorMsg: "cbor: data item of cbor type tag is not accepted by protocol: bignum",
 		},
 		{
-			name:           "BignumTagForbidden returns UnacceptableDataItemError on negative bignum",
-			opt:            DecOptions{BignumTag: BignumTagForbidden},
-			input:          mustHexDecode("c340"), // 3(0) i.e. negative bignum -1
-			wantErrMessage: "cbor: data item of cbor type tag is not accepted by protocol: bignum",
+			name:         "BignumTagForbidden returns UnacceptableDataItemError on negative bignum",
+			opt:          DecOptions{BignumTag: BignumTagForbidden},
+			input:        mustHexDecode("c340"), // 3(0) i.e. negative bignum -1
+			wantErrorMsg: "cbor: data item of cbor type tag is not accepted by protocol: bignum",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -10765,14 +10765,14 @@ func TestBignumTagMode(t *testing.T) {
 					dstv := reflect.New(dstType)
 					err = dm.Unmarshal(tc.input, dstv.Interface())
 					if err != nil {
-						if tc.wantErrMessage == "" {
+						if tc.wantErrorMsg == "" {
 							t.Errorf("want nil error, got: %v", err)
-						} else if gotErrMessage := err.Error(); gotErrMessage != tc.wantErrMessage {
-							t.Errorf("want error: %q, got error: %q", tc.wantErrMessage, gotErrMessage)
+						} else if gotErrMessage := err.Error(); gotErrMessage != tc.wantErrorMsg {
+							t.Errorf("Unmarshal() returned error %q, want %q", gotErrMessage, tc.wantErrorMsg)
 						}
 					} else {
-						if tc.wantErrMessage != "" {
-							t.Errorf("got nil error, want: %s", tc.wantErrMessage)
+						if tc.wantErrorMsg != "" {
+							t.Errorf("got nil error, want: %s", tc.wantErrorMsg)
 						}
 					}
 				})
@@ -10820,25 +10820,25 @@ func TestTextUnmarshalerMode(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		opts DecOptions
-		in   []byte
+		data []byte
 		want any
 	}{
 		{
 			name: "UnmarshalText is not called by default",
 			opts: DecOptions{},
-			in:   []byte("\x65hello"), // "hello"
+			data: []byte("\x65hello"), // "hello"
 			want: testTextUnmarshaler("hello"),
 		},
 		{
 			name: "UnmarshalText is called with TextUnmarshalerTextString",
 			opts: DecOptions{TextUnmarshaler: TextUnmarshalerTextString},
-			in:   []byte("\x65hello"), // "hello"
+			data: []byte("\x65hello"), // "hello"
 			want: testTextUnmarshaler("UnmarshalText"),
 		},
 		{
 			name: "default text string unmarshaling behavior is used with TextUnmarshalerNone",
 			opts: DecOptions{TextUnmarshaler: TextUnmarshalerNone},
-			in:   []byte("\x65hello"), // "hello"
+			data: []byte("\x65hello"), // "hello"
 			want: testTextUnmarshaler("hello"),
 		},
 		{
@@ -10847,7 +10847,7 @@ func TestTextUnmarshalerMode(t *testing.T) {
 				TextUnmarshaler:    TextUnmarshalerTextString,
 				ByteStringToString: ByteStringToStringAllowed,
 			},
-			in:   []byte("\x45hello"), // 'hello'
+			data: []byte("\x45hello"), // 'hello'
 			want: testTextUnmarshaler("UnmarshalText"),
 		},
 	} {
@@ -10858,7 +10858,7 @@ func TestTextUnmarshalerMode(t *testing.T) {
 			}
 
 			gotrv := reflect.New(reflect.TypeOf(tc.want))
-			if err := dm.Unmarshal(tc.in, gotrv.Interface()); err != nil {
+			if err := dm.Unmarshal(tc.data, gotrv.Interface()); err != nil {
 				t.Fatal(err)
 			}
 
@@ -10895,7 +10895,7 @@ func TestTextUnmarshalerModeError(t *testing.T) {
 func TestJSONUnmarshalerTranscoder(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		in   []byte
+		data []byte
 
 		transcodeInput  []byte
 		transcodeOutput []byte
@@ -10906,7 +10906,7 @@ func TestJSONUnmarshalerTranscoder(t *testing.T) {
 	}{
 		{
 			name: "successful transcode",
-			in:   []byte{0xf5},
+			data: []byte{0xf5},
 
 			transcodeInput:  []byte{0xf5},
 			transcodeOutput: []byte("true"),
@@ -10915,7 +10915,7 @@ func TestJSONUnmarshalerTranscoder(t *testing.T) {
 		},
 		{
 			name: "transcode returns non-nil error",
-			in:   []byte{0xf5},
+			data: []byte{0xf5},
 
 			transcodeInput: []byte{0xf5},
 			transcodeError: errors.New("test"),
@@ -10954,18 +10954,18 @@ func TestJSONUnmarshalerTranscoder(t *testing.T) {
 			}
 
 			gotrv := reflect.New(reflect.TypeOf(tc.want))
-			err = dec.Unmarshal(tc.in, gotrv.Interface())
+			err = dec.Unmarshal(tc.data, gotrv.Interface())
 			if tc.wantErrorMsg != "" {
 				if err == nil {
-					t.Errorf("Unmarshal(0x%x) didn't return an error, want error %q", tc.in, tc.wantErrorMsg)
+					t.Errorf("Unmarshal(0x%x) didn't return an error, want error %q", tc.data, tc.wantErrorMsg)
 				} else if gotErrorMsg := err.Error(); gotErrorMsg != tc.wantErrorMsg {
-					t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.in, gotErrorMsg, tc.wantErrorMsg)
+					t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.data, gotErrorMsg, tc.wantErrorMsg)
 				}
 			} else {
 				if err != nil {
-					t.Errorf("Unmarshal(0x%x) returned non-nil error %v", tc.in, err)
+					t.Errorf("Unmarshal(0x%x) returned non-nil error %v", tc.data, err)
 				} else if got := gotrv.Elem().Interface(); !reflect.DeepEqual(tc.want, got) {
-					t.Errorf("Unmarshal(0x%x): %v, want %v", tc.in, got, tc.want)
+					t.Errorf("Unmarshal(0x%x): %v, want %v", tc.data, got, tc.want)
 				}
 			}
 

--- a/diagnose.go
+++ b/diagnose.go
@@ -51,11 +51,8 @@ const (
 	maxByteStringEncoding
 )
 
-func (bse ByteStringEncoding) valid() error {
-	if bse >= maxByteStringEncoding {
-		return errors.New("cbor: invalid ByteStringEncoding " + strconv.Itoa(int(bse)))
-	}
-	return nil
+func (bse ByteStringEncoding) valid() bool {
+	return bse < maxByteStringEncoding
 }
 
 // DiagOptions specifies Diag options.
@@ -104,8 +101,8 @@ func (opts DiagOptions) DiagMode() (DiagMode, error) {
 }
 
 func (opts DiagOptions) diagMode() (*diagMode, error) {
-	if err := opts.ByteStringEncoding.valid(); err != nil {
-		return nil, err
+	if !opts.ByteStringEncoding.valid() {
+		return nil, errors.New("cbor: invalid ByteStringEncoding " + strconv.Itoa(int(opts.ByteStringEncoding)))
 	}
 
 	decMode, err := DecOptions{

--- a/diagnose.go
+++ b/diagnose.go
@@ -357,7 +357,7 @@ func (di *diagnose) item() error { //nolint:gocyclo
 
 	case cborTypeArray:
 		_, _, val := di.d.getHead()
-		count := int(val)
+		count := int(val) //nolint:gosec
 		di.w.WriteByte('[')
 
 		for i := 0; i < count; i++ {
@@ -373,7 +373,7 @@ func (di *diagnose) item() error { //nolint:gocyclo
 
 	case cborTypeMap:
 		_, _, val := di.d.getHead()
-		count := int(val)
+		count := int(val) //nolint:gosec
 		di.w.WriteByte('{')
 
 		for i := 0; i < count; i++ {
@@ -474,8 +474,8 @@ func (di *diagnose) item() error { //nolint:gocyclo
 func (di *diagnose) writeU16(val rune) {
 	di.w.WriteString("\\u")
 	var in [2]byte
-	in[0] = byte(val >> 8)
-	in[1] = byte(val)
+	in[0] = byte(val >> 8) //nolint:gosec
+	in[1] = byte(val)      //nolint:gosec
 	sz := hex.EncodedLen(len(in))
 	di.w.Grow(sz)
 	dst := di.w.Bytes()[di.w.Len() : di.w.Len()+sz]
@@ -628,7 +628,7 @@ func (di *diagnose) encodeFloat(ai byte, val uint64) error {
 	f64 := float64(0)
 	switch ai {
 	case additionalInformationAsFloat16:
-		f16 := float16.Frombits(uint16(val))
+		f16 := float16.Frombits(uint16(val)) //nolint:gosec
 		switch {
 		case f16.IsNaN():
 			di.w.WriteString("NaN")
@@ -644,7 +644,7 @@ func (di *diagnose) encodeFloat(ai byte, val uint64) error {
 		}
 
 	case additionalInformationAsFloat32:
-		f32 := math.Float32frombits(uint32(val))
+		f32 := math.Float32frombits(uint32(val)) //nolint:gosec
 		switch {
 		case f32 != f32:
 			di.w.WriteString("NaN")

--- a/diagnose.go
+++ b/diagnose.go
@@ -605,7 +605,7 @@ func (di *diagnose) encodeTextString(val string, quote byte) error {
 
 		c, size := utf8.DecodeRuneInString(val[i:])
 		switch {
-		case c == utf8.RuneError:
+		case c == utf8.RuneError && size == 1:
 			return &SemanticError{"cbor: invalid UTF-8 string"}
 
 		case c < utf16SurrSelf:

--- a/diagnose_test.go
+++ b/diagnose_test.go
@@ -608,6 +608,12 @@ func TestDiagnoseTextString(t *testing.T) {
 			},
 		},
 		{
+			name:     "valid U+FFFD replacement character in text string",
+			data:     mustHexDecode("63efbfbd"),
+			wantDiag: `"\ufffd"`,
+			opts:     &DiagOptions{},
+		},
+		{
 			name:     "indefinite-length text string with no chunks",
 			data:     mustHexDecode("7fff"),
 			wantDiag: `""_`,

--- a/diagnose_test.go
+++ b/diagnose_test.go
@@ -1103,6 +1103,18 @@ func TestDiagnoseEmptyData(t *testing.T) {
 	}
 }
 
+func TestDiagnoseInvalidByteStringEncoding(t *testing.T) {
+	_, err := DiagOptions{
+		ByteStringEncoding: maxByteStringEncoding,
+	}.DiagMode()
+	if err == nil {
+		t.Fatal("DiagMode() expected error for invalid ByteStringEncoding, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid ByteStringEncoding") {
+		t.Errorf("DiagMode() error = %q, want error containing \"invalid ByteStringEncoding\"", err.Error())
+	}
+}
+
 func BenchmarkDiagnose(b *testing.B) {
 	for _, tc := range []struct {
 		name  string

--- a/diagnose_test.go
+++ b/diagnose_test.go
@@ -504,13 +504,13 @@ func TestDiagnoseByteString(t *testing.T) {
 			opts:     &DiagOptions{},
 		},
 		{
-			name:     "indefinite-length byte string with a empty byte string",
+			name:     "indefinite-length byte string with an empty byte string",
 			data:     mustHexDecode("5f40ff"),
 			wantDiag: `(_ h'')`, // RFC 8949, Section 8.1 says `(_ '')` but it looks wrong and conflicts with Appendix A.
 			opts:     &DiagOptions{},
 		},
 		{
-			name:     "indefinite-length byte string with two empty byte string",
+			name:     "indefinite-length byte string with two empty byte strings",
 			data:     mustHexDecode("5f4040ff"),
 			wantDiag: `(_ h'', h'')`,
 			opts:     &DiagOptions{},
@@ -620,13 +620,13 @@ func TestDiagnoseTextString(t *testing.T) {
 			opts:     &DiagOptions{},
 		},
 		{
-			name:     "indefinite-length text string with a empty text string",
+			name:     "indefinite-length text string with an empty text string",
 			data:     mustHexDecode("7f60ff"),
 			wantDiag: `(_ "")`,
 			opts:     &DiagOptions{},
 		},
 		{
-			name:     "indefinite-length text string with two empty text string",
+			name:     "indefinite-length text string with two empty text strings",
 			data:     mustHexDecode("7f6060ff"),
 			wantDiag: `(_ "", "")`,
 			opts:     &DiagOptions{},

--- a/diagnose_test.go
+++ b/diagnose_test.go
@@ -15,355 +15,355 @@ import (
 func TestDiagnosticNotationExamples(t *testing.T) {
 	// https://www.rfc-editor.org/rfc/rfc8949.html#name-examples-of-encoded-cbor-da
 	testCases := []struct {
-		cbor []byte
-		diag string
+		data     []byte
+		wantDiag string
 	}{
 		{
-			cbor: mustHexDecode("00"),
-			diag: `0`,
+			data:     mustHexDecode("00"),
+			wantDiag: `0`,
 		},
 		{
-			cbor: mustHexDecode("01"),
-			diag: `1`,
+			data:     mustHexDecode("01"),
+			wantDiag: `1`,
 		},
 		{
-			cbor: mustHexDecode("0a"),
-			diag: `10`,
+			data:     mustHexDecode("0a"),
+			wantDiag: `10`,
 		},
 		{
-			cbor: mustHexDecode("17"),
-			diag: `23`,
+			data:     mustHexDecode("17"),
+			wantDiag: `23`,
 		},
 		{
-			cbor: mustHexDecode("1818"),
-			diag: `24`,
+			data:     mustHexDecode("1818"),
+			wantDiag: `24`,
 		},
 		{
-			cbor: mustHexDecode("1819"),
-			diag: `25`,
+			data:     mustHexDecode("1819"),
+			wantDiag: `25`,
 		},
 		{
-			cbor: mustHexDecode("1864"),
-			diag: `100`,
+			data:     mustHexDecode("1864"),
+			wantDiag: `100`,
 		},
 		{
-			cbor: mustHexDecode("1903e8"),
-			diag: `1000`,
+			data:     mustHexDecode("1903e8"),
+			wantDiag: `1000`,
 		},
 		{
-			cbor: mustHexDecode("1a000f4240"),
-			diag: `1000000`,
+			data:     mustHexDecode("1a000f4240"),
+			wantDiag: `1000000`,
 		},
 		{
-			cbor: mustHexDecode("1b000000e8d4a51000"),
-			diag: `1000000000000`,
+			data:     mustHexDecode("1b000000e8d4a51000"),
+			wantDiag: `1000000000000`,
 		},
 		{
-			cbor: mustHexDecode("1bffffffffffffffff"),
-			diag: `18446744073709551615`,
+			data:     mustHexDecode("1bffffffffffffffff"),
+			wantDiag: `18446744073709551615`,
 		},
 		{
-			cbor: mustHexDecode("c249010000000000000000"),
-			diag: `18446744073709551616`,
+			data:     mustHexDecode("c249010000000000000000"),
+			wantDiag: `18446744073709551616`,
 		},
 		{
-			cbor: mustHexDecode("3bffffffffffffffff"),
-			diag: `-18446744073709551616`,
+			data:     mustHexDecode("3bffffffffffffffff"),
+			wantDiag: `-18446744073709551616`,
 		},
 		{
-			cbor: mustHexDecode("c349010000000000000000"),
-			diag: `-18446744073709551617`,
+			data:     mustHexDecode("c349010000000000000000"),
+			wantDiag: `-18446744073709551617`,
 		},
 		{
-			cbor: mustHexDecode("20"),
-			diag: `-1`,
+			data:     mustHexDecode("20"),
+			wantDiag: `-1`,
 		},
 		{
-			cbor: mustHexDecode("29"),
-			diag: `-10`,
+			data:     mustHexDecode("29"),
+			wantDiag: `-10`,
 		},
 		{
-			cbor: mustHexDecode("3863"),
-			diag: `-100`,
+			data:     mustHexDecode("3863"),
+			wantDiag: `-100`,
 		},
 		{
-			cbor: mustHexDecode("3903e7"),
-			diag: `-1000`,
+			data:     mustHexDecode("3903e7"),
+			wantDiag: `-1000`,
 		},
 		{
-			cbor: mustHexDecode("f90000"),
-			diag: `0.0`,
+			data:     mustHexDecode("f90000"),
+			wantDiag: `0.0`,
 		},
 		{
-			cbor: mustHexDecode("f98000"),
-			diag: `-0.0`,
+			data:     mustHexDecode("f98000"),
+			wantDiag: `-0.0`,
 		},
 		{
-			cbor: mustHexDecode("f93c00"),
-			diag: `1.0`,
+			data:     mustHexDecode("f93c00"),
+			wantDiag: `1.0`,
 		},
 		{
-			cbor: mustHexDecode("fb3ff199999999999a"),
-			diag: `1.1`,
+			data:     mustHexDecode("fb3ff199999999999a"),
+			wantDiag: `1.1`,
 		},
 		{
-			cbor: mustHexDecode("f93e00"),
-			diag: `1.5`,
+			data:     mustHexDecode("f93e00"),
+			wantDiag: `1.5`,
 		},
 		{
-			cbor: mustHexDecode("f97bff"),
-			diag: `65504.0`,
+			data:     mustHexDecode("f97bff"),
+			wantDiag: `65504.0`,
 		},
 		{
-			cbor: mustHexDecode("fa47c35000"),
-			diag: `100000.0`,
+			data:     mustHexDecode("fa47c35000"),
+			wantDiag: `100000.0`,
 		},
 		{
-			cbor: mustHexDecode("fa7f7fffff"),
-			diag: `3.4028234663852886e+38`,
+			data:     mustHexDecode("fa7f7fffff"),
+			wantDiag: `3.4028234663852886e+38`,
 		},
 		{
-			cbor: mustHexDecode("fb7e37e43c8800759c"),
-			diag: `1.0e+300`,
+			data:     mustHexDecode("fb7e37e43c8800759c"),
+			wantDiag: `1.0e+300`,
 		},
 		{
-			cbor: mustHexDecode("f90001"),
-			diag: `5.960464477539063e-8`,
+			data:     mustHexDecode("f90001"),
+			wantDiag: `5.960464477539063e-8`,
 		},
 		{
-			cbor: mustHexDecode("f90400"),
-			diag: `0.00006103515625`,
+			data:     mustHexDecode("f90400"),
+			wantDiag: `0.00006103515625`,
 		},
 		{
-			cbor: mustHexDecode("f9c400"),
-			diag: `-4.0`,
+			data:     mustHexDecode("f9c400"),
+			wantDiag: `-4.0`,
 		},
 		{
-			cbor: mustHexDecode("fbc010666666666666"),
-			diag: `-4.1`,
+			data:     mustHexDecode("fbc010666666666666"),
+			wantDiag: `-4.1`,
 		},
 		{
-			cbor: mustHexDecode("f97c00"),
-			diag: `Infinity`,
+			data:     mustHexDecode("f97c00"),
+			wantDiag: `Infinity`,
 		},
 		{
-			cbor: mustHexDecode("f97e00"),
-			diag: `NaN`,
+			data:     mustHexDecode("f97e00"),
+			wantDiag: `NaN`,
 		},
 		{
-			cbor: mustHexDecode("f9fc00"),
-			diag: `-Infinity`,
+			data:     mustHexDecode("f9fc00"),
+			wantDiag: `-Infinity`,
 		},
 		{
-			cbor: mustHexDecode("fa7f800000"),
-			diag: `Infinity`,
+			data:     mustHexDecode("fa7f800000"),
+			wantDiag: `Infinity`,
 		},
 		{
-			cbor: mustHexDecode("fa7fc00000"),
-			diag: `NaN`,
+			data:     mustHexDecode("fa7fc00000"),
+			wantDiag: `NaN`,
 		},
 		{
-			cbor: mustHexDecode("faff800000"),
-			diag: `-Infinity`,
+			data:     mustHexDecode("faff800000"),
+			wantDiag: `-Infinity`,
 		},
 		{
-			cbor: mustHexDecode("fb7ff0000000000000"),
-			diag: `Infinity`,
+			data:     mustHexDecode("fb7ff0000000000000"),
+			wantDiag: `Infinity`,
 		},
 		{
-			cbor: mustHexDecode("fb7ff8000000000000"),
-			diag: `NaN`,
+			data:     mustHexDecode("fb7ff8000000000000"),
+			wantDiag: `NaN`,
 		},
 		{
-			cbor: mustHexDecode("fbfff0000000000000"),
-			diag: `-Infinity`,
+			data:     mustHexDecode("fbfff0000000000000"),
+			wantDiag: `-Infinity`,
 		},
 		{
-			cbor: mustHexDecode("f4"),
-			diag: `false`,
+			data:     mustHexDecode("f4"),
+			wantDiag: `false`,
 		},
 		{
-			cbor: mustHexDecode("f5"),
-			diag: `true`,
+			data:     mustHexDecode("f5"),
+			wantDiag: `true`,
 		},
 		{
-			cbor: mustHexDecode("f6"),
-			diag: `null`,
+			data:     mustHexDecode("f6"),
+			wantDiag: `null`,
 		},
 		{
-			cbor: mustHexDecode("f7"),
-			diag: `undefined`,
+			data:     mustHexDecode("f7"),
+			wantDiag: `undefined`,
 		},
 		{
-			cbor: mustHexDecode("f0"),
-			diag: `simple(16)`,
+			data:     mustHexDecode("f0"),
+			wantDiag: `simple(16)`,
 		},
 		{
-			cbor: mustHexDecode("f8ff"),
-			diag: `simple(255)`,
+			data:     mustHexDecode("f8ff"),
+			wantDiag: `simple(255)`,
 		},
 		{
-			cbor: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
-			diag: `0("2013-03-21T20:04:00Z")`,
+			data:     mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			wantDiag: `0("2013-03-21T20:04:00Z")`,
 		},
 		{
-			cbor: mustHexDecode("c11a514b67b0"),
-			diag: `1(1363896240)`,
+			data:     mustHexDecode("c11a514b67b0"),
+			wantDiag: `1(1363896240)`,
 		},
 		{
-			cbor: mustHexDecode("c1fb41d452d9ec200000"),
-			diag: `1(1363896240.5)`,
+			data:     mustHexDecode("c1fb41d452d9ec200000"),
+			wantDiag: `1(1363896240.5)`,
 		},
 		{
-			cbor: mustHexDecode("d74401020304"),
-			diag: `23(h'01020304')`,
+			data:     mustHexDecode("d74401020304"),
+			wantDiag: `23(h'01020304')`,
 		},
 		{
-			cbor: mustHexDecode("d818456449455446"),
-			diag: `24(h'6449455446')`,
+			data:     mustHexDecode("d818456449455446"),
+			wantDiag: `24(h'6449455446')`,
 		},
 		{
-			cbor: mustHexDecode("d82076687474703a2f2f7777772e6578616d706c652e636f6d"),
-			diag: `32("http://www.example.com")`,
+			data:     mustHexDecode("d82076687474703a2f2f7777772e6578616d706c652e636f6d"),
+			wantDiag: `32("http://www.example.com")`,
 		},
 		{
-			cbor: mustHexDecode("40"),
-			diag: `h''`,
+			data:     mustHexDecode("40"),
+			wantDiag: `h''`,
 		},
 		{
-			cbor: mustHexDecode("4401020304"),
-			diag: `h'01020304'`,
+			data:     mustHexDecode("4401020304"),
+			wantDiag: `h'01020304'`,
 		},
 		{
-			cbor: mustHexDecode("60"),
-			diag: `""`,
+			data:     mustHexDecode("60"),
+			wantDiag: `""`,
 		},
 		{
-			cbor: mustHexDecode("6161"),
-			diag: `"a"`,
+			data:     mustHexDecode("6161"),
+			wantDiag: `"a"`,
 		},
 		{
-			cbor: mustHexDecode("6449455446"),
-			diag: `"IETF"`,
+			data:     mustHexDecode("6449455446"),
+			wantDiag: `"IETF"`,
 		},
 		{
-			cbor: mustHexDecode("62225c"),
-			diag: `"\"\\"`,
+			data:     mustHexDecode("62225c"),
+			wantDiag: `"\"\\"`,
 		},
 		{
-			cbor: mustHexDecode("62c3bc"),
-			diag: `"\u00fc"`,
+			data:     mustHexDecode("62c3bc"),
+			wantDiag: `"\u00fc"`,
 		},
 		{
-			cbor: mustHexDecode("63e6b0b4"),
-			diag: `"\u6c34"`,
+			data:     mustHexDecode("63e6b0b4"),
+			wantDiag: `"\u6c34"`,
 		},
 		{
-			cbor: mustHexDecode("64f0908591"),
-			diag: `"\ud800\udd51"`,
+			data:     mustHexDecode("64f0908591"),
+			wantDiag: `"\ud800\udd51"`,
 		},
 		{
-			cbor: mustHexDecode("80"),
-			diag: `[]`,
+			data:     mustHexDecode("80"),
+			wantDiag: `[]`,
 		},
 		{
-			cbor: mustHexDecode("83010203"),
-			diag: `[1, 2, 3]`,
+			data:     mustHexDecode("83010203"),
+			wantDiag: `[1, 2, 3]`,
 		},
 		{
-			cbor: mustHexDecode("8301820203820405"),
-			diag: `[1, [2, 3], [4, 5]]`,
+			data:     mustHexDecode("8301820203820405"),
+			wantDiag: `[1, [2, 3], [4, 5]]`,
 		},
 		{
-			cbor: mustHexDecode("98190102030405060708090a0b0c0d0e0f101112131415161718181819"),
-			diag: `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]`,
+			data:     mustHexDecode("98190102030405060708090a0b0c0d0e0f101112131415161718181819"),
+			wantDiag: `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]`,
 		},
 		{
-			cbor: mustHexDecode("a0"),
-			diag: `{}`,
+			data:     mustHexDecode("a0"),
+			wantDiag: `{}`,
 		},
 		{
-			cbor: mustHexDecode("a201020304"),
-			diag: `{1: 2, 3: 4}`,
+			data:     mustHexDecode("a201020304"),
+			wantDiag: `{1: 2, 3: 4}`,
 		},
 		{
-			cbor: mustHexDecode("a26161016162820203"),
-			diag: `{"a": 1, "b": [2, 3]}`,
+			data:     mustHexDecode("a26161016162820203"),
+			wantDiag: `{"a": 1, "b": [2, 3]}`,
 		},
 		{
-			cbor: mustHexDecode("826161a161626163"),
-			diag: `["a", {"b": "c"}]`,
+			data:     mustHexDecode("826161a161626163"),
+			wantDiag: `["a", {"b": "c"}]`,
 		},
 		{
-			cbor: mustHexDecode("a56161614161626142616361436164614461656145"),
-			diag: `{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"}`,
+			data:     mustHexDecode("a56161614161626142616361436164614461656145"),
+			wantDiag: `{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"}`,
 		},
 		{
-			cbor: mustHexDecode("5f42010243030405ff"),
-			diag: `(_ h'0102', h'030405')`,
+			data:     mustHexDecode("5f42010243030405ff"),
+			wantDiag: `(_ h'0102', h'030405')`,
 		},
 		{
-			cbor: mustHexDecode("7f657374726561646d696e67ff"),
-			diag: `(_ "strea", "ming")`,
+			data:     mustHexDecode("7f657374726561646d696e67ff"),
+			wantDiag: `(_ "strea", "ming")`,
 		},
 		{
-			cbor: mustHexDecode("9fff"),
-			diag: `[_ ]`,
+			data:     mustHexDecode("9fff"),
+			wantDiag: `[_ ]`,
 		},
 		{
-			cbor: mustHexDecode("9f018202039f0405ffff"),
-			diag: `[_ 1, [2, 3], [_ 4, 5]]`,
+			data:     mustHexDecode("9f018202039f0405ffff"),
+			wantDiag: `[_ 1, [2, 3], [_ 4, 5]]`,
 		},
 		{
-			cbor: mustHexDecode("9f01820203820405ff"),
-			diag: `[_ 1, [2, 3], [4, 5]]`,
+			data:     mustHexDecode("9f01820203820405ff"),
+			wantDiag: `[_ 1, [2, 3], [4, 5]]`,
 		},
 		{
-			cbor: mustHexDecode("83018202039f0405ff"),
-			diag: `[1, [2, 3], [_ 4, 5]]`,
+			data:     mustHexDecode("83018202039f0405ff"),
+			wantDiag: `[1, [2, 3], [_ 4, 5]]`,
 		},
 		{
-			cbor: mustHexDecode("83019f0203ff820405"),
-			diag: `[1, [_ 2, 3], [4, 5]]`,
+			data:     mustHexDecode("83019f0203ff820405"),
+			wantDiag: `[1, [_ 2, 3], [4, 5]]`,
 		},
 		{
-			cbor: mustHexDecode("9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff"),
-			diag: `[_ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]`,
+			data:     mustHexDecode("9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff"),
+			wantDiag: `[_ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]`,
 		},
 		{
-			cbor: mustHexDecode("bf61610161629f0203ffff"),
-			diag: `{_ "a": 1, "b": [_ 2, 3]}`,
+			data:     mustHexDecode("bf61610161629f0203ffff"),
+			wantDiag: `{_ "a": 1, "b": [_ 2, 3]}`,
 		},
 		{
-			cbor: mustHexDecode("826161bf61626163ff"),
-			diag: `["a", {_ "b": "c"}]`,
+			data:     mustHexDecode("826161bf61626163ff"),
+			wantDiag: `["a", {_ "b": "c"}]`,
 		},
 		{
-			cbor: mustHexDecode("bf6346756ef563416d7421ff"),
-			diag: `{_ "Fun": true, "Amt": -2}`,
+			data:     mustHexDecode("bf6346756ef563416d7421ff"),
+			wantDiag: `{_ "Fun": true, "Amt": -2}`,
 		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Diagnostic %d", i), func(t *testing.T) {
-			str, err := Diagnose(tc.cbor)
+			str, err := Diagnose(tc.data)
 			if err != nil {
-				t.Errorf("Diagnostic(0x%x) returned error %q", tc.cbor, err)
-			} else if str != tc.diag {
-				t.Errorf("Diagnostic(0x%x) returned `%s`, want `%s`", tc.cbor, str, tc.diag)
+				t.Errorf("Diagnostic(0x%x) returned error %q", tc.data, err)
+			} else if str != tc.wantDiag {
+				t.Errorf("Diagnostic(0x%x) returned `%s`, want `%s`", tc.data, str, tc.wantDiag)
 			}
 
-			str, rest, err := DiagnoseFirst(tc.cbor)
+			str, rest, err := DiagnoseFirst(tc.data)
 			if err != nil {
-				t.Errorf("Diagnostic(0x%x) returned error %q", tc.cbor, err)
-			} else if str != tc.diag {
-				t.Errorf("Diagnostic(0x%x) returned `%s`, want `%s`", tc.cbor, str, tc.diag)
+				t.Errorf("Diagnostic(0x%x) returned error %q", tc.data, err)
+			} else if str != tc.wantDiag {
+				t.Errorf("Diagnostic(0x%x) returned `%s`, want `%s`", tc.data, str, tc.wantDiag)
 			}
 
 			if rest == nil {
-				t.Errorf("Diagnostic(0x%x) returned nil rest", tc.cbor)
+				t.Errorf("Diagnostic(0x%x) returned nil rest", tc.data)
 			} else if len(rest) != 0 {
-				t.Errorf("Diagnostic(0x%x) returned non-empty rest '%x'", tc.cbor, rest)
+				t.Errorf("Diagnostic(0x%x) returned non-empty rest '%x'", tc.data, rest)
 			}
 		})
 	}
@@ -371,164 +371,164 @@ func TestDiagnosticNotationExamples(t *testing.T) {
 
 func TestDiagnoseByteString(t *testing.T) {
 	testCases := []struct {
-		title string
-		cbor  []byte
-		diag  string
-		opts  *DiagOptions
+		name     string
+		data     []byte
+		wantDiag string
+		opts     *DiagOptions
 	}{
 		{
-			title: "base16",
-			cbor:  mustHexDecode("4412345678"),
-			diag:  `h'12345678'`,
+			name:     "base16",
+			data:     mustHexDecode("4412345678"),
+			wantDiag: `h'12345678'`,
 			opts: &DiagOptions{
 				ByteStringEncoding: ByteStringBase16Encoding,
 			},
 		},
 		{
-			title: "base32",
-			cbor:  mustHexDecode("4412345678"),
-			diag:  `b32'CI2FM6A'`,
+			name:     "base32",
+			data:     mustHexDecode("4412345678"),
+			wantDiag: `b32'CI2FM6A'`,
 			opts: &DiagOptions{
 				ByteStringEncoding: ByteStringBase32Encoding,
 			},
 		},
 		{
-			title: "base32hex",
-			cbor:  mustHexDecode("4412345678"),
-			diag:  `h32'28Q5CU0'`,
+			name:     "base32hex",
+			data:     mustHexDecode("4412345678"),
+			wantDiag: `h32'28Q5CU0'`,
 			opts: &DiagOptions{
 				ByteStringEncoding: ByteStringBase32HexEncoding,
 			},
 		},
 		{
-			title: "base64",
-			cbor:  mustHexDecode("4412345678"),
-			diag:  `b64'EjRWeA'`,
+			name:     "base64",
+			data:     mustHexDecode("4412345678"),
+			wantDiag: `b64'EjRWeA'`,
 			opts: &DiagOptions{
 				ByteStringEncoding: ByteStringBase64Encoding,
 			},
 		},
 		{
-			title: "without ByteStringHexWhitespace option",
-			cbor:  mustHexDecode("4b48656c6c6f20776f726c64"),
-			diag:  `h'48656c6c6f20776f726c64'`,
+			name:     "without ByteStringHexWhitespace option",
+			data:     mustHexDecode("4b48656c6c6f20776f726c64"),
+			wantDiag: `h'48656c6c6f20776f726c64'`,
 			opts: &DiagOptions{
 				ByteStringHexWhitespace: false,
 			},
 		},
 		{
-			title: "with ByteStringHexWhitespace option",
-			cbor:  mustHexDecode("4b48656c6c6f20776f726c64"),
-			diag:  `h'48 65 6c 6c 6f 20 77 6f 72 6c 64'`,
+			name:     "with ByteStringHexWhitespace option",
+			data:     mustHexDecode("4b48656c6c6f20776f726c64"),
+			wantDiag: `h'48 65 6c 6c 6f 20 77 6f 72 6c 64'`,
 			opts: &DiagOptions{
 				ByteStringHexWhitespace: true,
 			},
 		},
 		{
-			title: "without ByteStringText option",
-			cbor:  mustHexDecode("4b68656c6c6f20776f726c64"),
-			diag:  `h'68656c6c6f20776f726c64'`,
+			name:     "without ByteStringText option",
+			data:     mustHexDecode("4b68656c6c6f20776f726c64"),
+			wantDiag: `h'68656c6c6f20776f726c64'`,
 			opts: &DiagOptions{
 				ByteStringText: false,
 			},
 		},
 		{
-			title: "with ByteStringText option",
-			cbor:  mustHexDecode("4b68656c6c6f20776f726c64"),
-			diag:  `'hello world'`,
+			name:     "with ByteStringText option",
+			data:     mustHexDecode("4b68656c6c6f20776f726c64"),
+			wantDiag: `'hello world'`,
 			opts: &DiagOptions{
 				ByteStringText: true,
 			},
 		},
 		{
-			title: "without ByteStringText option and with ByteStringHexWhitespace option",
-			cbor:  mustHexDecode("4b68656c6c6f20776f726c64"),
-			diag:  `h'68 65 6c 6c 6f 20 77 6f 72 6c 64'`,
+			name:     "without ByteStringText option and with ByteStringHexWhitespace option",
+			data:     mustHexDecode("4b68656c6c6f20776f726c64"),
+			wantDiag: `h'68 65 6c 6c 6f 20 77 6f 72 6c 64'`,
 			opts: &DiagOptions{
 				ByteStringText:          false,
 				ByteStringHexWhitespace: true,
 			},
 		},
 		{
-			title: "without ByteStringEmbeddedCBOR",
-			cbor:  mustHexDecode("4101"),
-			diag:  `h'01'`,
+			name:     "without ByteStringEmbeddedCBOR",
+			data:     mustHexDecode("4101"),
+			wantDiag: `h'01'`,
 			opts: &DiagOptions{
 				ByteStringEmbeddedCBOR: false,
 			},
 		},
 		{
-			title: "with ByteStringEmbeddedCBOR",
-			cbor:  mustHexDecode("4101"),
-			diag:  `<<1>>`,
+			name:     "with ByteStringEmbeddedCBOR",
+			data:     mustHexDecode("4101"),
+			wantDiag: `<<1>>`,
 			opts: &DiagOptions{
 				ByteStringEmbeddedCBOR: true,
 			},
 		},
 		{
-			title: "multi CBOR items without ByteStringEmbeddedCBOR",
-			cbor:  mustHexDecode("420102"),
-			diag:  `h'0102'`,
+			name:     "multi CBOR items without ByteStringEmbeddedCBOR",
+			data:     mustHexDecode("420102"),
+			wantDiag: `h'0102'`,
 			opts: &DiagOptions{
 				ByteStringEmbeddedCBOR: false,
 			},
 		},
 		{
-			title: "multi CBOR items with ByteStringEmbeddedCBOR",
-			cbor:  mustHexDecode("420102"),
-			diag:  `<<1, 2>>`,
+			name:     "multi CBOR items with ByteStringEmbeddedCBOR",
+			data:     mustHexDecode("420102"),
+			wantDiag: `<<1, 2>>`,
 			opts: &DiagOptions{
 				ByteStringEmbeddedCBOR: true,
 			},
 		},
 		{
-			title: "multi CBOR items with ByteStringEmbeddedCBOR",
-			cbor:  mustHexDecode("4563666F6FF6"),
-			diag:  `h'63666f6ff6'`,
+			name:     "multi CBOR items with ByteStringEmbeddedCBOR",
+			data:     mustHexDecode("4563666F6FF6"),
+			wantDiag: `h'63666f6ff6'`,
 			opts: &DiagOptions{
 				ByteStringEmbeddedCBOR: false,
 			},
 		},
 		{
-			title: "multi CBOR items with ByteStringEmbeddedCBOR",
-			cbor:  mustHexDecode("4563666F6FF6"),
-			diag:  `<<"foo", null>>`,
+			name:     "multi CBOR items with ByteStringEmbeddedCBOR",
+			data:     mustHexDecode("4563666F6FF6"),
+			wantDiag: `<<"foo", null>>`,
 			opts: &DiagOptions{
 				ByteStringEmbeddedCBOR: true,
 			},
 		},
 		{
-			title: "indefinite length byte string with no chunks",
-			cbor:  mustHexDecode("5fff"),
-			diag:  `''_`,
-			opts:  &DiagOptions{},
+			name:     "indefinite-length byte string with no chunks",
+			data:     mustHexDecode("5fff"),
+			wantDiag: `''_`,
+			opts:     &DiagOptions{},
 		},
 		{
-			title: "indefinite length byte string with a empty byte string",
-			cbor:  mustHexDecode("5f40ff"),
-			diag:  `(_ h'')`, // RFC 8949, Section 8.1 says `(_ '')` but it looks wrong and conflicts with Appendix A.
-			opts:  &DiagOptions{},
+			name:     "indefinite-length byte string with a empty byte string",
+			data:     mustHexDecode("5f40ff"),
+			wantDiag: `(_ h'')`, // RFC 8949, Section 8.1 says `(_ '')` but it looks wrong and conflicts with Appendix A.
+			opts:     &DiagOptions{},
 		},
 		{
-			title: "indefinite length byte string with two empty byte string",
-			cbor:  mustHexDecode("5f4040ff"),
-			diag:  `(_ h'', h'')`,
-			opts:  &DiagOptions{},
+			name:     "indefinite-length byte string with two empty byte string",
+			data:     mustHexDecode("5f4040ff"),
+			wantDiag: `(_ h'', h'')`,
+			opts:     &DiagOptions{},
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.title, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			dm, err := tc.opts.DiagMode()
 			if err != nil {
-				t.Errorf("DiagMode() for 0x%x returned error %q", tc.cbor, err)
+				t.Errorf("DiagMode() for 0x%x returned error %q", tc.data, err)
 			}
 
-			str, err := dm.Diagnose(tc.cbor)
+			str, err := dm.Diagnose(tc.data)
 			if err != nil {
-				t.Errorf("Diagnose(0x%x) returned error %q", tc.cbor, err)
-			} else if str != tc.diag {
-				t.Errorf("Diagnose(0x%x) returned `%s`, want %s", tc.cbor, str, tc.diag)
+				t.Errorf("Diagnose(0x%x) returned error %q", tc.data, err)
+			} else if str != tc.wantDiag {
+				t.Errorf("Diagnose(0x%x) returned `%s`, want %s", tc.data, str, tc.wantDiag)
 			}
 		})
 	}
@@ -536,109 +536,109 @@ func TestDiagnoseByteString(t *testing.T) {
 
 func TestDiagnoseTextString(t *testing.T) {
 	testCases := []struct {
-		title string
-		cbor  []byte
-		diag  string
-		opts  *DiagOptions
+		name     string
+		data     []byte
+		wantDiag string
+		opts     *DiagOptions
 	}{
 		{
-			title: "\t",
-			cbor:  mustHexDecode("6109"),
-			diag:  `"\t"`,
-			opts:  &DiagOptions{},
+			name:     "\t",
+			data:     mustHexDecode("6109"),
+			wantDiag: `"\t"`,
+			opts:     &DiagOptions{},
 		},
 		{
-			title: "\r",
-			cbor:  mustHexDecode("610d"),
-			diag:  `"\r"`,
-			opts:  &DiagOptions{},
+			name:     "\r",
+			data:     mustHexDecode("610d"),
+			wantDiag: `"\r"`,
+			opts:     &DiagOptions{},
 		},
 		{
-			title: "other ascii",
-			cbor:  mustHexDecode("611b"),
-			diag:  `"\u001b"`,
-			opts:  &DiagOptions{},
+			name:     "other ascii",
+			data:     mustHexDecode("611b"),
+			wantDiag: `"\u001b"`,
+			opts:     &DiagOptions{},
 		},
 		{
-			title: "valid UTF-8 text in byte string",
-			cbor:  mustHexDecode("4d68656c6c6f2c20e4bda0e5a5bd"),
-			diag:  `'hello, \u4f60\u597d'`,
+			name:     "valid UTF-8 text in byte string",
+			data:     mustHexDecode("4d68656c6c6f2c20e4bda0e5a5bd"),
+			wantDiag: `'hello, \u4f60\u597d'`,
 			opts: &DiagOptions{
 				ByteStringText: true,
 			},
 		},
 		{
-			title: "valid UTF-8 text in text string",
-			cbor:  mustHexDecode("6d68656c6c6f2c20e4bda0e5a5bd"),
-			diag:  `"hello, \u4f60\u597d"`, // "hello, 你好"
+			name:     "valid UTF-8 text in text string",
+			data:     mustHexDecode("6d68656c6c6f2c20e4bda0e5a5bd"),
+			wantDiag: `"hello, \u4f60\u597d"`, // "hello, 你好"
 			opts: &DiagOptions{
 				ByteStringText: true,
 			},
 		},
 		{
-			title: "invalid UTF-8 text in byte string",
-			cbor:  mustHexDecode("4d68656c6c6fffeee4bda0e5a5bd"),
-			diag:  `h'68656c6c6fffeee4bda0e5a5bd'`,
+			name:     "invalid UTF-8 text in byte string",
+			data:     mustHexDecode("4d68656c6c6fffeee4bda0e5a5bd"),
+			wantDiag: `h'68656c6c6fffeee4bda0e5a5bd'`,
 			opts: &DiagOptions{
 				ByteStringText: true,
 			},
 		},
 		{
-			title: "valid grapheme cluster text in byte string",
-			cbor:  mustHexDecode("583448656c6c6f2c2027e29da4efb88fe2808df09f94a5270ae4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122"),
-			diag:  `'Hello, \'\u2764\ufe0f\u200d\ud83d\udd25\'\n\u4f60\u597d\uff0c"\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1"'`,
+			name:     "valid grapheme cluster text in byte string",
+			data:     mustHexDecode("583448656c6c6f2c2027e29da4efb88fe2808df09f94a5270ae4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122"),
+			wantDiag: `'Hello, \'\u2764\ufe0f\u200d\ud83d\udd25\'\n\u4f60\u597d\uff0c"\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1"'`,
 			opts: &DiagOptions{
 				ByteStringText: true,
 			},
 		},
 		{
-			title: "valid grapheme cluster text in text string",
-			cbor:  mustHexDecode("783448656c6c6f2c2027e29da4efb88fe2808df09f94a5270ae4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122"),
-			diag:  `"Hello, '\u2764\ufe0f\u200d\ud83d\udd25'\n\u4f60\u597d\uff0c\"\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\""`, // "Hello, '❤️‍🔥'\n你好，\"🧑‍🤝‍🧑\""
+			name:     "valid grapheme cluster text in text string",
+			data:     mustHexDecode("783448656c6c6f2c2027e29da4efb88fe2808df09f94a5270ae4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122"),
+			wantDiag: `"Hello, '\u2764\ufe0f\u200d\ud83d\udd25'\n\u4f60\u597d\uff0c\"\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1\""`, // "Hello, '❤️‍🔥'\n你好，\"🧑‍🤝‍🧑\""
 			opts: &DiagOptions{
 				ByteStringText: true,
 			},
 		},
 		{
-			title: "invalid grapheme cluster text in byte string",
-			cbor:  mustHexDecode("583448656c6c6feeff27e29da4efb88fe2808df09f94a5270de4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122"),
-			diag:  `h'48656c6c6feeff27e29da4efb88fe2808df09f94a5270de4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122'`,
+			name:     "invalid grapheme cluster text in byte string",
+			data:     mustHexDecode("583448656c6c6feeff27e29da4efb88fe2808df09f94a5270de4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122"),
+			wantDiag: `h'48656c6c6feeff27e29da4efb88fe2808df09f94a5270de4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122'`,
 			opts: &DiagOptions{
 				ByteStringText: true,
 			},
 		},
 		{
-			title: "indefinite length text string with no chunks",
-			cbor:  mustHexDecode("7fff"),
-			diag:  `""_`,
-			opts:  &DiagOptions{},
+			name:     "indefinite-length text string with no chunks",
+			data:     mustHexDecode("7fff"),
+			wantDiag: `""_`,
+			opts:     &DiagOptions{},
 		},
 		{
-			title: "indefinite length text string with a empty text string",
-			cbor:  mustHexDecode("7f60ff"),
-			diag:  `(_ "")`,
-			opts:  &DiagOptions{},
+			name:     "indefinite-length text string with a empty text string",
+			data:     mustHexDecode("7f60ff"),
+			wantDiag: `(_ "")`,
+			opts:     &DiagOptions{},
 		},
 		{
-			title: "indefinite length text string with two empty text string",
-			cbor:  mustHexDecode("7f6060ff"),
-			diag:  `(_ "", "")`,
-			opts:  &DiagOptions{},
+			name:     "indefinite-length text string with two empty text string",
+			data:     mustHexDecode("7f6060ff"),
+			wantDiag: `(_ "", "")`,
+			opts:     &DiagOptions{},
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.title, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			dm, err := tc.opts.DiagMode()
 			if err != nil {
-				t.Errorf("DiagMode() for 0x%x returned error %q", tc.cbor, err)
+				t.Errorf("DiagMode() for 0x%x returned error %q", tc.data, err)
 			}
 
-			str, err := dm.Diagnose(tc.cbor)
+			str, err := dm.Diagnose(tc.data)
 			if err != nil {
-				t.Errorf("Diagnose(0x%x) returned error %q", tc.cbor, err)
-			} else if str != tc.diag {
-				t.Errorf("Diagnose(0x%x) returned `%s`, want %s", tc.cbor, str, tc.diag)
+				t.Errorf("Diagnose(0x%x) returned error %q", tc.data, err)
+			} else if str != tc.wantDiag {
+				t.Errorf("Diagnose(0x%x) returned `%s`, want %s", tc.data, str, tc.wantDiag)
 			}
 		})
 	}
@@ -646,30 +646,30 @@ func TestDiagnoseTextString(t *testing.T) {
 
 func TestDiagnoseInvalidTextString(t *testing.T) {
 	testCases := []struct {
-		title        string
-		cbor         []byte
+		name         string
+		data         []byte
 		wantErrorMsg string
 		opts         *DiagOptions
 	}{
 		{
-			title:        "invalid UTF-8 text in text string",
-			cbor:         mustHexDecode("6d68656c6c6fffeee4bda0e5a5bd"),
+			name:         "invalid UTF-8 text in text string",
+			data:         mustHexDecode("6d68656c6c6fffeee4bda0e5a5bd"),
 			wantErrorMsg: "invalid UTF-8 string",
 			opts: &DiagOptions{
 				ByteStringText: true,
 			},
 		},
 		{
-			title:        "invalid grapheme cluster text in text string",
-			cbor:         mustHexDecode("783448656c6c6feeff27e29da4efb88fe2808df09f94a5270de4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122"),
+			name:         "invalid grapheme cluster text in text string",
+			data:         mustHexDecode("783448656c6c6feeff27e29da4efb88fe2808df09f94a5270de4bda0e5a5bdefbc8c22f09fa791e2808df09fa49de2808df09fa79122"),
 			wantErrorMsg: "invalid UTF-8 string",
 			opts: &DiagOptions{
 				ByteStringText: true,
 			},
 		},
 		{
-			title:        "invalid indefinite length text string",
-			cbor:         mustHexDecode("7f6040ff"),
+			name:         "invalid indefinite-length text string",
+			data:         mustHexDecode("7f6040ff"),
 			wantErrorMsg: `wrong element type`,
 			opts: &DiagOptions{
 				ByteStringText: true,
@@ -678,17 +678,17 @@ func TestDiagnoseInvalidTextString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.title, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			dm, err := tc.opts.DiagMode()
 			if err != nil {
-				t.Errorf("DiagMode() for 0x%x returned error %q", tc.cbor, err)
+				t.Errorf("DiagMode() for 0x%x returned error %q", tc.data, err)
 			}
 
-			_, err = dm.Diagnose(tc.cbor)
+			_, err = dm.Diagnose(tc.data)
 			if err == nil {
-				t.Errorf("Diagnose(0x%x) didn't return error", tc.cbor)
+				t.Errorf("Diagnose(0x%x) didn't return an error", tc.data)
 			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
-				t.Errorf("Diagnose(0x%x) returned error %q", tc.cbor, err)
+				t.Errorf("Diagnose(0x%x) returned error %q", tc.data, err)
 			}
 		})
 	}
@@ -696,63 +696,63 @@ func TestDiagnoseInvalidTextString(t *testing.T) {
 
 func TestDiagnoseFloatingPointNumber(t *testing.T) {
 	testCases := []struct {
-		title string
-		cbor  []byte
-		diag  string
-		opts  *DiagOptions
+		name     string
+		data     []byte
+		wantDiag string
+		opts     *DiagOptions
 	}{
 		{
-			title: "float16 without FloatPrecisionIndicator option",
-			cbor:  mustHexDecode("f93e00"),
-			diag:  `1.5`,
+			name:     "float16 without FloatPrecisionIndicator option",
+			data:     mustHexDecode("f93e00"),
+			wantDiag: `1.5`,
 			opts: &DiagOptions{
 				FloatPrecisionIndicator: false,
 			},
 		},
 		{
-			title: "float16 with FloatPrecisionIndicator option",
-			cbor:  mustHexDecode("f93e00"),
-			diag:  `1.5_1`,
+			name:     "float16 with FloatPrecisionIndicator option",
+			data:     mustHexDecode("f93e00"),
+			wantDiag: `1.5_1`,
 			opts: &DiagOptions{
 				FloatPrecisionIndicator: true,
 			},
 		},
 		{
-			title: "float32 without FloatPrecisionIndicator option",
-			cbor:  mustHexDecode("fa47c35000"),
-			diag:  `100000.0`,
+			name:     "float32 without FloatPrecisionIndicator option",
+			data:     mustHexDecode("fa47c35000"),
+			wantDiag: `100000.0`,
 			opts: &DiagOptions{
 				FloatPrecisionIndicator: false,
 			},
 		},
 		{
-			title: "float32 with FloatPrecisionIndicator option",
-			cbor:  mustHexDecode("fa47c35000"),
-			diag:  `100000.0_2`,
+			name:     "float32 with FloatPrecisionIndicator option",
+			data:     mustHexDecode("fa47c35000"),
+			wantDiag: `100000.0_2`,
 			opts: &DiagOptions{
 				FloatPrecisionIndicator: true,
 			},
 		},
 		{
-			title: "float64 without FloatPrecisionIndicator option",
-			cbor:  mustHexDecode("fbc010666666666666"),
-			diag:  `-4.1`,
+			name:     "float64 without FloatPrecisionIndicator option",
+			data:     mustHexDecode("fbc010666666666666"),
+			wantDiag: `-4.1`,
 			opts: &DiagOptions{
 				FloatPrecisionIndicator: false,
 			},
 		},
 		{
-			title: "float64 with FloatPrecisionIndicator option",
-			cbor:  mustHexDecode("fbc010666666666666"),
-			diag:  `-4.1_3`,
+			name:     "float64 with FloatPrecisionIndicator option",
+			data:     mustHexDecode("fbc010666666666666"),
+			wantDiag: `-4.1_3`,
 			opts: &DiagOptions{
 				FloatPrecisionIndicator: true,
 			},
 		},
 		{
-			title: "with FloatPrecisionIndicator option",
-			cbor:  mustHexDecode("c1fb41d452d9ec200000"),
-			diag:  `1(1363896240.5_3)`,
+			name:     "with FloatPrecisionIndicator option",
+			data:     mustHexDecode("c1fb41d452d9ec200000"),
+			wantDiag: `1(1363896240.5_3)`,
 			opts: &DiagOptions{
 				FloatPrecisionIndicator: true,
 			},
@@ -760,17 +760,17 @@ func TestDiagnoseFloatingPointNumber(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.title, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			dm, err := tc.opts.DiagMode()
 			if err != nil {
-				t.Errorf("DiagMode() for 0x%x returned error %q", tc.cbor, err)
+				t.Errorf("DiagMode() for 0x%x returned error %q", tc.data, err)
 			}
 
-			str, err := dm.Diagnose(tc.cbor)
+			str, err := dm.Diagnose(tc.data)
 			if err != nil {
-				t.Errorf("Diagnose(0x%x) returned error %q", tc.cbor, err)
-			} else if str != tc.diag {
-				t.Errorf("Diagnose(0x%x) returned `%s`, want %s", tc.cbor, str, tc.diag)
+				t.Errorf("Diagnose(0x%x) returned error %q", tc.data, err)
+			} else if str != tc.wantDiag {
+				t.Errorf("Diagnose(0x%x) returned `%s`, want %s", tc.data, str, tc.wantDiag)
 			}
 		})
 	}
@@ -778,62 +778,62 @@ func TestDiagnoseFloatingPointNumber(t *testing.T) {
 
 func TestDiagnoseFirst(t *testing.T) {
 	testCases := []struct {
-		title        string
-		cbor         []byte
-		diag         string
+		name         string
+		data         []byte
+		wantDiag     string
 		wantRest     []byte
 		wantErrorMsg string
 	}{
 		{
-			title:        "with no trailing data",
-			cbor:         mustHexDecode("f93e00"),
-			diag:         `1.5`,
+			name:         "with no trailing data",
+			data:         mustHexDecode("f93e00"),
+			wantDiag:     `1.5`,
 			wantRest:     []byte{},
 			wantErrorMsg: "",
 		},
 		{
-			title:        "with CBOR Sequences",
-			cbor:         mustHexDecode("f93e0064494554464401020304"),
-			diag:         `1.5`,
+			name:         "with CBOR Sequences",
+			data:         mustHexDecode("f93e0064494554464401020304"),
+			wantDiag:     `1.5`,
 			wantRest:     mustHexDecode("64494554464401020304"),
 			wantErrorMsg: "",
 		},
 		{
-			title:        "with invalid CBOR trailing data",
-			cbor:         mustHexDecode("f93e00ff494554464401020304"),
-			diag:         `1.5`,
+			name:         "with invalid CBOR trailing data",
+			data:         mustHexDecode("f93e00ff494554464401020304"),
+			wantDiag:     `1.5`,
 			wantRest:     mustHexDecode("ff494554464401020304"),
 			wantErrorMsg: "",
 		},
 		{
-			title:        "with invalid CBOR data",
-			cbor:         mustHexDecode("f93e"),
-			diag:         ``,
+			name:         "with invalid CBOR data",
+			data:         mustHexDecode("f93e"),
+			wantDiag:     ``,
 			wantRest:     nil,
 			wantErrorMsg: "unexpected EOF",
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.title, func(t *testing.T) {
-			str, rest, err := DiagnoseFirst(tc.cbor)
-			if str != tc.diag {
-				t.Errorf("DiagnoseFirst(0x%x) returned `%s`, want %s", tc.cbor, str, tc.diag)
+		t.Run(tc.name, func(t *testing.T) {
+			str, rest, err := DiagnoseFirst(tc.data)
+			if str != tc.wantDiag {
+				t.Errorf("DiagnoseFirst(0x%x) returned `%s`, want %s", tc.data, str, tc.wantDiag)
 			}
 
 			if bytes.Equal(rest, tc.wantRest) == false {
-				if str != tc.diag {
-					t.Errorf("DiagnoseFirst(0x%x) returned rest `%x`, want rest %x", tc.cbor, rest, tc.wantRest)
+				if str != tc.wantDiag {
+					t.Errorf("DiagnoseFirst(0x%x) returned rest `%x`, want rest %x", tc.data, rest, tc.wantRest)
 				}
 			}
 
 			switch {
 			case tc.wantErrorMsg == "" && err != nil:
-				t.Errorf("DiagnoseFirst(0x%x) returned error %q", tc.cbor, err)
+				t.Errorf("DiagnoseFirst(0x%x) returned error %q", tc.data, err)
 			case tc.wantErrorMsg != "" && err == nil:
-				t.Errorf("DiagnoseFirst(0x%x) returned nil error, want error %q", tc.cbor, err)
+				t.Errorf("DiagnoseFirst(0x%x) returned nil error, want error %q", tc.data, err)
 			case tc.wantErrorMsg != "" && !strings.Contains(err.Error(), tc.wantErrorMsg):
-				t.Errorf("DiagnoseFirst(0x%x) returned error %q, want error %q", tc.cbor, err, tc.wantErrorMsg)
+				t.Errorf("DiagnoseFirst(0x%x) returned error %q, want error %q", tc.data, err, tc.wantErrorMsg)
 			}
 		})
 	}
@@ -841,52 +841,52 @@ func TestDiagnoseFirst(t *testing.T) {
 
 func TestDiagnoseCBORSequences(t *testing.T) {
 	testCases := []struct {
-		title       string
-		cbor        []byte
-		diag        string
+		name        string
+		data        []byte
+		wantDiag    string
 		opts        *DiagOptions
 		returnError bool
 	}{
 		{
-			title: "CBOR Sequences without CBORSequence option",
-			cbor:  mustHexDecode("f93e0064494554464401020304"),
-			diag:  ``,
+			name:     "CBOR Sequences without CBORSequence option",
+			data:     mustHexDecode("f93e0064494554464401020304"),
+			wantDiag: ``,
 			opts: &DiagOptions{
 				CBORSequence: false,
 			},
 			returnError: true,
 		},
 		{
-			title: "CBOR Sequences with CBORSequence option",
-			cbor:  mustHexDecode("f93e0064494554464401020304"),
-			diag:  `1.5, "IETF", h'01020304'`,
+			name:     "CBOR Sequences with CBORSequence option",
+			data:     mustHexDecode("f93e0064494554464401020304"),
+			wantDiag: `1.5, "IETF", h'01020304'`,
 			opts: &DiagOptions{
 				CBORSequence: true,
 			},
 			returnError: false,
 		},
 		{
-			title: "CBOR Sequences with CBORSequence option",
-			cbor:  mustHexDecode("0102"),
-			diag:  `1, 2`,
+			name:     "CBOR Sequences with CBORSequence option",
+			data:     mustHexDecode("0102"),
+			wantDiag: `1, 2`,
 			opts: &DiagOptions{
 				CBORSequence: true,
 			},
 			returnError: false,
 		},
 		{
-			title: "CBOR Sequences with CBORSequence option",
-			cbor:  mustHexDecode("63666F6FF6"),
-			diag:  `"foo", null`,
+			name:     "CBOR Sequences with CBORSequence option",
+			data:     mustHexDecode("63666F6FF6"),
+			wantDiag: `"foo", null`,
 			opts: &DiagOptions{
 				CBORSequence: true,
 			},
 			returnError: false,
 		},
 		{
-			title: "partial/incomplete CBOR Sequences",
-			cbor:  mustHexDecode("f93e00644945544644010203"),
-			diag:  `1.5, "IETF"`,
+			name:     "partial/incomplete CBOR Sequences",
+			data:     mustHexDecode("f93e00644945544644010203"),
+			wantDiag: `1.5, "IETF"`,
 			opts: &DiagOptions{
 				CBORSequence: true,
 			},
@@ -895,21 +895,21 @@ func TestDiagnoseCBORSequences(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.title, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			dm, err := tc.opts.DiagMode()
 			if err != nil {
-				t.Errorf("DiagMode() for 0x%x returned error %q", tc.cbor, err)
+				t.Errorf("DiagMode() for 0x%x returned error %q", tc.data, err)
 			}
 
-			str, err := dm.Diagnose(tc.cbor)
+			str, err := dm.Diagnose(tc.data)
 			if tc.returnError && err == nil {
-				t.Errorf("Diagnose(0x%x) returned error %q", tc.cbor, err)
+				t.Errorf("Diagnose(0x%x) returned error %q", tc.data, err)
 			} else if !tc.returnError && err != nil {
-				t.Errorf("Diagnose(0x%x) returned error %q", tc.cbor, err)
+				t.Errorf("Diagnose(0x%x) returned error %q", tc.data, err)
 			}
 
-			if str != tc.diag {
-				t.Errorf("Diagnose(0x%x) returned `%s`, want %s", tc.cbor, str, tc.diag)
+			if str != tc.wantDiag {
+				t.Errorf("Diagnose(0x%x) returned `%s`, want %s", tc.data, str, tc.wantDiag)
 			}
 		})
 	}
@@ -917,72 +917,72 @@ func TestDiagnoseCBORSequences(t *testing.T) {
 
 func TestDiagnoseTag(t *testing.T) {
 	testCases := []struct {
-		title       string
-		cbor        []byte
-		diag        string
+		name        string
+		data        []byte
+		wantDiag    string
 		opts        *DiagOptions
 		returnError bool
 	}{
 		{
-			title:       "CBOR tag number 2 with not well-formed encoded CBOR data item",
-			cbor:        mustHexDecode("c201"),
-			diag:        ``,
+			name:        "CBOR tag number 2 with not well-formed encoded CBOR data item",
+			data:        mustHexDecode("c201"),
+			wantDiag:    ``,
 			opts:        &DiagOptions{},
 			returnError: true,
 		},
 		{
-			title:       "CBOR tag number 3 with not well-formed encoded CBOR data item",
-			cbor:        mustHexDecode("c301"),
-			diag:        ``,
+			name:        "CBOR tag number 3 with not well-formed encoded CBOR data item",
+			data:        mustHexDecode("c301"),
+			wantDiag:    ``,
 			opts:        &DiagOptions{},
 			returnError: true,
 		},
 		{
-			title:       "CBOR tag number 2 with well-formed encoded CBOR data item",
-			cbor:        mustHexDecode("c240"),
-			diag:        `0`,
+			name:        "CBOR tag number 2 with well-formed encoded CBOR data item",
+			data:        mustHexDecode("c240"),
+			wantDiag:    `0`,
 			opts:        &DiagOptions{},
 			returnError: false,
 		},
 		{
-			title:       "CBOR tag number 3 with well-formed encoded CBOR data item",
-			cbor:        mustHexDecode("c340"),
-			diag:        `-1`, // -1 - n
+			name:        "CBOR tag number 3 with well-formed encoded CBOR data item",
+			data:        mustHexDecode("c340"),
+			wantDiag:    `-1`, // -1 - n
 			opts:        &DiagOptions{},
 			returnError: false,
 		},
 		{
-			title:       "CBOR tag number 2 with well-formed encoded CBOR data item",
-			cbor:        mustHexDecode("c249010000000000000000"),
-			diag:        `18446744073709551616`,
+			name:        "CBOR tag number 2 with well-formed encoded CBOR data item",
+			data:        mustHexDecode("c249010000000000000000"),
+			wantDiag:    `18446744073709551616`,
 			opts:        &DiagOptions{},
 			returnError: false,
 		},
 		{
-			title:       "CBOR tag number 3 with well-formed encoded CBOR data item",
-			cbor:        mustHexDecode("c349010000000000000000"),
-			diag:        `-18446744073709551617`, // -1 - n
+			name:        "CBOR tag number 3 with well-formed encoded CBOR data item",
+			data:        mustHexDecode("c349010000000000000000"),
+			wantDiag:    `-18446744073709551617`, // -1 - n
 			opts:        &DiagOptions{},
 			returnError: false,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.title, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			dm, err := tc.opts.DiagMode()
 			if err != nil {
-				t.Errorf("DiagMode() for 0x%x returned error %q", tc.cbor, err)
+				t.Errorf("DiagMode() for 0x%x returned error %q", tc.data, err)
 			}
 
-			str, err := dm.Diagnose(tc.cbor)
+			str, err := dm.Diagnose(tc.data)
 			if tc.returnError && err == nil {
-				t.Errorf("Diagnose(0x%x) returned error %q", tc.cbor, err)
+				t.Errorf("Diagnose(0x%x) returned error %q", tc.data, err)
 			} else if !tc.returnError && err != nil {
-				t.Errorf("Diagnose(0x%x) returned error %q", tc.cbor, err)
+				t.Errorf("Diagnose(0x%x) returned error %q", tc.data, err)
 			}
 
-			if str != tc.diag {
-				t.Errorf("Diagnose(0x%x) returned `%s`, want %s", tc.cbor, str, tc.diag)
+			if str != tc.wantDiag {
+				t.Errorf("Diagnose(0x%x) returned `%s`, want %s", tc.data, str, tc.wantDiag)
 			}
 		})
 	}
@@ -1036,7 +1036,7 @@ func TestInvalidDiagnoseOptions(t *testing.T) {
 	}
 	_, err := opts.DiagMode()
 	if err == nil {
-		t.Errorf("DiagMode() with invalid ByteStringEncoding option didn't return error")
+		t.Errorf("DiagMode() with invalid ByteStringEncoding option didn't return an error")
 	}
 }
 
@@ -1044,7 +1044,7 @@ func TestDiagnoseExtraneousData(t *testing.T) {
 	data := mustHexDecode("63666F6FF6")
 	_, err := Diagnose(data)
 	if err == nil {
-		t.Errorf("Diagnose(0x%x) didn't return error", data)
+		t.Errorf("Diagnose(0x%x) didn't return an error", data)
 	} else if !strings.Contains(err.Error(), `extraneous data`) {
 		t.Errorf("Diagnose(0x%x) returned error %q", data, err)
 	}
@@ -1059,7 +1059,7 @@ func TestDiagnoseNotwellformedData(t *testing.T) {
 	data := mustHexDecode("5f4060ff")
 	_, err := Diagnose(data)
 	if err == nil {
-		t.Errorf("Diagnose(0x%x) didn't return error", data)
+		t.Errorf("Diagnose(0x%x) didn't return an error", data)
 	} else if !strings.Contains(err.Error(), `wrong element type`) {
 		t.Errorf("Diagnose(0x%x) returned error %q", data, err)
 	}
@@ -1116,7 +1116,7 @@ func TestDiagnoseInvalidByteStringEncoding(t *testing.T) {
 }
 
 func BenchmarkDiagnose(b *testing.B) {
-	for _, tc := range []struct {
+	testCases := []struct {
 		name  string
 		opts  DiagOptions
 		input []byte
@@ -1146,7 +1146,8 @@ func BenchmarkDiagnose(b *testing.B) {
 			opts:  DiagOptions{ByteStringEncoding: ByteStringBase64Encoding},
 			input: []byte("\x45hello"),
 		},
-	} {
+	}
+	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			dm, err := tc.opts.DiagMode()
 			if err != nil {

--- a/encode.go
+++ b/encode.go
@@ -343,7 +343,7 @@ const (
 	// non-UTC timezone then a "localtime - UTC" numeric offset will be included as specified in RFC3339.
 	// NOTE: User applications can avoid including the RFC3339 numeric offset by:
 	// - providing a time.Time value set to UTC, or
-	// - using the TimeUnix, TimeUnixMicro, or TimeUnixDynamic option instead of TimeRFC3339.
+	// - using the TimeUnix, TimeUnixMicro, TimeUnixDynamic, or TimeRFC3339NanoUTC option.
 	TimeRFC3339
 
 	// TimeRFC3339Nano causes time.Time to encode to a CBOR time (tag 0) with a text string content
@@ -351,8 +351,12 @@ const (
 	// non-UTC timezone then a "localtime - UTC" numeric offset will be included as specified in RFC3339.
 	// NOTE: User applications can avoid including the RFC3339 numeric offset by:
 	// - providing a time.Time value set to UTC, or
-	// - using the TimeUnix, TimeUnixMicro, or TimeUnixDynamic option instead of TimeRFC3339Nano.
+	// - using the TimeUnix, TimeUnixMicro, TimeUnixDynamic, or TimeRFC3339NanoUTC option.
 	TimeRFC3339Nano
+
+	// TimeRFC3339NanoUTC causes time.Time to encode to a CBOR time (tag 0) with a text string content
+	// representing UTC time using nanosecond precision in RFC3339 format.
+	TimeRFC3339NanoUTC
 
 	maxTimeMode
 )
@@ -1633,7 +1637,7 @@ func encodeTime(e *bytes.Buffer, em *encMode, v reflect.Value) error {
 	}
 	if em.timeTag == EncTagRequired {
 		tagNumber := 1
-		if em.time == TimeRFC3339 || em.time == TimeRFC3339Nano {
+		if em.time == TimeRFC3339 || em.time == TimeRFC3339Nano || em.time == TimeRFC3339NanoUTC {
 			tagNumber = 0
 		}
 		encodeHead(e, byte(cborTypeTag), uint64(tagNumber))
@@ -1659,6 +1663,10 @@ func encodeTime(e *bytes.Buffer, em *encMode, v reflect.Value) error {
 
 	case TimeRFC3339:
 		s := t.Format(time.RFC3339)
+		return encodeString(e, em, reflect.ValueOf(s))
+
+	case TimeRFC3339NanoUTC:
+		s := t.UTC().Format(time.RFC3339Nano)
 		return encodeString(e, em, reflect.ValueOf(s))
 
 	default: // TimeRFC3339Nano

--- a/encode.go
+++ b/encode.go
@@ -1136,10 +1136,11 @@ func encodeFloat(e *bytes.Buffer, em *encMode, v reflect.Value) error {
 	if fopt == ShortestFloat16 {
 		var f16 float16.Float16
 		p := float16.PrecisionFromfloat32(f32)
-		if p == float16.PrecisionExact {
+		switch p {
+		case float16.PrecisionExact:
 			// Roundtrip float32->float16->float32 test isn't needed.
 			f16 = float16.Fromfloat32(f32)
-		} else if p == float16.PrecisionUnknown {
+		case float16.PrecisionUnknown:
 			// Try roundtrip float32->float16->float32 to determine if float32 can fit into float16.
 			f16 = float16.Fromfloat32(f32)
 			if f16.Float32() == f32 {
@@ -1297,10 +1298,10 @@ func encodeByteString(e *bytes.Buffer, em *encMode, v reflect.Value) error {
 	if slen == 0 {
 		return e.WriteByte(byte(cborTypeByteString))
 	}
-	encodeHead(e, byte(cborTypeByteString), uint64(slen))
+	encodeHead(e, byte(cborTypeByteString), uint64(slen)) //nolint:gosec
 	if vk == reflect.Array {
 		for i := 0; i < slen; i++ {
-			e.WriteByte(byte(v.Index(i).Uint()))
+			e.WriteByte(byte(v.Index(i).Uint())) //nolint:gosec
 		}
 		return nil
 	}
@@ -1337,7 +1338,7 @@ func (ae arrayEncodeFunc) encode(e *bytes.Buffer, em *encMode, v reflect.Value) 
 	if alen == 0 {
 		return e.WriteByte(byte(cborTypeArray))
 	}
-	encodeHead(e, byte(cborTypeArray), uint64(alen))
+	encodeHead(e, byte(cborTypeArray), uint64(alen)) //nolint:gosec
 	for i := 0; i < alen; i++ {
 		if err := ae.f(e, em, v.Index(i)); err != nil {
 			return err
@@ -1368,7 +1369,7 @@ func (me mapEncodeFunc) encode(e *bytes.Buffer, em *encMode, v reflect.Value) er
 		return e.WriteByte(byte(cborTypeMap))
 	}
 
-	encodeHead(e, byte(cborTypeMap), uint64(mlen))
+	encodeHead(e, byte(cborTypeMap), uint64(mlen)) //nolint:gosec
 	if em.sort == SortNone || em.sort == SortFastShuffle || mlen <= 1 {
 		return me.e(e, em, v, nil)
 	}
@@ -1654,7 +1655,7 @@ func encodeTime(e *bytes.Buffer, em *encMode, v reflect.Value) error {
 
 	case TimeUnixDynamic:
 		t = t.UTC().Round(time.Microsecond)
-		secs, nsecs := t.Unix(), uint64(t.Nanosecond())
+		secs, nsecs := t.Unix(), uint64(t.Nanosecond()) //nolint:gosec
 		if nsecs == 0 {
 			return encodeInt(e, em, reflect.ValueOf(secs))
 		}

--- a/encode.go
+++ b/encode.go
@@ -30,7 +30,7 @@ import (
 // If value implements the Marshaler interface, Marshal calls its
 // MarshalCBOR method.
 //
-// If value implements encoding.BinaryMarshaler, Marhsal calls its
+// If value implements encoding.BinaryMarshaler, Marshal calls its
 // MarshalBinary method and encode it as CBOR byte string.
 //
 // Boolean values encode as CBOR booleans (type 7).
@@ -440,7 +440,7 @@ const (
 	// FieldNameToTextString encodes struct fields to CBOR text string (major type 3).
 	FieldNameToTextString FieldNameMode = iota
 
-	// FieldNameToTextString encodes struct fields to CBOR byte string (major type 2).
+	// FieldNameToByteString encodes struct fields to CBOR byte string (major type 2).
 	FieldNameToByteString
 
 	maxFieldNameMode
@@ -571,7 +571,7 @@ type EncOptions struct {
 	// RFC3339 format gets tag number 0, and numeric epoch time tag number 1.
 	TimeTag EncTagMode
 
-	// IndefLength specifies whether to allow indefinite length CBOR items.
+	// IndefLength specifies whether to allow indefinite-length CBOR items.
 	IndefLength IndefLengthMode
 
 	// NilContainers specifies how to encode nil slices and maps.
@@ -1539,8 +1539,8 @@ func encodeStruct(e *bytes.Buffer, em *encMode, v reflect.Value) (err error) {
 	// Head is rewritten later if actual encoded field count is different from struct field count.
 	encodedHeadLen := encodeHead(e, byte(cborTypeMap), uint64(len(flds)))
 
-	kvbegin := e.Len()
-	kvcount := 0
+	kvBeginOffset := e.Len()
+	kvCount := 0
 	for offset := 0; offset < len(flds); offset++ {
 		f := flds[(start+offset)%len(flds)]
 
@@ -1586,10 +1586,10 @@ func encodeStruct(e *bytes.Buffer, em *encMode, v reflect.Value) (err error) {
 			return err
 		}
 
-		kvcount++
+		kvCount++
 	}
 
-	if len(flds) == kvcount {
+	if len(flds) == kvCount {
 		// Encoded element count in head is the same as actual element count.
 		return nil
 	}
@@ -1597,8 +1597,8 @@ func encodeStruct(e *bytes.Buffer, em *encMode, v reflect.Value) (err error) {
 	// Overwrite the bytes that were reserved for the head before encoding the map entries.
 	var actualHeadLen int
 	{
-		headbuf := *bytes.NewBuffer(e.Bytes()[kvbegin-encodedHeadLen : kvbegin-encodedHeadLen : kvbegin])
-		actualHeadLen = encodeHead(&headbuf, byte(cborTypeMap), uint64(kvcount))
+		headbuf := *bytes.NewBuffer(e.Bytes()[kvBeginOffset-encodedHeadLen : kvBeginOffset-encodedHeadLen : kvBeginOffset])
+		actualHeadLen = encodeHead(&headbuf, byte(cborTypeMap), uint64(kvCount))
 	}
 
 	if actualHeadLen == encodedHeadLen {
@@ -1611,8 +1611,8 @@ func encodeStruct(e *bytes.Buffer, em *encMode, v reflect.Value) (err error) {
 	// encoded. The encoded entries are offset to the right by the number of excess reserved
 	// bytes. Shift the entries left to remove the gap.
 	excessReservedBytes := encodedHeadLen - actualHeadLen
-	dst := e.Bytes()[kvbegin-excessReservedBytes : e.Len()-excessReservedBytes]
-	src := e.Bytes()[kvbegin:e.Len()]
+	dst := e.Bytes()[kvBeginOffset-excessReservedBytes : e.Len()-excessReservedBytes]
+	src := e.Bytes()[kvBeginOffset:e.Len()]
 	copy(dst, src)
 
 	// After shifting, the excess bytes are at the end of the output buffer and they are

--- a/encode.go
+++ b/encode.go
@@ -1431,7 +1431,7 @@ func (x *bytewiseKeyValueSorter) Swap(i, j int) {
 
 func (x *bytewiseKeyValueSorter) Less(i, j int) bool {
 	kvi, kvj := x.kvs[i], x.kvs[j]
-	return bytes.Compare(x.data[kvi.offset:kvi.valueOffset], x.data[kvj.offset:kvj.valueOffset]) <= 0
+	return bytes.Compare(x.data[kvi.offset:kvi.valueOffset], x.data[kvj.offset:kvj.valueOffset]) < 0
 }
 
 type lengthFirstKeyValueSorter struct {
@@ -1452,7 +1452,7 @@ func (x *lengthFirstKeyValueSorter) Less(i, j int) bool {
 	if keyLengthDifference := (kvi.valueOffset - kvi.offset) - (kvj.valueOffset - kvj.offset); keyLengthDifference != 0 {
 		return keyLengthDifference < 0
 	}
-	return bytes.Compare(x.data[kvi.offset:kvi.valueOffset], x.data[kvj.offset:kvj.valueOffset]) <= 0
+	return bytes.Compare(x.data[kvi.offset:kvi.valueOffset], x.data[kvj.offset:kvj.valueOffset]) < 0
 }
 
 var keyValuePool = sync.Pool{}

--- a/encode_test.go
+++ b/encode_test.go
@@ -2687,318 +2687,591 @@ func TestEncodeInterface(t *testing.T) {
 	}
 }
 
-func TestEncodeTime(t *testing.T) {
-	timeUnixOpt := EncOptions{Time: TimeUnix}
-	timeUnixMicroOpt := EncOptions{Time: TimeUnixMicro}
-	timeUnixDynamicOpt := EncOptions{Time: TimeUnixDynamic}
-	timeRFC3339Opt := EncOptions{Time: TimeRFC3339}
-	timeRFC3339NanoOpt := EncOptions{Time: TimeRFC3339Nano}
+type encTimeOption struct {
+	name           string
+	opt            EncOptions
+	hasLocalOffset bool
+}
 
-	type timeConvert struct {
-		opt          EncOptions
+var (
+	timeUnixOpt = encTimeOption{
+		name:           "TimeUnix",
+		opt:            EncOptions{Time: TimeUnix},
+		hasLocalOffset: false,
+	}
+
+	timeUnixWithTagOpt = encTimeOption{
+		name:           "TimeUnixWithTag",
+		opt:            EncOptions{Time: TimeUnix, TimeTag: EncTagRequired},
+		hasLocalOffset: false,
+	}
+
+	timeUnixMicroOpt = encTimeOption{
+		name:           "TimeUnixMicro",
+		opt:            EncOptions{Time: TimeUnixMicro},
+		hasLocalOffset: false,
+	}
+
+	timeUnixMicroWithTagOpt = encTimeOption{
+		name:           "TimeUnixMicroWithTag",
+		opt:            EncOptions{Time: TimeUnixMicro, TimeTag: EncTagRequired},
+		hasLocalOffset: false,
+	}
+
+	timeUnixDynamicOpt = encTimeOption{
+		name:           "TimeUnixDynamic",
+		opt:            EncOptions{Time: TimeUnixDynamic},
+		hasLocalOffset: false,
+	}
+
+	timeUnixDynamicWithTagOpt = encTimeOption{
+		name:           "TimeUnixDynamicWithTag",
+		opt:            EncOptions{Time: TimeUnixDynamic, TimeTag: EncTagRequired},
+		hasLocalOffset: false,
+	}
+
+	timeRFC3339Opt = encTimeOption{
+		name:           "TimeRFC3339",
+		opt:            EncOptions{Time: TimeRFC3339},
+		hasLocalOffset: true,
+	}
+
+	timeRFC3339WithTagOpt = encTimeOption{
+		name:           "TimeRFC3339WithTag",
+		opt:            EncOptions{Time: TimeRFC3339, TimeTag: EncTagRequired},
+		hasLocalOffset: true,
+	}
+
+	timeRFC3339NanoOpt = encTimeOption{
+		name:           "TimeRFC3339Nano",
+		opt:            EncOptions{Time: TimeRFC3339Nano},
+		hasLocalOffset: true,
+	}
+
+	timeRFC3339NanoWithTagOpt = encTimeOption{
+		name:           "TimeRFC3339NanoWithTag",
+		opt:            EncOptions{Time: TimeRFC3339Nano, TimeTag: EncTagRequired},
+		hasLocalOffset: true,
+	}
+
+	timeRFC3339NanoUTCOpt = encTimeOption{
+		name:           "TimeRFC3339NanoUTC",
+		opt:            EncOptions{Time: TimeRFC3339NanoUTC},
+		hasLocalOffset: false,
+	}
+
+	timeRFC3339NanoUTCWithTagOpt = encTimeOption{
+		name:           "TimeRFC3339NanoUTCWithTag",
+		opt:            EncOptions{Time: TimeRFC3339NanoUTC, TimeTag: EncTagRequired},
+		hasLocalOffset: false,
+	}
+)
+
+func TestEncodeTime(t *testing.T) {
+	type conversion struct {
+		opt          encTimeOption
 		wantCborData []byte
+		roundtrip    bool
 	}
 	testCases := []struct {
 		name    string
 		tm      time.Time
-		convert []timeConvert
+		convert []conversion
 	}{
 		{
 			name: "zero time",
 			tm:   time.Time{},
-			convert: []timeConvert{
+			convert: []conversion{
 				{
 					opt:          timeUnixOpt,
 					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixWithTagOpt,
+					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
 				},
 				{
 					opt:          timeUnixMicroOpt,
 					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixMicroWithTagOpt,
+					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
 				},
 				{
 					opt:          timeUnixDynamicOpt,
 					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixDynamicWithTagOpt,
+					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
 				},
 				{
 					opt:          timeRFC3339Opt,
 					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339WithTagOpt,
+					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
 				},
 				{
 					opt:          timeRFC3339NanoOpt,
 					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoWithTagOpt,
+					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCOpt,
+					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCWithTagOpt,
+					wantCborData: mustHexDecode("f6"), // encode as CBOR null
+					roundtrip:    true,
 				},
 			},
 		},
 		{
-			name: "time without fractional seconds",
-			tm:   parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
-			convert: []timeConvert{
+			name: "UTC time without fractional seconds",
+			tm:   mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+			convert: []conversion{
 				{
 					opt:          timeUnixOpt,
 					wantCborData: mustHexDecode("1a514b67b0"), // 1363896240
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixWithTagOpt,
+					wantCborData: mustHexDecode("c11a514b67b0"), // 1(1363896240)
+					roundtrip:    true,
 				},
 				{
 					opt:          timeUnixMicroOpt,
 					wantCborData: mustHexDecode("fb41d452d9ec000000"), // 1363896240.0
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixMicroWithTagOpt,
+					wantCborData: mustHexDecode("c1fb41d452d9ec000000"), // 1(1363896240.0)
+					roundtrip:    true,
 				},
 				{
 					opt:          timeUnixDynamicOpt,
 					wantCborData: mustHexDecode("1a514b67b0"), // 1363896240
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixDynamicWithTagOpt,
+					wantCborData: mustHexDecode("c11a514b67b0"), // 1(1363896240)
+					roundtrip:    true,
 				},
 				{
 					opt:          timeRFC3339Opt,
 					wantCborData: mustHexDecode("74323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339WithTagOpt,
+					wantCborData: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"), // 0("2013-03-21T20:04:00Z")
+					roundtrip:    true,
 				},
 				{
 					opt:          timeRFC3339NanoOpt,
 					wantCborData: mustHexDecode("74323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoWithTagOpt,
+					wantCborData: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"), // 0("2013-03-21T20:04:00Z")
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCOpt,
+					wantCborData: mustHexDecode("74323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCWithTagOpt,
+					wantCborData: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"), // 0("2013-03-21T20:04:00Z")
+					roundtrip:    true,
 				},
 			},
 		},
 		{
-			name: "time with fractional seconds",
-			tm:   parseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5Z"),
-			convert: []timeConvert{
+			name: "local time without fractional seconds",
+			tm:   mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00-05:00"),
+			convert: []conversion{
+				{
+					opt:          timeUnixOpt,
+					wantCborData: mustHexDecode("1a514bae00"), // 1363914240
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixWithTagOpt,
+					wantCborData: mustHexDecode("c11a514bae00"), // 1(1363914240)
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixMicroOpt,
+					wantCborData: mustHexDecode("fb41d452eb80000000"), // 1363914240.0
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixMicroWithTagOpt,
+					wantCborData: mustHexDecode("c1fb41d452eb80000000"), // 1(1363914240.0)
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixDynamicOpt,
+					wantCborData: mustHexDecode("1a514bae00"), // 1363914240
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixDynamicWithTagOpt,
+					wantCborData: mustHexDecode("c11a514bae00"), // 1(1363914240)
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339Opt,
+					wantCborData: mustHexDecode("7819323031332d30332d32315432303a30343a30302d30353a3030"), // "2013-03-21T20:04:00-05:00"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339WithTagOpt,
+					wantCborData: mustHexDecode("c07819323031332d30332d32315432303a30343a30302d30353a3030"), // 0("2013-03-21T20:04:00-05:00")
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoOpt,
+					wantCborData: mustHexDecode("7819323031332d30332d32315432303a30343a30302d30353a3030"), // "2013-03-21T20:04:00-05:00"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoWithTagOpt,
+					wantCborData: mustHexDecode("c07819323031332d30332d32315432303a30343a30302d30353a3030"), // 0("2013-03-21T20:04:00-05:00")
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCOpt,
+					wantCborData: mustHexDecode("74323031332d30332d32325430313a30343a30305a"), // "2013-03-22T01:04:00Z"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCWithTagOpt,
+					wantCborData: mustHexDecode("c074323031332d30332d32325430313a30343a30305a"), // 0("2013-03-22T01:04:00Z")
+					roundtrip:    true,
+				},
+			},
+		},
+		{
+			name: "UTC time with fractional seconds",
+			tm:   mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5Z"),
+			convert: []conversion{
 				{
 					opt:          timeUnixOpt,
 					wantCborData: mustHexDecode("1a514b67b0"), // 1363896240
+					roundtrip:    false,
+				},
+				{
+					opt:          timeUnixWithTagOpt,
+					wantCborData: mustHexDecode("c11a514b67b0"), // 1(1363896240)
+					roundtrip:    false,
 				},
 				{
 					opt:          timeUnixMicroOpt,
 					wantCborData: mustHexDecode("fb41d452d9ec200000"), // 1363896240.5
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixMicroWithTagOpt,
+					wantCborData: mustHexDecode("c1fb41d452d9ec200000"), // 1(1363896240.5)
+					roundtrip:    true,
 				},
 				{
 					opt:          timeUnixDynamicOpt,
 					wantCborData: mustHexDecode("fb41d452d9ec200000"), // 1363896240.5
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixDynamicWithTagOpt,
+					wantCborData: mustHexDecode("c1fb41d452d9ec200000"), // 1(1363896240.5)
+					roundtrip:    true,
 				},
 				{
 					opt:          timeRFC3339Opt,
 					wantCborData: mustHexDecode("74323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
+					roundtrip:    false,
+				},
+				{
+					opt:          timeRFC3339WithTagOpt,
+					wantCborData: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"), // 0("2013-03-21T20:04:00Z")
+					roundtrip:    false,
 				},
 				{
 					opt:          timeRFC3339NanoOpt,
 					wantCborData: mustHexDecode("76323031332d30332d32315432303a30343a30302e355a"), // "2013-03-21T20:04:00.5Z"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoWithTagOpt,
+					wantCborData: mustHexDecode("c076323031332d30332d32315432303a30343a30302e355a"), // 0("2013-03-21T20:04:00.5Z")
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCOpt,
+					wantCborData: mustHexDecode("76323031332d30332d32315432303a30343a30302e355a"), // "2013-03-21T20:04:00.5Z"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCWithTagOpt,
+					wantCborData: mustHexDecode("c076323031332d30332d32315432303a30343a30302e355a"), // 0("2013-03-21T20:04:00.5Z")
+					roundtrip:    true,
 				},
 			},
 		},
 		{
-			name: "time before January 1, 1970 UTC without fractional seconds",
-			tm:   parseTime(time.RFC3339Nano, "1969-03-21T20:04:00Z"),
-			convert: []timeConvert{
+			name: "local time with fractional seconds",
+			tm:   mustParseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5-05:00"),
+			convert: []conversion{
+				{
+					opt:          timeUnixOpt,
+					wantCborData: mustHexDecode("1a514bae00"), // 1363914240
+					roundtrip:    false,
+				},
+				{
+					opt:          timeUnixWithTagOpt,
+					wantCborData: mustHexDecode("c11a514bae00"), // 1(1363914240)
+					roundtrip:    false,
+				},
+				{
+					opt:          timeUnixMicroOpt,
+					wantCborData: mustHexDecode("fb41d452eb80200000"), // 1363914240.5
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixMicroWithTagOpt,
+					wantCborData: mustHexDecode("c1fb41d452eb80200000"), // 1(1363914240.5)
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixDynamicOpt,
+					wantCborData: mustHexDecode("fb41d452eb80200000"), // 1363914240.5
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixDynamicWithTagOpt,
+					wantCborData: mustHexDecode("c1fb41d452eb80200000"), // 1(1363914240.5)
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339Opt,
+					wantCborData: mustHexDecode("7819323031332d30332d32315432303a30343a30302d30353a3030"), // "2013-03-21T20:04:00-05:00"
+					roundtrip:    false,
+				},
+				{
+					opt:          timeRFC3339WithTagOpt,
+					wantCborData: mustHexDecode("c07819323031332d30332d32315432303a30343a30302d30353a3030"), // 0("2013-03-21T20:04:00-05:00")
+					roundtrip:    false,
+				},
+				{
+					opt:          timeRFC3339NanoOpt,
+					wantCborData: mustHexDecode("781b323031332d30332d32315432303a30343a30302e352d30353a3030"), // "2013-03-21T20:04:00.5-05:00"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoWithTagOpt,
+					wantCborData: mustHexDecode("c0781b323031332d30332d32315432303a30343a30302e352d30353a3030"), // 0("2013-03-21T20:04:00.5-05:00")
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCOpt,
+					wantCborData: mustHexDecode("76323031332d30332d32325430313a30343a30302e355a"), // "2013-03-22T01:04:00.5Z"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCWithTagOpt,
+					wantCborData: mustHexDecode("c076323031332d30332d32325430313a30343a30302e355a"), // 0("2013-03-22T01:04:00.5Z")
+					roundtrip:    true,
+				},
+			},
+		},
+		{
+			name: "UTC time before January 1, 1970 UTC without fractional seconds",
+			tm:   mustParseTime(time.RFC3339Nano, "1969-03-21T20:04:00Z"),
+			convert: []conversion{
 				{
 					opt:          timeUnixOpt,
 					wantCborData: mustHexDecode("3a0177f2cf"), // -24638160
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixWithTagOpt,
+					wantCborData: mustHexDecode("c13a0177f2cf"), // 1(-24638160)
+					roundtrip:    true,
 				},
 				{
 					opt:          timeUnixMicroOpt,
 					wantCborData: mustHexDecode("fbc1777f2d00000000"), // -24638160.0
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixMicroWithTagOpt,
+					wantCborData: mustHexDecode("c1fbc1777f2d00000000"), // 1(-24638160.0)
+					roundtrip:    true,
 				},
 				{
 					opt:          timeUnixDynamicOpt,
 					wantCborData: mustHexDecode("3a0177f2cf"), // -24638160
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixDynamicWithTagOpt,
+					wantCborData: mustHexDecode("c13a0177f2cf"), // 1(-24638160)
+					roundtrip:    true,
 				},
 				{
 					opt:          timeRFC3339Opt,
 					wantCborData: mustHexDecode("74313936392d30332d32315432303a30343a30305a"), // "1969-03-21T20:04:00Z"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339WithTagOpt,
+					wantCborData: mustHexDecode("c074313936392d30332d32315432303a30343a30305a"), // 0("1969-03-21T20:04:00Z")
+					roundtrip:    true,
 				},
 				{
 					opt:          timeRFC3339NanoOpt,
 					wantCborData: mustHexDecode("74313936392d30332d32315432303a30343a30305a"), // "1969-03-21T20:04:00Z"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoWithTagOpt,
+					wantCborData: mustHexDecode("c074313936392d30332d32315432303a30343a30305a"), // 0("1969-03-21T20:04:00Z")
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCOpt,
+					wantCborData: mustHexDecode("74313936392d30332d32315432303a30343a30305a"), // "1969-03-21T20:04:00Z"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCWithTagOpt,
+					wantCborData: mustHexDecode("c074313936392d30332d32315432303a30343a30305a"), // 0("1969-03-21T20:04:00Z")
+					roundtrip:    true,
+				},
+			},
+		},
+		{
+			name: "local time before January 1, 1970 UTC without fractional seconds",
+			tm:   mustParseTime(time.RFC3339Nano, "1969-03-21T20:04:00-05:00"),
+			convert: []conversion{
+				{
+					opt:          timeUnixOpt,
+					wantCborData: mustHexDecode("3a0177ac7f"), // -24620160
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixWithTagOpt,
+					wantCborData: mustHexDecode("c13a0177ac7f"), // 1(-24620160)
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixMicroOpt,
+					wantCborData: mustHexDecode("fbc1777ac800000000"), // -24620160.0
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixMicroWithTagOpt,
+					wantCborData: mustHexDecode("c1fbc1777ac800000000"), // 1(-24620160.0)
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixDynamicOpt,
+					wantCborData: mustHexDecode("3a0177ac7f"), // -24620160
+					roundtrip:    true,
+				},
+				{
+					opt:          timeUnixDynamicWithTagOpt,
+					wantCborData: mustHexDecode("c13a0177ac7f"), // 1(-24620160)
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339Opt,
+					wantCborData: mustHexDecode("7819313936392d30332d32315432303a30343a30302d30353a3030"), // "1969-03-21T20:04:00-05:00"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339WithTagOpt,
+					wantCborData: mustHexDecode("c07819313936392d30332d32315432303a30343a30302d30353a3030"), // 0("1969-03-21T20:04:00-05:00")
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoOpt,
+					wantCborData: mustHexDecode("7819313936392d30332d32315432303a30343a30302d30353a3030"), // "1969-03-21T20:04:00-05:00"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoWithTagOpt,
+					wantCborData: mustHexDecode("c07819313936392d30332d32315432303a30343a30302d30353a3030"), // 0("1969-03-21T20:04:00-05:00")
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCOpt,
+					wantCborData: mustHexDecode("74313936392d30332d32325430313a30343a30305a"), // "1969-03-22T01:04:00Z"
+					roundtrip:    true,
+				},
+				{
+					opt:          timeRFC3339NanoUTCWithTagOpt,
+					wantCborData: mustHexDecode("c074313936392d30332d32325430313a30343a30305a"), // 0("1969-03-22T01:04:00Z")
+					roundtrip:    true,
 				},
 			},
 		},
 	}
 	for _, tc := range testCases {
 		for _, convert := range tc.convert {
-			var convertName string
-			switch convert.opt.Time {
-			case TimeUnix:
-				convertName = "TimeUnix"
-			case TimeUnixMicro:
-				convertName = "TimeUnixMicro"
-			case TimeUnixDynamic:
-				convertName = "TimeUnixDynamic"
-			case TimeRFC3339:
-				convertName = "TimeRFC3339"
-			case TimeRFC3339Nano:
-				convertName = "TimeRFC3339Nano"
-			}
-			name := tc.name + " with " + convertName + " option"
+			name := tc.name + " with " + convert.opt.name + " option"
 			t.Run(name, func(t *testing.T) {
-				em, err := convert.opt.EncMode()
+				em, err := convert.opt.opt.EncMode()
 				if err != nil {
 					t.Errorf("EncMode() returned error %v", err)
 				}
+
 				b, err := em.Marshal(tc.tm)
 				if err != nil {
 					t.Errorf("Marshal(%+v) returned error %v", tc.tm, err)
 				} else if !bytes.Equal(b, convert.wantCborData) {
 					t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.tm, b, convert.wantCborData)
 				}
-			})
-		}
-	}
-}
 
-func TestEncodeTimeWithTag(t *testing.T) {
-	timeUnixOpt := EncOptions{Time: TimeUnix, TimeTag: EncTagRequired}
-	timeUnixMicroOpt := EncOptions{Time: TimeUnixMicro, TimeTag: EncTagRequired}
-	timeUnixDynamicOpt := EncOptions{Time: TimeUnixDynamic, TimeTag: EncTagRequired}
-	timeRFC3339Opt := EncOptions{Time: TimeRFC3339, TimeTag: EncTagRequired}
-	timeRFC3339NanoOpt := EncOptions{Time: TimeRFC3339Nano, TimeTag: EncTagRequired}
-
-	type timeConvert struct {
-		opt          EncOptions
-		wantCborData []byte
-	}
-	testCases := []struct {
-		name    string
-		tm      time.Time
-		convert []timeConvert
-	}{
-		{
-			name: "zero time",
-			tm:   time.Time{},
-			convert: []timeConvert{
-				{
-					opt:          timeUnixOpt,
-					wantCborData: mustHexDecode("f6"), // encode as CBOR null
-				},
-				{
-					opt:          timeUnixMicroOpt,
-					wantCborData: mustHexDecode("f6"), // encode as CBOR null
-				},
-				{
-					opt:          timeUnixDynamicOpt,
-					wantCborData: mustHexDecode("f6"), // encode as CBOR null
-				},
-				{
-					opt:          timeRFC3339Opt,
-					wantCborData: mustHexDecode("f6"), // encode as CBOR null
-				},
-				{
-					opt:          timeRFC3339NanoOpt,
-					wantCborData: mustHexDecode("f6"), // encode as CBOR null
-				},
-			},
-		},
-		{
-			name: "time without fractional seconds",
-			tm:   parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
-			convert: []timeConvert{
-				{
-					opt:          timeUnixOpt,
-					wantCborData: mustHexDecode("c11a514b67b0"), // 1363896240
-				},
-				{
-					opt:          timeUnixMicroOpt,
-					wantCborData: mustHexDecode("c1fb41d452d9ec000000"), // 1363896240.0
-				},
-				{
-					opt:          timeUnixDynamicOpt,
-					wantCborData: mustHexDecode("c11a514b67b0"), // 1363896240
-				},
-				{
-					opt:          timeRFC3339Opt,
-					wantCborData: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
-				},
-				{
-					opt:          timeRFC3339NanoOpt,
-					wantCborData: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
-				},
-			},
-		},
-		{
-			name: "time with fractional seconds",
-			tm:   parseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5Z"),
-			convert: []timeConvert{
-				{
-					opt:          timeUnixOpt,
-					wantCborData: mustHexDecode("c11a514b67b0"), // 1363896240
-				},
-				{
-					opt:          timeUnixMicroOpt,
-					wantCborData: mustHexDecode("c1fb41d452d9ec200000"), // 1363896240.5
-				},
-				{
-					opt:          timeUnixDynamicOpt,
-					wantCborData: mustHexDecode("c1fb41d452d9ec200000"), // 1363896240.5
-				},
-				{
-					opt:          timeRFC3339Opt,
-					wantCborData: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
-				},
-				{
-					opt:          timeRFC3339NanoOpt,
-					wantCborData: mustHexDecode("c076323031332d30332d32315432303a30343a30302e355a"), // "2013-03-21T20:04:00.5Z"
-				},
-			},
-		},
-		{
-			name: "time before January 1, 1970 UTC without fractional seconds",
-			tm:   parseTime(time.RFC3339Nano, "1969-03-21T20:04:00Z"),
-			convert: []timeConvert{
-				{
-					opt:          timeUnixOpt,
-					wantCborData: mustHexDecode("c13a0177f2cf"), // -24638160
-				},
-				{
-					opt:          timeUnixMicroOpt,
-					wantCborData: mustHexDecode("c1fbc1777f2d00000000"), // -24638160.0
-				},
-				{
-					opt:          timeUnixDynamicOpt,
-					wantCborData: mustHexDecode("c13a0177f2cf"), // -24638160
-				},
-				{
-					opt:          timeRFC3339Opt,
-					wantCborData: mustHexDecode("c074313936392d30332d32315432303a30343a30305a"), // "1969-03-21T20:04:00Z"
-				},
-				{
-					opt:          timeRFC3339NanoOpt,
-					wantCborData: mustHexDecode("c074313936392d30332d32315432303a30343a30305a"), // "1969-03-21T20:04:00Z"
-				},
-			},
-		},
-	}
-	for _, tc := range testCases {
-		for _, convert := range tc.convert {
-			var convertName string
-			switch convert.opt.Time {
-			case TimeUnix:
-				convertName = "TimeUnix"
-			case TimeUnixMicro:
-				convertName = "TimeUnixMicro"
-			case TimeUnixDynamic:
-				convertName = "TimeUnixDynamic"
-			case TimeRFC3339:
-				convertName = "TimeRFC3339"
-			case TimeRFC3339Nano:
-				convertName = "TimeRFC3339Nano"
-			}
-			name := tc.name + " with " + convertName + " option"
-			t.Run(name, func(t *testing.T) {
-				em, err := convert.opt.EncMode()
+				var tm time.Time
+				err = Unmarshal(b, &tm)
 				if err != nil {
-					t.Errorf("EncMode() returned error %v", err)
-				}
-				b, err := em.Marshal(tc.tm)
-				if err != nil {
-					t.Errorf("Marshal(%+v) returned error %v", tc.tm, err)
-				} else if !bytes.Equal(b, convert.wantCborData) {
-					t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.tm, b, convert.wantCborData)
+					t.Errorf("Unmarshal(0x%x) to time.Time returned error %v", b, err)
+				} else if convert.roundtrip {
+					if convert.opt.hasLocalOffset && tc.tm.Compare(tm) != 0 {
+						t.Errorf("failed to rountrip local time: want %s, got %s", tc.tm, tm)
+					}
+					if !convert.opt.hasLocalOffset && tc.tm.UTC().Compare(tm.UTC()) != 0 {
+						t.Errorf("failed to roundtrip UTC time: want %s, got %s", tc.tm, tm)
+					}
 				}
 			})
 		}
 	}
-}
-
-func parseTime(layout string, value string) time.Time {
-	tm, err := time.Parse(layout, value)
-	if err != nil {
-		panic(err)
-	}
-	return tm
 }
 
 func TestInvalidTimeMode(t *testing.T) {
@@ -6809,4 +7082,12 @@ func TestJSONMarshalerTranscoder(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustParseTime(layout string, value string) time.Time {
+	tm, err := time.Parse(layout, value)
+	if err != nil {
+		panic(err)
+	}
+	return tm
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -3728,6 +3728,9 @@ func TestMarshalStructKeyAsIntNumError(t *testing.T) {
 	type T2 struct {
 		F1 int `cbor:"-18446744073709551616,keyasint"`
 	}
+	type T3 struct {
+		F1 int `cbor:"99999999999999999999,keyasint"`
+	}
 	testCases := []struct {
 		name         string
 		obj          any
@@ -3739,9 +3742,14 @@ func TestMarshalStructKeyAsIntNumError(t *testing.T) {
 			wantErrorMsg: "cbor: failed to parse field name \"2.0\" to int",
 		},
 		{
-			name:         "out of range int as key",
+			name:         "int key < math.MinInt",
 			obj:          T2{},
 			wantErrorMsg: "cbor: failed to parse field name \"-18446744073709551616\" to int",
+		},
+		{
+			name:         "int key > math.MaxInt",
+			obj:          T3{},
+			wantErrorMsg: "cbor: failed to parse field name \"99999999999999999999\" to int",
 		},
 	}
 	for _, tc := range testCases {
@@ -7081,6 +7089,59 @@ func TestJSONMarshalerTranscoder(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMarshalerErrorUnwrap(t *testing.T) {
+	innerErr := errors.New("MarshalCBOR: error")
+	v := marshalCBORError(innerErr.Error())
+	_, err := Marshal(v)
+	if err == nil {
+		t.Fatal("Marshal() didn't return an error")
+	}
+	var me *MarshalerError
+	if errors.As(err, &me) {
+		if unwrapped := me.Unwrap(); unwrapped == nil || unwrapped.Error() != innerErr.Error() {
+			t.Errorf("MarshalerError.Unwrap() = %v, want error with message %q", unwrapped, innerErr.Error())
+		}
+	}
+	// The marshalCBORError type returns the raw error, not a MarshalerError,
+	// so also test Unwrap directly by constructing a MarshalerError.
+	me2 := &MarshalerError{typ: reflect.TypeOf(0), err: innerErr}
+	if unwrapped := me2.Unwrap(); unwrapped != innerErr {
+		t.Errorf("MarshalerError.Unwrap() = %v, want %v", unwrapped, innerErr)
+	}
+}
+
+func TestTranscodeErrorUnwrap(t *testing.T) {
+	innerErr := errors.New("transcode failed")
+	te := TranscodeError{err: innerErr, rtype: reflect.TypeOf(0), sourceFormat: "json", targetFormat: "cbor"}
+	if unwrapped := te.Unwrap(); unwrapped != innerErr {
+		t.Errorf("TranscodeError.Unwrap() = %v, want %v", unwrapped, innerErr)
+	}
+}
+
+func TestUnsupportedValueErrorMessage(t *testing.T) {
+	err := &UnsupportedValueError{msg: "floating-point infinity"}
+	want := "cbor: unsupported value: floating-point infinity"
+	if got := err.Error(); got != want {
+		t.Errorf("UnsupportedValueError.Error() = %q, want %q", got, want)
+	}
+}
+
+func TestMarshalToBufferNilBuffer(t *testing.T) {
+	// Test package-level function
+	if err := MarshalToBuffer(42, nil); err == nil {
+		t.Error("MarshalToBuffer(42, nil) didn't return an error")
+	}
+
+	// Test UserBufferEncMode method
+	bem, err := EncOptions{}.UserBufferEncMode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bem.MarshalToBuffer(42, nil); err == nil {
+		t.Error("UserBufferEncMode.MarshalToBuffer(42, nil) didn't return an error")
 	}
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -18,19 +18,19 @@ import (
 	"time"
 )
 
-type marshalTest struct {
+type marshalTestCase struct {
 	wantData []byte
 	values   []any
 }
 
-type marshalErrorTest struct {
+type marshalErrorTestCase struct {
 	name         string
 	value        any
 	wantErrorMsg string
 }
 
 // CBOR test data are from https://tools.ietf.org/html/rfc7049#appendix-A.
-var marshalTests = []marshalTest{
+var marshalTestCases = []marshalTestCase{
 	// unsigned integer
 	{
 		wantData: mustHexDecode("00"),
@@ -459,7 +459,7 @@ var marshalTests = []marshalTest{
 }
 
 func TestMarshal(t *testing.T) {
-	testMarshal(t, marshalTests)
+	testMarshal(t, marshalTestCases)
 }
 
 func TestInvalidTypeMarshal(t *testing.T) {
@@ -470,7 +470,7 @@ func TestInvalidTypeMarshal(t *testing.T) {
 		_    struct{} `cbor:",toarray"`
 		Chan chan bool
 	}
-	var marshalErrorTests = []marshalErrorTest{
+	var marshalErrorTestCases = []marshalErrorTestCase{
 		{
 			name:         "channel cannot be marshaled",
 			value:        make(chan bool),
@@ -516,7 +516,7 @@ func TestInvalidTypeMarshal(t *testing.T) {
 	if err != nil {
 		t.Errorf("EncMode() returned an error %v", err)
 	}
-	for _, tc := range marshalErrorTests {
+	for _, tc := range marshalErrorTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			v := tc.value
 			b, err := Marshal(&v)
@@ -548,7 +548,7 @@ func TestInvalidTypeMarshal(t *testing.T) {
 func TestMarshalLargeByteString(t *testing.T) {
 	// []byte{100, 100, 100, ...}
 	lengths := []int{0, 1, 2, 22, 23, 24, 254, 255, 256, 65534, 65535, 65536, 10000000}
-	tests := make([]marshalTest, len(lengths))
+	testCases := make([]marshalTestCase, len(lengths))
 	for i, length := range lengths {
 		data := bytes.NewBuffer(encodeCborHeader(cborTypeByteString, uint64(length)))
 		value := make([]byte, length)
@@ -556,16 +556,16 @@ func TestMarshalLargeByteString(t *testing.T) {
 			data.WriteByte(100)
 			value[j] = 100
 		}
-		tests[i] = marshalTest{data.Bytes(), []any{value}}
+		testCases[i] = marshalTestCase{data.Bytes(), []any{value}}
 	}
 
-	testMarshal(t, tests)
+	testMarshal(t, testCases)
 }
 
 func TestMarshalLargeTextString(t *testing.T) {
 	// "ddd..."
 	lengths := []int{0, 1, 2, 22, 23, 24, 254, 255, 256, 65534, 65535, 65536, 10000000}
-	tests := make([]marshalTest, len(lengths))
+	testCases := make([]marshalTestCase, len(lengths))
 	for i, length := range lengths {
 		data := bytes.NewBuffer(encodeCborHeader(cborTypeTextString, uint64(length)))
 		value := make([]byte, length)
@@ -573,16 +573,16 @@ func TestMarshalLargeTextString(t *testing.T) {
 			data.WriteByte(100)
 			value[j] = 100
 		}
-		tests[i] = marshalTest{data.Bytes(), []any{string(value)}}
+		testCases[i] = marshalTestCase{data.Bytes(), []any{string(value)}}
 	}
 
-	testMarshal(t, tests)
+	testMarshal(t, testCases)
 }
 
 func TestMarshalLargeArray(t *testing.T) {
 	// []string{"水", "水", "水", ...}
 	lengths := []int{0, 1, 2, 22, 23, 24, 254, 255, 256, 65534, 65535, 65536, 131072}
-	tests := make([]marshalTest, len(lengths))
+	testCases := make([]marshalTestCase, len(lengths))
 	for i, length := range lengths {
 		data := bytes.NewBuffer(encodeCborHeader(cborTypeArray, uint64(length)))
 		value := make([]string, length)
@@ -590,16 +590,16 @@ func TestMarshalLargeArray(t *testing.T) {
 			data.Write([]byte{0x63, 0xe6, 0xb0, 0xb4})
 			value[j] = "水"
 		}
-		tests[i] = marshalTest{data.Bytes(), []any{value}}
+		testCases[i] = marshalTestCase{data.Bytes(), []any{value}}
 	}
 
-	testMarshal(t, tests)
+	testMarshal(t, testCases)
 }
 
 func TestMarshalLargeMapCanonical(t *testing.T) {
 	// map[int]int {0:0, 1:1, 2:2, ...}
 	lengths := []int{0, 1, 2, 22, 23, 24, 254, 255, 256, 65534, 65535, 65536, 131072}
-	tests := make([]marshalTest, len(lengths))
+	testCases := make([]marshalTestCase, len(lengths))
 	for i, length := range lengths {
 		data := bytes.NewBuffer(encodeCborHeader(cborTypeMap, uint64(length)))
 		value := make(map[int]int, length)
@@ -609,10 +609,10 @@ func TestMarshalLargeMapCanonical(t *testing.T) {
 			data.Write(d)
 			value[j] = j
 		}
-		tests[i] = marshalTest{data.Bytes(), []any{value}}
+		testCases[i] = marshalTestCase{data.Bytes(), []any{value}}
 	}
 
-	testMarshal(t, tests)
+	testMarshal(t, testCases)
 }
 
 func TestMarshalLargeMap(t *testing.T) {
@@ -683,7 +683,7 @@ func encodeCborHeader(t cborType, n uint64) []byte {
 	return b[:]
 }
 
-func testMarshal(t *testing.T, testCases []marshalTest) {
+func testMarshal(t *testing.T, testCases []marshalTestCase) {
 	em, err := EncOptions{Sort: SortCanonical}.EncMode()
 	if err != nil {
 		t.Errorf("EncMode() returned an error %v", err)
@@ -828,7 +828,7 @@ func TestMarshalStructVariableLength(t *testing.T) {
 				t.Fatal(err)
 			}
 			if !bytes.Equal(tc.want, got) {
-				t.Errorf("want 0x%x but got 0x%x", tc.want, got)
+				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", tc.in, got, tc.want)
 			}
 		})
 	}
@@ -1301,10 +1301,10 @@ func TestOmitAndRenameStructField(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	tests := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{"default values", v1, want1},
 		{"non-default values", v2, want2}}
-	testRoundTrip(t, tests, em, dm)
+	testRoundTrip(t, testCases, em, dm)
 }
 
 func TestOmitEmptyForBuiltinType(t *testing.T) {
@@ -1345,7 +1345,7 @@ func TestOmitEmptyForBuiltinType(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 func TestOmitEmptyForAnonymousStruct(t *testing.T) {
@@ -1359,7 +1359,7 @@ func TestOmitEmptyForAnonymousStruct(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 func TestOmitEmptyForStruct1(t *testing.T) {
@@ -1384,7 +1384,7 @@ func TestOmitEmptyForStruct1(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 func TestOmitEmptyForStruct2(t *testing.T) {
@@ -1408,7 +1408,7 @@ func TestOmitEmptyForStruct2(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"non-default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"non-default values", v, want}}, em, dm)
 }
 
 func TestInvalidOmitEmptyMode(t *testing.T) {
@@ -1500,8 +1500,8 @@ func TestOmitEmptyMode(t *testing.T) {
 	emOmitEmptyGoValue, _ := EncOptions{OmitEmpty: OmitEmptyGoValue}.EncMode()
 	emOmitEmptyCBORValue, _ := EncOptions{OmitEmpty: OmitEmptyCBORValue}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"OmitEmptyGoValue (default) ", v, wantDataWithOmitEmptyGoValue}}, emOmitEmptyGoValue, dm)
-	testRoundTrip(t, []roundTripTest{{"OmitEmptyCBORValue", v, wantDataWithOmitEmptyCBORValue}}, emOmitEmptyCBORValue, dm)
+	testRoundTrip(t, []roundTripTestCase{{"OmitEmptyGoValue (default)", v, wantDataWithOmitEmptyGoValue}}, emOmitEmptyGoValue, dm)
+	testRoundTrip(t, []roundTripTestCase{{"OmitEmptyCBORValue", v, wantDataWithOmitEmptyCBORValue}}, emOmitEmptyCBORValue, dm)
 }
 
 func TestOmitEmptyForNestedStruct(t *testing.T) {
@@ -1529,7 +1529,7 @@ func TestOmitEmptyForNestedStruct(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 func TestOmitEmptyForToArrayStruct1(t *testing.T) {
@@ -1558,7 +1558,7 @@ func TestOmitEmptyForToArrayStruct1(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"no exportable fields", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"no exportable fields", v, want}}, em, dm)
 }
 
 func TestOmitEmptyForToArrayStruct2(t *testing.T) {
@@ -1584,7 +1584,7 @@ func TestOmitEmptyForToArrayStruct2(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"has exportable fields", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"has exportable fields", v, want}}, em, dm)
 }
 
 func TestOmitEmptyForStructWithPtrToAnonymousField(t *testing.T) {
@@ -1714,7 +1714,7 @@ func TestOmitEmptyForBinaryMarshaler1(t *testing.T) {
 		Stro T1 `cbor:"stro,omitempty"`
 	}
 
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			"empty BinaryMarshaler",
 			T1{},
@@ -1741,7 +1741,7 @@ func TestOmitEmptyForBinaryMarshaler2(t *testing.T) {
 		Stro T1 `cbor:"stro,omitempty"`
 	}
 
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			"empty BinaryMarshaler",
 			T1{},
@@ -1770,7 +1770,7 @@ func TestOmitEmptyForTime(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 // omitempty is a no-op for big.Int.
@@ -1784,7 +1784,7 @@ func TestOmitEmptyForBigInt(t *testing.T) {
 
 	em, _ := EncOptions{BigIntConvert: BigIntConvertNone}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 func TestOmitZeroForBuiltinType(t *testing.T) {
@@ -1825,7 +1825,7 @@ func TestOmitZeroForBuiltinType(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 func TestOmitZeroForAnonymousStruct(t *testing.T) {
@@ -1839,7 +1839,7 @@ func TestOmitZeroForAnonymousStruct(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 func TestOmitZeroForStruct1(t *testing.T) {
@@ -1864,7 +1864,7 @@ func TestOmitZeroForStruct1(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 func TestOmitZeroForStruct2(t *testing.T) {
@@ -1888,7 +1888,7 @@ func TestOmitZeroForStruct2(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"non-default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"non-default values", v, want}}, em, dm)
 }
 
 func TestOmitZeroForNestedStruct(t *testing.T) {
@@ -1916,7 +1916,7 @@ func TestOmitZeroForNestedStruct(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 func TestOmitZeroForToArrayStruct1(t *testing.T) {
@@ -1945,7 +1945,7 @@ func TestOmitZeroForToArrayStruct1(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"no exportable fields", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"no exportable fields", v, want}}, em, dm)
 }
 
 func TestOmitZeroForToArrayStruct2(t *testing.T) {
@@ -1971,7 +1971,7 @@ func TestOmitZeroForToArrayStruct2(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"has exportable fields", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"has exportable fields", v, want}}, em, dm)
 }
 
 func TestOmitZeroForStructWithPtrToAnonymousField(t *testing.T) {
@@ -2101,7 +2101,7 @@ func TestOmitZeroForBinaryMarshaler1(t *testing.T) {
 		Stro T1 `cbor:"stro,omitzero"`
 	}
 
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			"empty BinaryMarshaler",
 			T1{},
@@ -2128,7 +2128,7 @@ func TestOmitZeroForBinaryMarshaler2(t *testing.T) {
 		Stro T1 `cbor:"stro,omitzero"`
 	}
 
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			"empty BinaryMarshaler",
 			T1{},
@@ -2156,7 +2156,7 @@ func TestOmitZeroForTime(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 func TestOmitZeroForBigInt(t *testing.T) {
@@ -2169,257 +2169,257 @@ func TestOmitZeroForBigInt(t *testing.T) {
 
 	em, _ := EncOptions{BigIntConvert: BigIntConvertNone}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	testRoundTrip(t, []roundTripTest{{"default values", v, want}}, em, dm)
+	testRoundTrip(t, []roundTripTestCase{{"default values", v, want}}, em, dm)
 }
 
 func TestIsZero(t *testing.T) {
 	var zeroStructZeroer isZeroer = zeroTestTypeCustom{value: 42}
 
-	testcases := []struct {
+	testCases := []struct {
 		name string
 		t    reflect.Type
 		v    reflect.Value
 
-		expect    bool
-		expectErr bool
+		want       bool
+		wantHasErr bool
 	}{
 		{
-			name:   "nil",
-			t:      reflect.TypeOf(nil),
-			v:      reflect.ValueOf(nil),
-			expect: true,
+			name: "nil",
+			t:    reflect.TypeOf(nil),
+			v:    reflect.ValueOf(nil),
+			want: true,
 		},
 		{
-			name:   "string-zero",
-			t:      reflect.TypeOf(""),
-			v:      reflect.ValueOf(""),
-			expect: true,
-		},
-
-		{
-			name:   "string-nonzero",
-			t:      reflect.TypeOf(""),
-			v:      reflect.ValueOf("a"),
-			expect: false,
-		},
-		{
-			name:   "int-zero",
-			t:      reflect.TypeOf(0),
-			v:      reflect.ValueOf(0),
-			expect: true,
-		},
-		{
-			name:   "int-nonzero",
-			t:      reflect.TypeOf(0),
-			v:      reflect.ValueOf(1),
-			expect: false,
+			name: "string-zero",
+			t:    reflect.TypeOf(""),
+			v:    reflect.ValueOf(""),
+			want: true,
 		},
 
 		{
-			name:   "bool-zero",
-			t:      reflect.TypeOf(false),
-			v:      reflect.ValueOf(false),
-			expect: true,
+			name: "string-nonzero",
+			t:    reflect.TypeOf(""),
+			v:    reflect.ValueOf("a"),
+			want: false,
 		},
 		{
-			name:   "bool-nonzero",
-			t:      reflect.TypeOf(false),
-			v:      reflect.ValueOf(true),
-			expect: false,
-		},
-
-		{
-			name:   "slice-zero",
-			t:      reflect.TypeOf([]string(nil)),
-			v:      reflect.ValueOf([]string(nil)),
-			expect: true,
+			name: "int-zero",
+			t:    reflect.TypeOf(0),
+			v:    reflect.ValueOf(0),
+			want: true,
 		},
 		{
-			name:   "slice-nonzero",
-			t:      reflect.TypeOf([]string(nil)),
-			v:      reflect.ValueOf([]string{}),
-			expect: false,
+			name: "int-nonzero",
+			t:    reflect.TypeOf(0),
+			v:    reflect.ValueOf(1),
+			want: false,
 		},
 
 		{
-			name:   "map-zero",
-			t:      reflect.TypeOf(map[string]string(nil)),
-			v:      reflect.ValueOf(map[string]string(nil)),
-			expect: true,
+			name: "bool-zero",
+			t:    reflect.TypeOf(false),
+			v:    reflect.ValueOf(false),
+			want: true,
 		},
 		{
-			name:   "map-nonzero",
-			t:      reflect.TypeOf(map[string]string(nil)),
-			v:      reflect.ValueOf(map[string]string{}),
-			expect: false,
-		},
-
-		{
-			name:   "struct-zero",
-			t:      reflect.TypeOf(zeroTestType{}),
-			v:      reflect.ValueOf(zeroTestType{}),
-			expect: true,
-		},
-		{
-			name:   "struct-nonzero",
-			t:      reflect.TypeOf(zeroTestType{}),
-			v:      reflect.ValueOf(zeroTestType{value: 42}),
-			expect: false,
+			name: "bool-nonzero",
+			t:    reflect.TypeOf(false),
+			v:    reflect.ValueOf(true),
+			want: false,
 		},
 
 		{
-			name:   "pointer-zero",
-			t:      reflect.TypeOf((*zeroTestType)(nil)),
-			v:      reflect.ValueOf((*zeroTestType)(nil)),
-			expect: true,
+			name: "slice-zero",
+			t:    reflect.TypeOf([]string(nil)),
+			v:    reflect.ValueOf([]string(nil)),
+			want: true,
 		},
 		{
-			name:   "pointer-nonzero",
-			t:      reflect.TypeOf((*zeroTestType)(nil)),
-			v:      reflect.ValueOf(&zeroTestType{}),
-			expect: false,
-		},
-
-		{
-			name:   "any-struct-zero",
-			t:      reflect.TypeOf(any(nil)),
-			v:      reflect.ValueOf(zeroTestType{}),
-			expect: true,
-		},
-		{
-			name:   "any-struct-nonzero",
-			t:      reflect.TypeOf(any(nil)),
-			v:      reflect.ValueOf(zeroTestType{value: 42}),
-			expect: false,
+			name: "slice-nonzero",
+			t:    reflect.TypeOf([]string(nil)),
+			v:    reflect.ValueOf([]string{}),
+			want: false,
 		},
 
 		{
-			name:   "any-pointer-zero",
-			t:      reflect.TypeOf(any(nil)),
-			v:      reflect.ValueOf((*zeroTestType)(nil)),
-			expect: true,
+			name: "map-zero",
+			t:    reflect.TypeOf(map[string]string(nil)),
+			v:    reflect.ValueOf(map[string]string(nil)),
+			want: true,
 		},
 		{
-			name:   "any-pointer-nonzero",
-			t:      reflect.TypeOf(any(nil)),
-			v:      reflect.ValueOf(&zeroTestType{}),
-			expect: false,
-		},
-
-		{
-			name:   "custom-structreceiver-zero-structvalue",
-			t:      reflect.TypeOf(zeroTestTypeCustom{}),
-			v:      reflect.ValueOf(zeroTestTypeCustom{value: 42}),
-			expect: true,
-		},
-		{
-			name:   "custom-structreceiver-nonzero-structvalue",
-			t:      reflect.TypeOf(zeroTestTypeCustom{}),
-			v:      reflect.ValueOf(zeroTestTypeCustom{value: 1}),
-			expect: false,
-		},
-		{
-			name:   "custom-structreceiver-zero-pointervalue",
-			t:      reflect.TypeOf(zeroTestTypeCustom{}),
-			v:      reflect.ValueOf(&zeroTestTypeCustom{value: 42}),
-			expect: true,
-		},
-		{
-			name:   "custom-structreceiver-nonzero-pointervalue",
-			t:      reflect.TypeOf(zeroTestTypeCustom{}),
-			v:      reflect.ValueOf(&zeroTestTypeCustom{value: 1}),
-			expect: false,
+			name: "map-nonzero",
+			t:    reflect.TypeOf(map[string]string(nil)),
+			v:    reflect.ValueOf(map[string]string{}),
+			want: false,
 		},
 
 		{
-			name:   "custom-structreceiver-zero-pointervalue",
-			t:      reflect.TypeOf(&zeroTestTypeCustom{}),
-			v:      reflect.ValueOf(&zeroTestTypeCustom{value: 42}),
-			expect: true,
+			name: "struct-zero",
+			t:    reflect.TypeOf(zeroTestType{}),
+			v:    reflect.ValueOf(zeroTestType{}),
+			want: true,
 		},
 		{
-			name:   "custom-structreceiver-nonzero-pointervalue",
-			t:      reflect.TypeOf(&zeroTestTypeCustom{}),
-			v:      reflect.ValueOf(&zeroTestTypeCustom{value: 1}),
-			expect: false,
-		},
-		{
-			name:   "custom-structreceiver-zero-nil-pointervalue",
-			t:      reflect.TypeOf(&zeroTestTypeCustom{}),
-			v:      reflect.ValueOf((*zeroTestTypeCustom)(nil)),
-			expect: true,
+			name: "struct-nonzero",
+			t:    reflect.TypeOf(zeroTestType{}),
+			v:    reflect.ValueOf(zeroTestType{value: 42}),
+			want: false,
 		},
 
 		{
-			name:   "custom-pointerreceiver-zero-structvalue",
-			t:      reflect.TypeOf(zeroTestTypeCustomPointer{}),
-			v:      reflect.ValueOf(zeroTestTypeCustomPointer{value: 42}),
-			expect: true,
+			name: "pointer-zero",
+			t:    reflect.TypeOf((*zeroTestType)(nil)),
+			v:    reflect.ValueOf((*zeroTestType)(nil)),
+			want: true,
 		},
 		{
-			name:   "custom-pointerreceiver-nonzero-structvalue",
-			t:      reflect.TypeOf(zeroTestTypeCustomPointer{}),
-			v:      reflect.ValueOf(zeroTestTypeCustomPointer{value: 1}),
-			expect: false,
-		},
-
-		{
-			name:   "custom-pointerreceiver-zero-pointervalue",
-			t:      reflect.TypeOf(&zeroTestTypeCustomPointer{}),
-			v:      reflect.ValueOf(&zeroTestTypeCustomPointer{value: 42}),
-			expect: true,
-		},
-		{
-			name:   "custom-pointerreceiver-nonzero-pointervalue",
-			t:      reflect.TypeOf(&zeroTestTypeCustomPointer{}),
-			v:      reflect.ValueOf(&zeroTestTypeCustomPointer{value: 1}),
-			expect: false,
+			name: "pointer-nonzero",
+			t:    reflect.TypeOf((*zeroTestType)(nil)),
+			v:    reflect.ValueOf(&zeroTestType{}),
+			want: false,
 		},
 
 		{
-			name:   "custom-interface-nil-pointer",
-			t:      isZeroerType,
-			v:      reflect.ValueOf((*zeroTestTypeCustom)(nil)),
-			expect: true,
+			name: "any-struct-zero",
+			t:    reflect.TypeOf(any(nil)),
+			v:    reflect.ValueOf(zeroTestType{}),
+			want: true,
 		},
 		{
-			name:   "custom-interface-zero-structreceiver-pointer",
-			t:      isZeroerType,
-			v:      reflect.ValueOf(&zeroTestTypeCustom{value: 42}),
-			expect: true,
+			name: "any-struct-nonzero",
+			t:    reflect.TypeOf(any(nil)),
+			v:    reflect.ValueOf(zeroTestType{value: 42}),
+			want: false,
+		},
+
+		{
+			name: "any-pointer-zero",
+			t:    reflect.TypeOf(any(nil)),
+			v:    reflect.ValueOf((*zeroTestType)(nil)),
+			want: true,
 		},
 		{
-			name:   "custom-interface-zero-structreceiver",
-			t:      isZeroerType,
-			v:      reflect.ValueOf(zeroStructZeroer),
-			expect: true,
+			name: "any-pointer-nonzero",
+			t:    reflect.TypeOf(any(nil)),
+			v:    reflect.ValueOf(&zeroTestType{}),
+			want: false,
+		},
+
+		{
+			name: "custom-structreceiver-zero-structvalue",
+			t:    reflect.TypeOf(zeroTestTypeCustom{}),
+			v:    reflect.ValueOf(zeroTestTypeCustom{value: 42}),
+			want: true,
 		},
 		{
-			name:   "custom-interface-nonzero-struct",
-			t:      isZeroerType,
-			v:      reflect.ValueOf(&zeroTestTypeCustom{value: 1}),
-			expect: false,
+			name: "custom-structreceiver-nonzero-structvalue",
+			t:    reflect.TypeOf(zeroTestTypeCustom{}),
+			v:    reflect.ValueOf(zeroTestTypeCustom{value: 1}),
+			want: false,
 		},
 		{
-			name:   "custom-interface-nil-pointerreceiver",
-			t:      isZeroerType,
-			v:      reflect.ValueOf((*zeroTestTypeCustomPointer)(nil)),
-			expect: true,
+			name: "custom-structreceiver-zero-pointervalue",
+			t:    reflect.TypeOf(zeroTestTypeCustom{}),
+			v:    reflect.ValueOf(&zeroTestTypeCustom{value: 42}),
+			want: true,
 		},
 		{
-			name:   "custom-interface-zero-pointerreceiver",
-			t:      isZeroerType,
-			v:      reflect.ValueOf(&zeroTestTypeCustomPointer{value: 42}),
-			expect: true,
+			name: "custom-structreceiver-nonzero-pointervalue",
+			t:    reflect.TypeOf(zeroTestTypeCustom{}),
+			v:    reflect.ValueOf(&zeroTestTypeCustom{value: 1}),
+			want: false,
+		},
+
+		{
+			name: "custom-structreceiver-zero-pointervalue",
+			t:    reflect.TypeOf(&zeroTestTypeCustom{}),
+			v:    reflect.ValueOf(&zeroTestTypeCustom{value: 42}),
+			want: true,
 		},
 		{
-			name:   "custom-interface-nonzero-pointerreceiver",
-			t:      isZeroerType,
-			v:      reflect.ValueOf(&zeroTestTypeCustomPointer{value: 1}),
-			expect: false,
+			name: "custom-structreceiver-nonzero-pointervalue",
+			t:    reflect.TypeOf(&zeroTestTypeCustom{}),
+			v:    reflect.ValueOf(&zeroTestTypeCustom{value: 1}),
+			want: false,
+		},
+		{
+			name: "custom-structreceiver-zero-nil-pointervalue",
+			t:    reflect.TypeOf(&zeroTestTypeCustom{}),
+			v:    reflect.ValueOf((*zeroTestTypeCustom)(nil)),
+			want: true,
+		},
+
+		{
+			name: "custom-pointerreceiver-zero-structvalue",
+			t:    reflect.TypeOf(zeroTestTypeCustomPointer{}),
+			v:    reflect.ValueOf(zeroTestTypeCustomPointer{value: 42}),
+			want: true,
+		},
+		{
+			name: "custom-pointerreceiver-nonzero-structvalue",
+			t:    reflect.TypeOf(zeroTestTypeCustomPointer{}),
+			v:    reflect.ValueOf(zeroTestTypeCustomPointer{value: 1}),
+			want: false,
+		},
+
+		{
+			name: "custom-pointerreceiver-zero-pointervalue",
+			t:    reflect.TypeOf(&zeroTestTypeCustomPointer{}),
+			v:    reflect.ValueOf(&zeroTestTypeCustomPointer{value: 42}),
+			want: true,
+		},
+		{
+			name: "custom-pointerreceiver-nonzero-pointervalue",
+			t:    reflect.TypeOf(&zeroTestTypeCustomPointer{}),
+			v:    reflect.ValueOf(&zeroTestTypeCustomPointer{value: 1}),
+			want: false,
+		},
+
+		{
+			name: "custom-interface-nil-pointer",
+			t:    isZeroerType,
+			v:    reflect.ValueOf((*zeroTestTypeCustom)(nil)),
+			want: true,
+		},
+		{
+			name: "custom-interface-zero-structreceiver-pointer",
+			t:    isZeroerType,
+			v:    reflect.ValueOf(&zeroTestTypeCustom{value: 42}),
+			want: true,
+		},
+		{
+			name: "custom-interface-zero-structreceiver",
+			t:    isZeroerType,
+			v:    reflect.ValueOf(zeroStructZeroer),
+			want: true,
+		},
+		{
+			name: "custom-interface-nonzero-struct",
+			t:    isZeroerType,
+			v:    reflect.ValueOf(&zeroTestTypeCustom{value: 1}),
+			want: false,
+		},
+		{
+			name: "custom-interface-nil-pointerreceiver",
+			t:    isZeroerType,
+			v:    reflect.ValueOf((*zeroTestTypeCustomPointer)(nil)),
+			want: true,
+		},
+		{
+			name: "custom-interface-zero-pointerreceiver",
+			t:    isZeroerType,
+			v:    reflect.ValueOf(&zeroTestTypeCustomPointer{value: 42}),
+			want: true,
+		},
+		{
+			name: "custom-interface-nonzero-pointerreceiver",
+			t:    isZeroerType,
+			v:    reflect.ValueOf(&zeroTestTypeCustomPointer{value: 1}),
+			want: false,
 		},
 	}
-	for _, tc := range testcases {
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			defer func() {
 				if err := recover(); err != nil {
@@ -2428,11 +2428,11 @@ func TestIsZero(t *testing.T) {
 				}
 			}()
 			got, err := getIsZeroFunc(tc.t)(tc.v)
-			if tc.expectErr != (err != nil) {
-				t.Errorf("got err=%v, expected %v", err, tc.expectErr)
+			if tc.wantHasErr != (err != nil) {
+				t.Errorf("getIsZeroFunc() returned err=%v, wantErr=%v", err, tc.wantHasErr)
 			}
-			if tc.expect != got {
-				t.Errorf("got %v, expected %v", got, tc.expect)
+			if tc.want != got {
+				t.Errorf("getIsZeroFunc() returned %v, want %v", got, tc.want)
 			}
 		})
 	}
@@ -2466,7 +2466,7 @@ func TestJSONStdlibOmitZero(t *testing.T) {
 		S string `json:"s,omitzero"`
 	}
 
-	testcases := []struct {
+	testCases := []struct {
 		name   string
 		stdlib bool
 		obj    any
@@ -2513,7 +2513,7 @@ func TestJSONStdlibOmitZero(t *testing.T) {
 		})
 	}
 
-	for _, tc := range testcases {
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			reset()
 			jsonStdlibSupportsOmitzero = tc.stdlib
@@ -2521,7 +2521,7 @@ func TestJSONStdlibOmitZero(t *testing.T) {
 
 			em, _ := EncOptions{}.EncMode()
 			dm, _ := DecOptions{}.DecMode()
-			testRoundTrip(t, []roundTripTest{{tc.name, tc.obj, tc.want}}, em, dm)
+			testRoundTrip(t, []roundTripTestCase{{tc.name, tc.obj, tc.want}}, em, dm)
 		})
 	}
 }
@@ -3413,7 +3413,7 @@ func TestMarshalRawMessageValue(t *testing.T) {
 		raw      = RawMessage([]byte{0x01})
 	)
 
-	tests := []struct {
+	testCases := []struct {
 		obj  any
 		want []byte
 	}{
@@ -3640,7 +3640,7 @@ func TestMarshalRawMessageValue(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
+	for _, tc := range testCases {
 		b, err := Marshal(tc.obj)
 		if err != nil {
 			t.Errorf("Marshal(%+v) returned error %v", tc.obj, err)
@@ -3686,12 +3686,12 @@ func TestMarshalUnmarshalStructKeyAsInt(t *testing.T) {
 		wantCborData []byte
 	}{
 		{
-			name:         "Zero value struct",
+			name:         "zero value struct",
 			obj:          T{},
 			wantCborData: mustHexDecode("a0"), // {}
 		},
 		{
-			name:         "Initialized value struct",
+			name:         "initialized value struct",
 			obj:          T{F1: 1, F2: 2, F3: 3},
 			wantCborData: mustHexDecode("a301012203613202"), // {1: 1, -3: 3, "2": 2}
 		},
@@ -3787,17 +3787,17 @@ func TestMarshalUnmarshalStructToArray(t *testing.T) {
 		wantCborData []byte
 	}{
 		{
-			name:         "Zero value struct (test omitempty)",
+			name:         "zero value struct (test omitempty)",
 			obj:          T{},
 			wantCborData: mustHexDecode("8500a000f6f6"), // [0, {}, 0, nil, nil]
 		},
 		{
-			name:         "Initialized struct",
+			name:         "initialized struct",
 			obj:          T{A: 24, B: T1{M: 1}, T1: T1{M: 2}, T2: &T2{N: 3, O: 4}},
 			wantCborData: mustHexDecode("851818a1614d01020304"), // [24, {M: 1}, 2, 3, 4]
 		},
 		{
-			name:         "Null pointer to embedded struct",
+			name:         "null pointer to embedded struct",
 			obj:          T{A: 24, B: T1{M: 1}, T1: T1{M: 2}},
 			wantCborData: mustHexDecode("851818a1614d0102f6f6"), // [24, {M: 1}, 2, nil, nil]
 		},
@@ -3862,12 +3862,12 @@ func TestMapSort(t *testing.T) {
 		wantCborData []byte
 	}{
 		{
-			name:         "Length first sort",
+			name:         "length first sort",
 			opts:         EncOptions{Sort: SortLengthFirst},
 			wantCborData: lenFirstSortedCborData,
 		},
 		{
-			name:         "Bytewise sort",
+			name:         "bytewise sort",
 			opts:         EncOptions{Sort: SortBytewiseLexical},
 			wantCborData: bytewiseSortedCborData,
 		},
@@ -3882,7 +3882,7 @@ func TestMapSort(t *testing.T) {
 			wantCborData: bytewiseSortedCborData,
 		},
 		{
-			name:         "Core deterministic sort",
+			name:         "core deterministic sort",
 			opts:         EncOptions{Sort: SortCoreDeterministic},
 			wantCborData: bytewiseSortedCborData,
 		},
@@ -3924,22 +3924,22 @@ func TestStructSort(t *testing.T) {
 		wantCborData []byte
 	}{
 		{
-			name:         "No sort",
+			name:         "no sort",
 			opts:         EncOptions{},
 			wantCborData: unsortedCborData,
 		},
 		{
-			name:         "No sort",
+			name:         "no sort",
 			opts:         EncOptions{Sort: SortNone},
 			wantCborData: unsortedCborData,
 		},
 		{
-			name:         "Length first sort",
+			name:         "length first sort",
 			opts:         EncOptions{Sort: SortLengthFirst},
 			wantCborData: lenFirstSortedCborData,
 		},
 		{
-			name:         "Bytewise sort",
+			name:         "bytewise sort",
 			opts:         EncOptions{Sort: SortBytewiseLexical},
 			wantCborData: bytewiseSortedCborData,
 		},
@@ -3954,7 +3954,7 @@ func TestStructSort(t *testing.T) {
 			wantCborData: bytewiseSortedCborData,
 		},
 		{
-			name:         "Core deterministic sort",
+			name:         "core deterministic sort",
 			opts:         EncOptions{Sort: SortCoreDeterministic},
 			wantCborData: bytewiseSortedCborData,
 		},
@@ -4024,7 +4024,7 @@ func TestTypeAlias(t *testing.T) { //nolint:dupl,unconvert
 	type myIntArray = [4]int
 	type myMapIntInt = map[int]int
 
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			name:         "bool alias",
 			obj:          myBool(true),
@@ -4147,7 +4147,7 @@ func TestNewTypeWithBuiltinUnderlyingType(t *testing.T) { //nolint:dupl
 	type myIntArray [4]int
 	type myMapIntInt map[int]int
 
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			name:         "bool alias",
 			obj:          myBool(true),
@@ -4258,77 +4258,77 @@ func TestShortestFloat16(t *testing.T) {
 	}{
 		// Data from RFC 7049 appendix A
 		{
-			name:         "Shrink to float16",
+			name:         "shrink to float16",
 			f64:          0.0,
 			wantCborData: mustHexDecode("f90000"),
 		},
 		{
-			name:         "Shrink to float16",
+			name:         "shrink to float16",
 			f64:          1.0,
 			wantCborData: mustHexDecode("f93c00"),
 		},
 		{
-			name:         "Shrink to float16",
+			name:         "shrink to float16",
 			f64:          1.5,
 			wantCborData: mustHexDecode("f93e00"),
 		},
 		{
-			name:         "Shrink to float16",
+			name:         "shrink to float16",
 			f64:          65504.0,
 			wantCborData: mustHexDecode("f97bff"),
 		},
 		{
-			name:         "Shrink to float16",
+			name:         "shrink to float16",
 			f64:          5.960464477539063e-08,
 			wantCborData: mustHexDecode("f90001"),
 		},
 		{
-			name:         "Shrink to float16",
+			name:         "shrink to float16",
 			f64:          6.103515625e-05,
 			wantCborData: mustHexDecode("f90400"),
 		},
 		{
-			name:         "Shrink to float16",
+			name:         "shrink to float16",
 			f64:          -4.0,
 			wantCborData: mustHexDecode("f9c400"),
 		},
 		// Data from https://en.wikipedia.org/wiki/Half-precision_floating-point_format
 		{
-			name:         "Shrink to float16",
+			name:         "shrink to float16",
 			f64:          0.333251953125,
 			wantCborData: mustHexDecode("f93555"),
 		},
 		// Data from 7049bis 4.2.1 and 5.5
 		{
-			name:         "Shrink to float16",
+			name:         "shrink to float16",
 			f64:          5.5,
 			wantCborData: mustHexDecode("f94580"),
 		},
 		// Data from RFC 7049 appendix A
 		{
-			name:         "Shrink to float32",
+			name:         "shrink to float32",
 			f64:          100000.0,
 			wantCborData: mustHexDecode("fa47c35000"),
 		},
 		{
-			name:         "Shrink to float32",
+			name:         "shrink to float32",
 			f64:          3.4028234663852886e+38,
 			wantCborData: mustHexDecode("fa7f7fffff"),
 		},
 		// Data from 7049bis 4.2.1 and 5.5
 		{
-			name:         "Shrink to float32",
+			name:         "shrink to float32",
 			f64:          5555.5,
 			wantCborData: mustHexDecode("fa45ad9c00"),
 		},
 		{
-			name:         "Shrink to float32",
+			name:         "shrink to float32",
 			f64:          1000000.5,
 			wantCborData: mustHexDecode("fa49742408"),
 		},
 		// Data from RFC 7049 appendix A
 		{
-			name:         "Shrink to float64",
+			name:         "shrink to float64",
 			f64:          1.0e+300,
 			wantCborData: mustHexDecode("fb7e37e43c8800759c"),
 		},
@@ -4646,7 +4646,7 @@ func TestInfConvert(t *testing.T) {
 			}
 			want := &UnsupportedValueError{msg: "floating-point infinity"}
 			if _, got := em.Marshal(tc.v); !reflect.DeepEqual(want, got) {
-				t.Errorf("expected Marshal(%v) to return error: %v, got: %v", tc.v, want, got)
+				t.Errorf("Marshal(%v) returned error %v, want %v", tc.v, got, want)
 			}
 		})
 	}
@@ -5323,7 +5323,7 @@ func TestNaNConvert(t *testing.T) {
 			}
 			want := &UnsupportedValueError{msg: "floating-point NaN"}
 			if _, got := em.Marshal(tc.v); !reflect.DeepEqual(want, got) {
-				t.Errorf("expected Marshal(%v) to return error: %v, got: %v", tc.v, want, got)
+				t.Errorf("Marshal(%v) returned error %v, want %v", tc.v, got, want)
 			}
 		})
 	}
@@ -5753,7 +5753,7 @@ func TestEncModeInvalidFieldNameMode(t *testing.T) {
 }
 
 func TestEncIndefiniteLengthOption(t *testing.T) {
-	// Default option allows indefinite length items
+	// Default option allows indefinite-length items
 	var buf bytes.Buffer
 	enc := NewEncoder(&buf)
 	if err := enc.StartIndefiniteByteString(); err != nil {
@@ -6032,10 +6032,10 @@ func TestStructWithSimpleValueFields(t *testing.T) {
 
 	em, _ := EncOptions{}.EncMode()
 	dm, _ := DecOptions{}.DecMode()
-	tests := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{"default values", v1, want1},
 		{"non-default values", v2, want2}}
-	testRoundTrip(t, tests, em, dm)
+	testRoundTrip(t, testCases, em, dm)
 }
 
 func TestMapWithSimpleValueKey(t *testing.T) {
@@ -6285,13 +6285,13 @@ func TestMarshalerReturnsDisallowedCBORData(t *testing.T) {
 		wantErrorMsg string
 	}{
 		{
-			name:         "enc mode forbids indefinite length, data has indefinite length",
+			name:         "enc mode forbids indefinite-length, data has indefinite-length",
 			encOpts:      EncOptions{IndefLength: IndefLengthForbidden},
 			value:        marshaler{data: mustHexDecode("5f42010243030405ff")},
 			wantErrorMsg: "cbor: error calling MarshalCBOR for type cbor.marshaler: cbor: indefinite-length byte string isn't allowed",
 		},
 		{
-			name:    "enc mode allows indefinite length, data has indefinite length",
+			name:    "enc mode allows indefinite-length, data has indefinite-length",
 			encOpts: EncOptions{IndefLength: IndefLengthAllowed},
 			value:   marshaler{data: mustHexDecode("5f42010243030405ff")},
 		},
@@ -6459,28 +6459,28 @@ func TestInvalidByteArray(t *testing.T) {
 
 func TestMarshalByteArrayMode(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		opts     EncOptions
-		in       any
-		expected []byte
+		name string
+		opts EncOptions
+		in   any
+		want []byte
 	}{
 		{
-			name:     "byte array treated as byte slice by default",
-			opts:     EncOptions{},
-			in:       [1]byte{},
-			expected: []byte{0x41, 0x00},
+			name: "byte array treated as byte slice by default",
+			opts: EncOptions{},
+			in:   [1]byte{},
+			want: []byte{0x41, 0x00},
 		},
 		{
-			name:     "byte array treated as byte slice with ByteArrayAsByteSlice",
-			opts:     EncOptions{ByteArray: ByteArrayToByteSlice},
-			in:       [1]byte{},
-			expected: []byte{0x41, 0x00},
+			name: "byte array treated as byte slice with ByteArrayAsByteSlice",
+			opts: EncOptions{ByteArray: ByteArrayToByteSlice},
+			in:   [1]byte{},
+			want: []byte{0x41, 0x00},
 		},
 		{
-			name:     "byte array treated as array of integers with ByteArrayToArray",
-			opts:     EncOptions{ByteArray: ByteArrayToArray},
-			in:       [1]byte{},
-			expected: []byte{0x81, 0x00},
+			name: "byte array treated as array of integers with ByteArrayToArray",
+			opts: EncOptions{ByteArray: ByteArrayToArray},
+			in:   [1]byte{},
+			want: []byte{0x81, 0x00},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -6494,8 +6494,8 @@ func TestMarshalByteArrayMode(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal(out, tc.expected) {
-				t.Errorf("unexpected output, got 0x%x want 0x%x", out, tc.expected)
+			if !bytes.Equal(out, tc.want) {
+				t.Errorf("unexpected output, got 0x%x want 0x%x", out, tc.want)
 			}
 		})
 	}
@@ -6509,69 +6509,69 @@ func TestMarshalByteSliceMode(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name     string
-		tags     TagSet
-		opts     EncOptions
-		in       any
-		expected []byte
+		name string
+		tags TagSet
+		opts EncOptions
+		in   any
+		want []byte
 	}{
 		{
-			name:     "byte slice marshals to byte string by default",
-			opts:     EncOptions{},
-			in:       []byte{0xbb},
-			expected: []byte{0x41, 0xbb},
+			name: "byte slice marshals to byte string by default",
+			opts: EncOptions{},
+			in:   []byte{0xbb},
+			want: []byte{0x41, 0xbb},
 		},
 		{
-			name:     "byte slice marshals to byte string by with ByteSliceToByteString",
-			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatNone},
-			in:       []byte{0xbb},
-			expected: []byte{0x41, 0xbb},
+			name: "byte slice marshals to byte string by with ByteSliceToByteString",
+			opts: EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatNone},
+			in:   []byte{0xbb},
+			want: []byte{0x41, 0xbb},
 		},
 		{
-			name:     "byte slice marshaled to byte string enclosed in base64url expected encoding tag",
-			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64URL},
-			in:       []byte{0xbb},
-			expected: []byte{0xd5, 0x41, 0xbb},
+			name: "byte slice marshaled to byte string enclosed in base64url expected encoding tag",
+			opts: EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64URL},
+			in:   []byte{0xbb},
+			want: []byte{0xd5, 0x41, 0xbb},
 		},
 		{
-			name:     "byte slice marshaled to byte string enclosed in base64 expected encoding tag",
-			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64},
-			in:       []byte{0xbb},
-			expected: []byte{0xd6, 0x41, 0xbb},
+			name: "byte slice marshaled to byte string enclosed in base64 expected encoding tag",
+			opts: EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64},
+			in:   []byte{0xbb},
+			want: []byte{0xd6, 0x41, 0xbb},
 		},
 		{
-			name:     "byte slice marshaled to byte string enclosed in base16 expected encoding tag",
-			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase16},
-			in:       []byte{0xbb},
-			expected: []byte{0xd7, 0x41, 0xbb},
+			name: "byte slice marshaled to byte string enclosed in base16 expected encoding tag",
+			opts: EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase16},
+			in:   []byte{0xbb},
+			want: []byte{0xd7, 0x41, 0xbb},
 		},
 		{
-			name:     "user-registered tag numbers are encoded with no expected encoding tag",
-			tags:     ts,
-			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatNone},
-			in:       namedByteSlice{0xbb},
-			expected: []byte{0xd8, 0xcc, 0x41, 0xbb},
+			name: "user-registered tag numbers are encoded with no expected encoding tag",
+			tags: ts,
+			opts: EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatNone},
+			in:   namedByteSlice{0xbb},
+			want: []byte{0xd8, 0xcc, 0x41, 0xbb},
 		},
 		{
-			name:     "user-registered tag numbers are encoded after base64url expected encoding tag",
-			tags:     ts,
-			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64URL},
-			in:       namedByteSlice{0xbb},
-			expected: []byte{0xd5, 0xd8, 0xcc, 0x41, 0xbb},
+			name: "user-registered tag numbers are encoded after base64url expected encoding tag",
+			tags: ts,
+			opts: EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64URL},
+			in:   namedByteSlice{0xbb},
+			want: []byte{0xd5, 0xd8, 0xcc, 0x41, 0xbb},
 		},
 		{
-			name:     "user-registered tag numbers are encoded after base64 expected encoding tag",
-			tags:     ts,
-			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64},
-			in:       namedByteSlice{0xbb},
-			expected: []byte{0xd6, 0xd8, 0xcc, 0x41, 0xbb},
+			name: "user-registered tag numbers are encoded after base64 expected encoding tag",
+			tags: ts,
+			opts: EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase64},
+			in:   namedByteSlice{0xbb},
+			want: []byte{0xd6, 0xd8, 0xcc, 0x41, 0xbb},
 		},
 		{
-			name:     "user-registered tag numbers are encoded after base16 expected encoding tag",
-			tags:     ts,
-			opts:     EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase16},
-			in:       namedByteSlice{0xbb},
-			expected: []byte{0xd7, 0xd8, 0xcc, 0x41, 0xbb},
+			name: "user-registered tag numbers are encoded after base16 expected encoding tag",
+			tags: ts,
+			opts: EncOptions{ByteSliceLaterFormat: ByteSliceLaterFormatBase16},
+			in:   namedByteSlice{0xbb},
+			want: []byte{0xd7, 0xd8, 0xcc, 0x41, 0xbb},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -6593,8 +6593,8 @@ func TestMarshalByteSliceMode(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal(out, tc.expected) {
-				t.Errorf("unexpected output, got 0x%x want 0x%x", out, tc.expected)
+			if !bytes.Equal(out, tc.want) {
+				t.Errorf("unexpected output, got 0x%x want 0x%x", out, tc.want)
 			}
 		})
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -184,11 +184,11 @@ func ExampleEncoder() {
 }
 
 // ExampleEncoder_indefiniteLengthByteString encodes a stream of definite
-// length byte string ("chunks") as an indefinite length byte string.
+// length byte string ("chunks") as an indefinite-length byte string.
 func ExampleEncoder_indefiniteLengthByteString() {
 	var buf bytes.Buffer
 	encoder := cbor.NewEncoder(&buf)
-	// Start indefinite length byte string encoding.
+	// Start indefinite-length byte string encoding.
 	if err := encoder.StartIndefiniteByteString(); err != nil {
 		fmt.Println("error:", err)
 	}
@@ -200,7 +200,7 @@ func ExampleEncoder_indefiniteLengthByteString() {
 	if err := encoder.Encode([3]byte{3, 4, 5}); err != nil {
 		fmt.Println("error:", err)
 	}
-	// Close indefinite length byte string.
+	// Close indefinite-length byte string.
 	if err := encoder.EndIndefinite(); err != nil {
 		fmt.Println("error:", err)
 	}
@@ -210,11 +210,11 @@ func ExampleEncoder_indefiniteLengthByteString() {
 }
 
 // ExampleEncoder_indefiniteLengthTextString encodes a stream of definite
-// length text string ("chunks") as an indefinite length text string.
+// length text string ("chunks") as an indefinite-length text string.
 func ExampleEncoder_indefiniteLengthTextString() {
 	var buf bytes.Buffer
 	encoder := cbor.NewEncoder(&buf)
-	// Start indefinite length text string encoding.
+	// Start indefinite-length text string encoding.
 	if err := encoder.StartIndefiniteTextString(); err != nil {
 		fmt.Println("error:", err)
 	}
@@ -226,7 +226,7 @@ func ExampleEncoder_indefiniteLengthTextString() {
 	if err := encoder.Encode("ming"); err != nil {
 		fmt.Println("error:", err)
 	}
-	// Close indefinite length text string.
+	// Close indefinite-length text string.
 	if err := encoder.EndIndefinite(); err != nil {
 		fmt.Println("error:", err)
 	}
@@ -236,11 +236,11 @@ func ExampleEncoder_indefiniteLengthTextString() {
 }
 
 // ExampleEncoder_indefiniteLengthArray encodes a stream of elements as an
-// indefinite length array.  Encoder supports nested indefinite length values.
+// indefinite-length array.  Encoder supports nested indefinite-length values.
 func ExampleEncoder_indefiniteLengthArray() {
 	var buf bytes.Buffer
 	enc := cbor.NewEncoder(&buf)
-	// Start indefinite length array encoding.
+	// Start indefinite-length array encoding.
 	if err := enc.StartIndefiniteArray(); err != nil {
 		fmt.Println("error:", err)
 	}
@@ -252,7 +252,7 @@ func ExampleEncoder_indefiniteLengthArray() {
 	if err := enc.Encode([]int{2, 3}); err != nil {
 		fmt.Println("error:", err)
 	}
-	// Start a nested indefinite length array as array element.
+	// Start a nested indefinite-length array as array element.
 	if err := enc.StartIndefiniteArray(); err != nil {
 		fmt.Println("error:", err)
 	}
@@ -264,11 +264,11 @@ func ExampleEncoder_indefiniteLengthArray() {
 	if err := enc.Encode(5); err != nil {
 		fmt.Println("error:", err)
 	}
-	// Close nested indefinite length array.
+	// Close nested indefinite-length array.
 	if err := enc.EndIndefinite(); err != nil {
 		fmt.Println("error:", err)
 	}
-	// Close outer indefinite length array.
+	// Close outer indefinite-length array.
 	if err := enc.EndIndefinite(); err != nil {
 		fmt.Println("error:", err)
 	}
@@ -278,7 +278,7 @@ func ExampleEncoder_indefiniteLengthArray() {
 }
 
 // ExampleEncoder_indefiniteLengthMap encodes a stream of elements as an
-// indefinite length map.  Encoder supports nested indefinite length values.
+// indefinite-length map.  Encoder supports nested indefinite-length values.
 func ExampleEncoder_indefiniteLengthMap() {
 	var buf bytes.Buffer
 	em, err := cbor.EncOptions{Sort: cbor.SortCanonical}.EncMode()
@@ -286,7 +286,7 @@ func ExampleEncoder_indefiniteLengthMap() {
 		fmt.Println("error:", err)
 	}
 	enc := em.NewEncoder(&buf)
-	// Start indefinite length map encoding.
+	// Start indefinite-length map encoding.
 	if err := enc.StartIndefiniteMap(); err != nil {
 		fmt.Println("error:", err)
 	}
@@ -302,7 +302,7 @@ func ExampleEncoder_indefiniteLengthMap() {
 	if err := enc.Encode("b"); err != nil {
 		fmt.Println("error:", err)
 	}
-	// Start an indefinite length array as map value.
+	// Start an indefinite-length array as map value.
 	if err := enc.StartIndefiniteArray(); err != nil {
 		fmt.Println("error:", err)
 	}
@@ -314,11 +314,11 @@ func ExampleEncoder_indefiniteLengthMap() {
 	if err := enc.Encode(3); err != nil {
 		fmt.Println("error:", err)
 	}
-	// Close indefinite length array.
+	// Close indefinite-length array.
 	if err := enc.EndIndefinite(); err != nil {
 		fmt.Println("error:", err)
 	}
-	// Close indefinite length map.
+	// Close indefinite-length map.
 	if err := enc.EndIndefinite(); err != nil {
 		fmt.Println("error:", err)
 	}

--- a/json_test.go
+++ b/json_test.go
@@ -35,7 +35,7 @@ func TestStdlibJSONCompatibility(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, tc := range []struct {
+	testCases := []struct {
 		name       string
 		original   any
 		ifaceEqual bool // require equal intermediate interface{} values from both protocols
@@ -50,7 +50,8 @@ func TestStdlibJSONCompatibility(t *testing.T) {
 			original:   [11]byte{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'},
 			ifaceEqual: false, // encoding/json decodes the array elements to float64
 		},
-	} {
+	}
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("original: %#v", tc.original)
 

--- a/simplevalue.go
+++ b/simplevalue.go
@@ -93,6 +93,6 @@ func (sv *SimpleValue) unmarshalCBOR(data []byte) error {
 	// It is safe to cast val to uint8 here because
 	// - data is already verified to be well-formed CBOR simple value and
 	// - val is <= math.MaxUint8.
-	*sv = SimpleValue(val)
+	*sv = SimpleValue(val) //nolint:gosec
 	return nil
 }

--- a/simplevalue_test.go
+++ b/simplevalue_test.go
@@ -55,90 +55,90 @@ func TestUnmarshalSimpleValue(t *testing.T) {
 
 func TestUnmarshalSimpleValueOnBadData(t *testing.T) {
 	testCases := []struct {
-		name   string
-		data   []byte
-		errMsg string
+		name         string
+		data         []byte
+		wantErrorMsg string
 	}{
 		// Empty data
 		{
-			name:   "nil data",
-			data:   nil,
-			errMsg: io.EOF.Error(),
+			name:         "nil data",
+			data:         nil,
+			wantErrorMsg: io.EOF.Error(),
 		},
 		{
-			name:   "empty data",
-			data:   []byte{},
-			errMsg: io.EOF.Error(),
+			name:         "empty data",
+			data:         []byte{},
+			wantErrorMsg: io.EOF.Error(),
 		},
 
 		// Wrong CBOR types
 		{
-			name:   "uint type",
-			data:   mustHexDecode("01"),
-			errMsg: "cbor: cannot unmarshal positive integer into Go value of type SimpleValue",
+			name:         "uint type",
+			data:         mustHexDecode("01"),
+			wantErrorMsg: "cbor: cannot unmarshal positive integer into Go value of type SimpleValue",
 		},
 		{
-			name:   "int type",
-			data:   mustHexDecode("20"),
-			errMsg: "cbor: cannot unmarshal negative integer into Go value of type SimpleValue",
+			name:         "int type",
+			data:         mustHexDecode("20"),
+			wantErrorMsg: "cbor: cannot unmarshal negative integer into Go value of type SimpleValue",
 		},
 		{
-			name:   "byte string type",
-			data:   mustHexDecode("40"),
-			errMsg: "cbor: cannot unmarshal byte string into Go value of type SimpleValue",
+			name:         "byte string type",
+			data:         mustHexDecode("40"),
+			wantErrorMsg: "cbor: cannot unmarshal byte string into Go value of type SimpleValue",
 		},
 		{
-			name:   "string type",
-			data:   mustHexDecode("60"),
-			errMsg: "cbor: cannot unmarshal UTF-8 text string into Go value of type SimpleValue",
+			name:         "string type",
+			data:         mustHexDecode("60"),
+			wantErrorMsg: "cbor: cannot unmarshal UTF-8 text string into Go value of type SimpleValue",
 		},
 		{
-			name:   "array type",
-			data:   mustHexDecode("80"),
-			errMsg: "cbor: cannot unmarshal array into Go value of type SimpleValue",
+			name:         "array type",
+			data:         mustHexDecode("80"),
+			wantErrorMsg: "cbor: cannot unmarshal array into Go value of type SimpleValue",
 		},
 		{
-			name:   "map type",
-			data:   mustHexDecode("a0"),
-			errMsg: "cbor: cannot unmarshal map into Go value of type SimpleValue",
+			name:         "map type",
+			data:         mustHexDecode("a0"),
+			wantErrorMsg: "cbor: cannot unmarshal map into Go value of type SimpleValue",
 		},
 		{
-			name:   "tag type",
-			data:   mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
-			errMsg: "cbor: cannot unmarshal tag into Go value of type SimpleValue",
+			name:         "tag type",
+			data:         mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			wantErrorMsg: "cbor: cannot unmarshal tag into Go value of type SimpleValue",
 		},
 		{
-			name:   "float type",
-			data:   mustHexDecode("f90000"),
-			errMsg: "cbor: cannot unmarshal primitives into Go value of type SimpleValue",
+			name:         "float type",
+			data:         mustHexDecode("f90000"),
+			wantErrorMsg: "cbor: cannot unmarshal primitives into Go value of type SimpleValue",
 		},
 
 		// Truncated CBOR data
 		{
-			name:   "truncated head",
-			data:   mustHexDecode("18"),
-			errMsg: io.ErrUnexpectedEOF.Error(),
+			name:         "truncated head",
+			data:         mustHexDecode("18"),
+			wantErrorMsg: io.ErrUnexpectedEOF.Error(),
 		},
 
 		// Truncated CBOR simple value
 		{
-			name:   "truncated simple value",
-			data:   mustHexDecode("f8"),
-			errMsg: io.ErrUnexpectedEOF.Error(),
+			name:         "truncated simple value",
+			data:         mustHexDecode("f8"),
+			wantErrorMsg: io.ErrUnexpectedEOF.Error(),
 		},
 
 		// Invalid simple value
 		{
-			name:   "invalid simple value",
-			data:   mustHexDecode("f800"),
-			errMsg: "cbor: invalid simple value 0 for type primitives",
+			name:         "invalid simple value",
+			data:         mustHexDecode("f800"),
+			wantErrorMsg: "cbor: invalid simple value 0 for type primitives",
 		},
 
 		// Extraneous CBOR data
 		{
-			name:   "extraneous data",
-			data:   mustHexDecode("f4f5"),
-			errMsg: "cbor: 1 bytes of extraneous data starting at index 1",
+			name:         "extraneous data",
+			data:         mustHexDecode("f4f5"),
+			wantErrorMsg: "cbor: 1 bytes of extraneous data starting at index 1",
 		},
 	}
 
@@ -152,8 +152,8 @@ func TestUnmarshalSimpleValueOnBadData(t *testing.T) {
 				if err == nil {
 					t.Errorf("UnmarshalCBOR(%x) didn't return error", tc.data)
 				}
-				if !strings.HasPrefix(err.Error(), tc.errMsg) {
-					t.Errorf("UnmarshalCBOR(%x) returned error %q, want %q", tc.data, err.Error(), tc.errMsg)
+				if !strings.HasPrefix(err.Error(), tc.wantErrorMsg) {
+					t.Errorf("UnmarshalCBOR(%x) returned error %q, want %q", tc.data, err.Error(), tc.wantErrorMsg)
 				}
 			}
 			// Test Unmarshal(data, *SimpleValue), which calls SimpleValue.unmarshalCBOR() under the hood
@@ -164,8 +164,8 @@ func TestUnmarshalSimpleValueOnBadData(t *testing.T) {
 				if err == nil {
 					t.Errorf("Unmarshal(%x) didn't return error", tc.data)
 				}
-				if !strings.HasPrefix(err.Error(), tc.errMsg) {
-					t.Errorf("Unmarshal(%x) returned error %q, want %q", tc.data, err.Error(), tc.errMsg)
+				if !strings.HasPrefix(err.Error(), tc.wantErrorMsg) {
+					t.Errorf("Unmarshal(%x) returned error %q, want %q", tc.data, err.Error(), tc.wantErrorMsg)
 				}
 			}
 		})

--- a/stream.go
+++ b/stream.go
@@ -171,14 +171,20 @@ func NewEncoder(w io.Writer) *Encoder {
 
 // Encode writes the CBOR encoding of v.
 func (enc *Encoder) Encode(v any) error {
-	if len(enc.indefTypes) > 0 && v != nil {
-		indefType := enc.indefTypes[len(enc.indefTypes)-1]
-		if indefType == cborTypeTextString {
+	if len(enc.indefTypes) > 0 {
+		switch enc.indefTypes[len(enc.indefTypes)-1] {
+		case cborTypeTextString:
+			if v == nil {
+				return errors.New("cbor: cannot encode nil for indefinite-length text string")
+			}
 			k := reflect.TypeOf(v).Kind()
 			if k != reflect.String {
 				return errors.New("cbor: cannot encode item type " + k.String() + " for indefinite-length text string")
 			}
-		} else if indefType == cborTypeByteString {
+		case cborTypeByteString:
+			if v == nil {
+				return errors.New("cbor: cannot encode nil for indefinite-length byte string")
+			}
 			t := reflect.TypeOf(v)
 			k := t.Kind()
 			if (k != reflect.Array && k != reflect.Slice) || t.Elem().Kind() != reflect.Uint8 {
@@ -219,7 +225,7 @@ func (enc *Encoder) StartIndefiniteArray() error {
 	return enc.startIndefinite(cborTypeArray)
 }
 
-// StartIndefiniteMap starts array encoding of indefinite length.
+// StartIndefiniteMap starts map encoding of indefinite length.
 // Subsequent calls of (*Encoder).Encode() encodes elements of the map
 // until EndIndefinite is called.
 func (enc *Encoder) StartIndefiniteMap() error {

--- a/stream.go
+++ b/stream.go
@@ -204,35 +204,35 @@ func (enc *Encoder) Encode(v any) error {
 	return err
 }
 
-// StartIndefiniteByteString starts byte string encoding of indefinite length.
+// StartIndefiniteByteString starts indefinite-length byte string encoding.
 // Subsequent calls of (*Encoder).Encode() encodes definite length byte strings
 // ("chunks") as one contiguous string until EndIndefinite is called.
 func (enc *Encoder) StartIndefiniteByteString() error {
 	return enc.startIndefinite(cborTypeByteString)
 }
 
-// StartIndefiniteTextString starts text string encoding of indefinite length.
+// StartIndefiniteTextString starts indefinite-length text string encoding.
 // Subsequent calls of (*Encoder).Encode() encodes definite length text strings
 // ("chunks") as one contiguous string until EndIndefinite is called.
 func (enc *Encoder) StartIndefiniteTextString() error {
 	return enc.startIndefinite(cborTypeTextString)
 }
 
-// StartIndefiniteArray starts array encoding of indefinite length.
+// StartIndefiniteArray starts indefinite-length array encoding.
 // Subsequent calls of (*Encoder).Encode() encodes elements of the array
 // until EndIndefinite is called.
 func (enc *Encoder) StartIndefiniteArray() error {
 	return enc.startIndefinite(cborTypeArray)
 }
 
-// StartIndefiniteMap starts map encoding of indefinite length.
+// StartIndefiniteMap starts indefinite-length map encoding.
 // Subsequent calls of (*Encoder).Encode() encodes elements of the map
 // until EndIndefinite is called.
 func (enc *Encoder) StartIndefiniteMap() error {
 	return enc.startIndefinite(cborTypeMap)
 }
 
-// EndIndefinite closes last opened indefinite length value.
+// EndIndefinite closes last opened indefinite-length value.
 func (enc *Encoder) EndIndefinite() error {
 	if len(enc.indefTypes) == 0 {
 		return errors.New("cbor: cannot encode \"break\" code outside indefinite length values")
@@ -244,18 +244,22 @@ func (enc *Encoder) EndIndefinite() error {
 	return err
 }
 
-var cborIndefHeader = map[cborType][]byte{
-	cborTypeByteString: {cborByteStringWithIndefiniteLengthHead},
-	cborTypeTextString: {cborTextStringWithIndefiniteLengthHead},
-	cborTypeArray:      {cborArrayWithIndefiniteLengthHead},
-	cborTypeMap:        {cborMapWithIndefiniteLengthHead},
-}
-
 func (enc *Encoder) startIndefinite(typ cborType) error {
 	if enc.em.indefLength == IndefLengthForbidden {
 		return &IndefiniteLengthError{typ}
 	}
-	_, err := enc.w.Write(cborIndefHeader[typ])
+	var head byte
+	switch typ {
+	case cborTypeByteString:
+		head = cborByteStringWithIndefiniteLengthHead
+	case cborTypeTextString:
+		head = cborTextStringWithIndefiniteLengthHead
+	case cborTypeArray:
+		head = cborArrayWithIndefiniteLengthHead
+	case cborTypeMap:
+		head = cborMapWithIndefiniteLengthHead
+	}
+	_, err := enc.w.Write([]byte{head})
 	if err == nil {
 		enc.indefTypes = append(enc.indefTypes, typ)
 	}

--- a/stream.go
+++ b/stream.go
@@ -272,7 +272,9 @@ type RawMessage []byte
 // MarshalCBOR returns m or CBOR nil if m is nil.
 func (m RawMessage) MarshalCBOR() ([]byte, error) {
 	if len(m) == 0 {
-		return cborNil, nil
+		b := make([]byte, len(cborNil))
+		copy(b, cborNil)
+		return b, nil
 	}
 	return m, nil
 }

--- a/stream_decode.go
+++ b/stream_decode.go
@@ -391,9 +391,9 @@ func (sd *StreamDecoder) DecodeBytes() ([]byte, error) {
 		return nil, errors.New("cbor: indefinite length byte string isn't supported")
 	}
 
-	b := make([]byte, int(val))
-	copy(b, d.data[d.off:d.off+int(val)])
-	d.off += int(val)
+	b := make([]byte, int(val))           //nolint:gosec
+	copy(b, d.data[d.off:d.off+int(val)]) //nolint:gosec
+	d.off += int(val)                     //nolint:gosec
 
 	end := d.off
 
@@ -425,9 +425,9 @@ func (sd *StreamDecoder) DecodeString() (string, error) {
 		return "", errors.New("cbor: indefinite length text string isn't supported")
 	}
 
-	b := d.data[d.off : d.off+int(val)]
+	b := d.data[d.off : d.off+int(val)] //nolint:gosec
 
-	d.off += int(val)
+	d.off += int(val) //nolint:gosec
 	end := d.off
 
 	sd.updateState(end - start)

--- a/stream_encode.go
+++ b/stream_encode.go
@@ -49,7 +49,7 @@ func (se *StreamEncoder) Flush() error {
 	if se.closed {
 		return ErrStreamClosed
 	}
-	_, err := se.buf.WriteTo(se.Encoder.w)
+	_, err := se.buf.WriteTo(se.w)
 	return err
 }
 
@@ -199,7 +199,7 @@ func (se *StreamEncoder) EncodeInt64(i int64) error {
 		t = cborTypeNegativeInt
 		i = i*(-1) - 1
 	}
-	encodeHead(se.buf, byte(t), uint64(i))
+	encodeHead(se.buf, byte(t), uint64(i)) //nolint:gosec
 	return nil
 }
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -883,6 +883,19 @@ func TestIndefiniteTextString(t *testing.T) {
 	}
 }
 
+func TestIndefiniteByteStringNilError(t *testing.T) {
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	if err := encoder.StartIndefiniteByteString(); err != nil {
+		t.Fatalf("StartIndefiniteByteString() returned error %v", err)
+	}
+	if err := encoder.Encode(nil); err == nil {
+		t.Errorf("Encode() didn't return an error")
+	} else if err.Error() != "cbor: cannot encode nil for indefinite-length byte string" {
+		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode nil for indefinite-length byte string")
+	}
+}
+
 func TestIndefiniteTextStringError(t *testing.T) {
 	var w bytes.Buffer
 	encoder := NewEncoder(&w)
@@ -893,6 +906,24 @@ func TestIndefiniteTextStringError(t *testing.T) {
 		t.Errorf("Encode() didn't return an error")
 	} else if err.Error() != "cbor: cannot encode item type slice for indefinite-length text string" {
 		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type slice for indefinite-length text string")
+	}
+	if err := encoder.Encode(123); err == nil {
+		t.Errorf("Encode() didn't return an error")
+	} else if err.Error() != "cbor: cannot encode item type int for indefinite-length text string" {
+		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type int for indefinite-length text string")
+	}
+}
+
+func TestIndefiniteTextStringNilError(t *testing.T) {
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	if err := encoder.StartIndefiniteTextString(); err != nil {
+		t.Fatalf("StartIndefiniteTextString() returned error %v", err)
+	}
+	if err := encoder.Encode(nil); err == nil {
+		t.Errorf("Encode() didn't return an error")
+	} else if err.Error() != "cbor: cannot encode nil for indefinite-length text string" {
+		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode nil for indefinite-length text string")
 	}
 }
 
@@ -926,6 +957,41 @@ func TestIndefiniteArray(t *testing.T) {
 	}
 	if !bytes.Equal(w.Bytes(), want) {
 		t.Errorf("Encoding mismatch: got %v, want %v", w.Bytes(), want)
+	}
+}
+
+func TestIndefiniteArrayWithNilElement(t *testing.T) {
+	want := mustHexDecode("9f01f6ff") // [1, null]
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	if err := encoder.StartIndefiniteArray(); err != nil {
+		t.Fatalf("StartIndefiniteArray() returned error %v", err)
+	}
+	if err := encoder.Encode(1); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.Encode(nil); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.EndIndefinite(); err != nil {
+		t.Fatalf("EndIndefinite() returned error %v", err)
+	}
+	if !bytes.Equal(w.Bytes(), want) {
+		t.Errorf("Encoding mismatch: got %v, want %v", w.Bytes(), want)
+	}
+
+	var decoded []any
+	if err := Unmarshal(w.Bytes(), &decoded); err != nil {
+		t.Fatalf("Unmarshal() returned error %v", err)
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("Unmarshal() returned %d elements, want 2", len(decoded))
+	}
+	if decoded[0] != uint64(1) {
+		t.Errorf("decoded[0] = %v (%T), want uint64(1)", decoded[0], decoded[0])
+	}
+	if decoded[1] != nil {
+		t.Errorf("decoded[1] = %v (%T), want nil", decoded[1], decoded[1])
 	}
 }
 
@@ -966,6 +1032,42 @@ func TestIndefiniteMap(t *testing.T) {
 	}
 	if !bytes.Equal(w.Bytes(), want) {
 		t.Errorf("Encoding mismatch: got %v, want %v", w.Bytes(), want)
+	}
+}
+
+func TestIndefiniteMapWithNilElement(t *testing.T) {
+	want := mustHexDecode("bf6161f6ff") // {"a": null}
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	if err := encoder.StartIndefiniteMap(); err != nil {
+		t.Fatalf("StartIndefiniteMap() returned error %v", err)
+	}
+	if err := encoder.Encode("a"); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.Encode(nil); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.EndIndefinite(); err != nil {
+		t.Fatalf("EndIndefinite() returned error %v", err)
+	}
+	if !bytes.Equal(w.Bytes(), want) {
+		t.Errorf("Encoding mismatch: got %v, want %v", w.Bytes(), want)
+	}
+
+	var decoded map[string]any
+	if err := Unmarshal(w.Bytes(), &decoded); err != nil {
+		t.Fatalf("Unmarshal() returned error %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("Unmarshal() returned %d entries, want 1", len(decoded))
+	}
+	v, ok := decoded["a"]
+	if !ok {
+		t.Fatalf("decoded map missing key \"a\"")
+	}
+	if v != nil {
+		t.Errorf("decoded[\"a\"] = %v (%T), want nil", v, v)
 	}
 }
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -17,7 +17,7 @@ import (
 func TestDecoder(t *testing.T) {
 	var buf bytes.Buffer
 	for i := 0; i < 5; i++ {
-		for _, tc := range unmarshalTests {
+		for _, tc := range unmarshalTestCases {
 			buf.Write(tc.data)
 		}
 	}
@@ -45,7 +45,7 @@ func TestDecoder(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
 			for i := 0; i < 5; i++ {
-				for _, tc := range unmarshalTests {
+				for _, tc := range unmarshalTestCases {
 					var v any
 					if err := decoder.Decode(&v); err != nil {
 						t.Fatalf("Decode() returned error %v", err)
@@ -81,7 +81,7 @@ func TestDecoder(t *testing.T) {
 func TestDecoderUnmarshalTypeError(t *testing.T) {
 	var buf bytes.Buffer
 	for i := 0; i < 5; i++ {
-		for _, tc := range unmarshalTests {
+		for _, tc := range unmarshalTestCases {
 			for j := 0; j < len(tc.wrongTypes)*2; j++ {
 				buf.Write(tc.data)
 			}
@@ -111,7 +111,7 @@ func TestDecoderUnmarshalTypeError(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
 			for i := 0; i < 5; i++ {
-				for _, tc := range unmarshalTests {
+				for _, tc := range unmarshalTestCases {
 					for _, typ := range tc.wrongTypes {
 						v := reflect.New(typ)
 						if err := decoder.Decode(v.Interface()); err == nil {
@@ -159,7 +159,7 @@ func TestDecoderUnmarshalTypeError(t *testing.T) {
 
 func TestDecoderUnexpectedEOFError(t *testing.T) {
 	var buf bytes.Buffer
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		buf.Write(tc.data)
 	}
 	buf.Truncate(buf.Len() - 1)
@@ -187,8 +187,8 @@ func TestDecoderUnexpectedEOFError(t *testing.T) {
 
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < len(unmarshalTests)-1; i++ {
-				tc := unmarshalTests[i]
+			for i := 0; i < len(unmarshalTestCases)-1; i++ {
+				tc := unmarshalTestCases[i]
 				var v any
 				if err := decoder.Decode(&v); err != nil {
 					t.Fatalf("Decode() returned error %v", err)
@@ -222,7 +222,7 @@ func TestDecoderUnexpectedEOFError(t *testing.T) {
 
 func TestDecoderReadError(t *testing.T) {
 	var buf bytes.Buffer
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		buf.Write(tc.data)
 	}
 	buf.Truncate(buf.Len() - 1)
@@ -251,8 +251,8 @@ func TestDecoderReadError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < len(unmarshalTests)-1; i++ {
-				tc := unmarshalTests[i]
+			for i := 0; i < len(unmarshalTestCases)-1; i++ {
+				tc := unmarshalTestCases[i]
 				var v any
 				if err := decoder.Decode(&v); err != nil {
 					t.Fatalf("Decode() returned error %v", err)
@@ -293,7 +293,7 @@ func TestDecoderNoData(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "byte.Buffer",
+			name:    "bytes.Buffer",
 			reader:  new(bytes.Buffer),
 			wantErr: io.EOF,
 		},
@@ -383,7 +383,7 @@ func TestDecoderInvalidData(t *testing.T) {
 func TestDecoderSkip(t *testing.T) {
 	var buf bytes.Buffer
 	for i := 0; i < 5; i++ {
-		for _, tc := range unmarshalTests {
+		for _, tc := range unmarshalTestCases {
 			buf.Write(tc.data)
 		}
 	}
@@ -411,7 +411,7 @@ func TestDecoderSkip(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
 			for i := 0; i < 5; i++ {
-				for _, tc := range unmarshalTests {
+				for _, tc := range unmarshalTestCases {
 					if err := decoder.Skip(); err != nil {
 						t.Fatalf("Skip() returned error %v", err)
 					}
@@ -434,7 +434,7 @@ func TestDecoderSkip(t *testing.T) {
 
 func TestDecoderSkipInvalidDataError(t *testing.T) {
 	var buf bytes.Buffer
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		buf.Write(tc.data)
 	}
 	buf.WriteByte(0x3e)
@@ -461,8 +461,8 @@ func TestDecoderSkipInvalidDataError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < len(unmarshalTests); i++ {
-				tc := unmarshalTests[i]
+			for i := 0; i < len(unmarshalTestCases); i++ {
+				tc := unmarshalTestCases[i]
 				if err := decoder.Skip(); err != nil {
 					t.Fatalf("Skip() returned error %v", err)
 				}
@@ -486,7 +486,7 @@ func TestDecoderSkipInvalidDataError(t *testing.T) {
 
 func TestDecoderSkipUnexpectedEOFError(t *testing.T) {
 	var buf bytes.Buffer
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		buf.Write(tc.data)
 	}
 	buf.Truncate(buf.Len() - 1)
@@ -513,8 +513,8 @@ func TestDecoderSkipUnexpectedEOFError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < len(unmarshalTests)-1; i++ {
-				tc := unmarshalTests[i]
+			for i := 0; i < len(unmarshalTestCases)-1; i++ {
+				tc := unmarshalTestCases[i]
 				if err := decoder.Skip(); err != nil {
 					t.Fatalf("Skip() returned error %v", err)
 				}
@@ -536,7 +536,7 @@ func TestDecoderSkipUnexpectedEOFError(t *testing.T) {
 
 func TestDecoderSkipReadError(t *testing.T) {
 	var buf bytes.Buffer
-	for _, tc := range unmarshalTests {
+	for _, tc := range unmarshalTestCases {
 		buf.Write(tc.data)
 	}
 	buf.Truncate(buf.Len() - 1)
@@ -565,8 +565,8 @@ func TestDecoderSkipReadError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < len(unmarshalTests)-1; i++ {
-				tc := unmarshalTests[i]
+			for i := 0; i < len(unmarshalTestCases)-1; i++ {
+				tc := unmarshalTestCases[i]
 				if err := decoder.Skip(); err != nil {
 					t.Fatalf("Skip() returned error %v", err)
 				}
@@ -595,7 +595,7 @@ func TestDecoderSkipNoData(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "byte.Buffer",
+			name:    "bytes.Buffer",
 			reader:  new(bytes.Buffer),
 			wantErr: io.EOF,
 		},
@@ -767,7 +767,7 @@ func TestEncoder(t *testing.T) {
 		t.Errorf("EncMode() returned an error %v", err)
 	}
 	encoder := em.NewEncoder(&w)
-	for _, tc := range marshalTests {
+	for _, tc := range marshalTestCases {
 		for _, value := range tc.values {
 			want.Write(tc.wantData)
 
@@ -782,7 +782,7 @@ func TestEncoder(t *testing.T) {
 }
 
 func TestEncoderError(t *testing.T) {
-	testcases := []struct {
+	testCases := []struct {
 		name         string
 		value        any
 		wantErrorMsg string
@@ -805,7 +805,7 @@ func TestEncoderError(t *testing.T) {
 	}
 	var w bytes.Buffer
 	encoder := NewEncoder(&w)
-	for _, tc := range testcases {
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			v := tc.value
 			err := encoder.Encode(&v)

--- a/structfields.go
+++ b/structfields.go
@@ -6,6 +6,7 @@ package cbor
 import (
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -84,6 +85,10 @@ func (x *nameLevelAndTagFieldSorter) Less(i, j int) bool {
 	if fi.name != fj.name {
 		return fi.name < fj.name
 	}
+	// Fields with the same name but different keyAsInt are in separate namespaces.
+	if fi.keyAsInt != fj.keyAsInt {
+		return fi.keyAsInt
+	}
 	if len(fi.idx) != len(fj.idx) {
 		return len(fi.idx) < len(fj.idx)
 	}
@@ -132,22 +137,37 @@ func getFields(t reflect.Type) (flds fields, structOptions string) {
 		}
 	}
 
+	// Normalize keyasint field names to their canonical integer string form.
+	// This ensures that "01", "+1", and "1" are treated as the same key
+	// during deduplication.
+	for _, f := range flds {
+		if f.keyAsInt {
+			nameAsInt, err := strconv.Atoi(f.name)
+			if err != nil {
+				continue // Leave invalid names for callers to report.
+			}
+			f.nameAsInt = int64(nameAsInt)
+			f.name = strconv.Itoa(nameAsInt)
+		}
+	}
+
 	sort.Sort(&nameLevelAndTagFieldSorter{flds})
 
 	// Keep visible fields.
 	j := 0 // index of next unique field
 	for i := 0; i < len(flds); {
 		name := flds[i].name
+		keyAsInt := flds[i].keyAsInt
 		if i == len(flds)-1 || // last field
-			name != flds[i+1].name || // field i has unique field name
+			name != flds[i+1].name || flds[i+1].keyAsInt != keyAsInt || // field i has unique (name, keyAsInt)
 			len(flds[i].idx) < len(flds[i+1].idx) || // field i is at a less nested level than field i+1
 			(flds[i].tagged && !flds[i+1].tagged) { // field i is tagged while field i+1 is not
 			flds[j] = flds[i]
 			j++
 		}
 
-		// Skip fields with the same field name.
-		for i++; i < len(flds) && name == flds[i].name; i++ { //nolint:revive
+		// Skip fields with the same (name, keyAsInt).
+		for i++; i < len(flds) && name == flds[i].name && keyAsInt == flds[i].keyAsInt; i++ { //nolint:revive
 		}
 	}
 	if j != len(flds) {

--- a/structfields.go
+++ b/structfields.go
@@ -9,24 +9,39 @@ import (
 	"strings"
 )
 
+// field holds shared struct field metadata returned by getFields().
 type field struct {
-	name               string
-	nameAsInt          int64 // used to decoder to match field name with CBOR int
-	cborName           []byte
-	cborNameByteString []byte // major type 2 name encoding iff cborName has major type 3
-	idx                []int
-	typ                reflect.Type
-	ef                 encodeFunc
-	ief                isEmptyFunc
-	izf                isZeroFunc
-	typInfo            *typeInfo // used to decoder to reuse type info
-	tagged             bool      // used to choose dominant field (at the same level tagged fields dominate untagged fields)
-	omitEmpty          bool      // used to skip empty field
-	omitZero           bool      // used to skip zero field
-	keyAsInt           bool      // used to encode/decode field name as int
+	name      string
+	nameAsInt int64 // used to match field name with CBOR int
+	idx       []int
+	typ       reflect.Type // used during cache building only
+	keyAsInt  bool         // used to encode/decode field name as int
+	tagged    bool         // used to choose dominant field (at the same level tagged fields dominate untagged fields)
+	omitEmpty bool         // used to skip empty field
+	omitZero  bool         // used to skip zero field
 }
 
 type fields []*field
+
+// encodingField extends field with encoding-specific data.
+type encodingField struct {
+	field
+	cborName           []byte
+	cborNameByteString []byte // major type 2 name encoding if cborName has major type 3
+	ef                 encodeFunc
+	ief                isEmptyFunc
+	izf                isZeroFunc
+}
+
+type encodingFields []*encodingField
+
+// decodingField extends field with decoding-specific data.
+type decodingField struct {
+	field
+	typInfo *typeInfo // used by decoder to reuse type info
+}
+
+type decodingFields []*decodingField
 
 // indexFieldSorter sorts fields by field idx at each level, breaking ties with idx depth.
 type indexFieldSorter struct {

--- a/structfields.go
+++ b/structfields.go
@@ -48,7 +48,7 @@ func (x *indexFieldSorter) Less(i, j int) bool {
 			return iIdx[k] < jIdx[k]
 		}
 	}
-	return len(iIdx) <= len(jIdx)
+	return len(iIdx) < len(jIdx)
 }
 
 // nameLevelAndTagFieldSorter sorts fields by field name, idx depth, and presence of tag.

--- a/tag_test.go
+++ b/tag_test.go
@@ -689,7 +689,7 @@ func TestAddTagTypeAliasError(t *testing.T) {
 	tags := NewTagSet()
 	for i, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, tc.typ, uint64(100+i)); err == nil {
+			if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, tc.typ, uint64(100+i)); err == nil { //nolint:gosec
 				t.Errorf("TagSet.Add(%s, %d) didn't return an error", tc.typ.String(), 0)
 			} else if err.Error() != tc.wantErrorMsg {
 				t.Errorf("TagSet.Add(%s, %d) returned error msg %q, want %q", tc.typ.String(), 0, err, tc.wantErrorMsg)

--- a/tag_test.go
+++ b/tag_test.go
@@ -66,7 +66,7 @@ func TestTagNewTypeWithBuiltinUnderlyingType(t *testing.T) {
 	em, _ := EncOptions{Sort: SortCanonical}.EncModeWithTags(tags)
 	dm, _ := DecOptions{}.DecModeWithTags(tags)
 
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			name:         "bool",
 			obj:          myBool(true),
@@ -177,7 +177,7 @@ func TestTagBinaryMarshalerUnmarshaler(t *testing.T) {
 	em, _ := EncOptions{}.EncModeWithTags(tags)
 	dm, _ := DecOptions{}.DecModeWithTags(tags)
 
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			name:         "primitive obj",
 			obj:          number(1234567890),
@@ -743,7 +743,7 @@ func TestDecodeTagData(t *testing.T) {
 		{"EncTagRequired_DecTagIgnored", tagsDecIgnored},
 	}
 
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			name:         "BinaryMarshaler non-struct",
 			obj:          number(1234567890),
@@ -813,7 +813,7 @@ func TestDecodeNoTagData(t *testing.T) {
 		{"EncTagIgnored_DecTagOptional", tagsDecOptional},
 	}
 
-	testCases := []roundTripTest{
+	testCases := []roundTripTestCase{
 		{
 			name:         "BinaryMarshaler non-struct",
 			obj:          number(1234567890),
@@ -1497,7 +1497,7 @@ func TestMarshalRawTagContainingMalformedCBORData(t *testing.T) {
 // TestEncodeBuiltinTag tests that marshaling a value of type Tag "does the right thing" when
 // marshaling the enclosed data item of a built-in tag number.
 func TestEncodeBuiltinTag(t *testing.T) {
-	for _, tc := range []struct {
+	testCases := []struct {
 		name string
 		tag  Tag
 		opts EncOptions
@@ -1521,7 +1521,8 @@ func TestEncodeBuiltinTag(t *testing.T) {
 			opts: EncOptions{String: StringToByteString},
 			want: mustHexDecode("c074323031332d30332d32315432303a30343a30305a"),
 		},
-	} {
+	}
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			em, err := tc.opts.EncMode()
 			if err != nil {
@@ -1542,93 +1543,93 @@ func TestEncodeBuiltinTag(t *testing.T) {
 
 func TestUnmarshalRawTagOnBadData(t *testing.T) {
 	testCases := []struct {
-		name   string
-		data   []byte
-		errMsg string
+		name         string
+		data         []byte
+		wantErrorMsg string
 	}{
 		// Empty data
 		{
-			name:   "nil data",
-			data:   nil,
-			errMsg: io.EOF.Error(),
+			name:         "nil data",
+			data:         nil,
+			wantErrorMsg: io.EOF.Error(),
 		},
 		{
-			name:   "empty data",
-			data:   []byte{},
-			errMsg: io.EOF.Error(),
+			name:         "empty data",
+			data:         []byte{},
+			wantErrorMsg: io.EOF.Error(),
 		},
 
 		// Wrong CBOR types
 		{
-			name:   "uint type",
-			data:   mustHexDecode("01"),
-			errMsg: "cbor: cannot unmarshal positive integer into Go value of type cbor.RawTag",
+			name:         "uint type",
+			data:         mustHexDecode("01"),
+			wantErrorMsg: "cbor: cannot unmarshal positive integer into Go value of type cbor.RawTag",
 		},
 		{
-			name:   "int type",
-			data:   mustHexDecode("20"),
-			errMsg: "cbor: cannot unmarshal negative integer into Go value of type cbor.RawTag",
+			name:         "int type",
+			data:         mustHexDecode("20"),
+			wantErrorMsg: "cbor: cannot unmarshal negative integer into Go value of type cbor.RawTag",
 		},
 		{
-			name:   "byte string type",
-			data:   mustHexDecode("40"),
-			errMsg: "cbor: cannot unmarshal byte string into Go value of type cbor.RawTag",
+			name:         "byte string type",
+			data:         mustHexDecode("40"),
+			wantErrorMsg: "cbor: cannot unmarshal byte string into Go value of type cbor.RawTag",
 		},
 		{
-			name:   "string type",
-			data:   mustHexDecode("60"),
-			errMsg: "cbor: cannot unmarshal UTF-8 text string into Go value of type cbor.RawTag",
+			name:         "string type",
+			data:         mustHexDecode("60"),
+			wantErrorMsg: "cbor: cannot unmarshal UTF-8 text string into Go value of type cbor.RawTag",
 		},
 		{
-			name:   "array type",
-			data:   mustHexDecode("80"),
-			errMsg: "cbor: cannot unmarshal array into Go value of type cbor.RawTag",
+			name:         "array type",
+			data:         mustHexDecode("80"),
+			wantErrorMsg: "cbor: cannot unmarshal array into Go value of type cbor.RawTag",
 		},
 		{
-			name:   "map type",
-			data:   mustHexDecode("a0"),
-			errMsg: "cbor: cannot unmarshal map into Go value of type cbor.RawTag",
+			name:         "map type",
+			data:         mustHexDecode("a0"),
+			wantErrorMsg: "cbor: cannot unmarshal map into Go value of type cbor.RawTag",
 		},
 		{
-			name:   "primitive type",
-			data:   mustHexDecode("f4"),
-			errMsg: "cbor: cannot unmarshal primitives into Go value of type cbor.RawTag",
+			name:         "primitive type",
+			data:         mustHexDecode("f4"),
+			wantErrorMsg: "cbor: cannot unmarshal primitives into Go value of type cbor.RawTag",
 		},
 		{
-			name:   "float type",
-			data:   mustHexDecode("f90000"),
-			errMsg: "cbor: cannot unmarshal primitives into Go value of type cbor.RawTag",
+			name:         "float type",
+			data:         mustHexDecode("f90000"),
+			wantErrorMsg: "cbor: cannot unmarshal primitives into Go value of type cbor.RawTag",
 		},
 
 		// Truncated CBOR data
 		{
-			name:   "truncated head",
-			data:   mustHexDecode("18"),
-			errMsg: io.ErrUnexpectedEOF.Error(),
+			name:         "truncated head",
+			data:         mustHexDecode("18"),
+			wantErrorMsg: io.ErrUnexpectedEOF.Error(),
 		},
 
 		// Truncated CBOR tag data
 		{
-			name:   "truncated tag number",
-			data:   mustHexDecode("d8"),
-			errMsg: io.ErrUnexpectedEOF.Error(),
+			name:         "truncated tag number",
+			data:         mustHexDecode("d8"),
+			wantErrorMsg: io.ErrUnexpectedEOF.Error(),
 		},
 		{
-			name:   "tag number not followed by tag content",
-			data:   mustHexDecode("da"),
-			errMsg: io.ErrUnexpectedEOF.Error(),
+			name:         "tag number not followed by tag content",
+			data:         mustHexDecode("da"),
+			wantErrorMsg: io.ErrUnexpectedEOF.Error(),
 		},
 		{
-			name:   "truncated tag content",
-			data:   mustHexDecode("c074323031332d30332d32315432303a30343a3030"),
-			errMsg: io.ErrUnexpectedEOF.Error(),
+			name:         "truncated tag content",
+			data:         mustHexDecode("c074323031332d30332d32315432303a30343a3030"),
+			wantErrorMsg: io.ErrUnexpectedEOF.Error(),
 		},
 
 		// Extraneous CBOR data
 		{
-			name:   "extraneous data",
-			data:   mustHexDecode("c074323031332d30332d32315432303a30343a30305a00"),
-			errMsg: "cbor: 1 bytes of extraneous data starting at index 22",
+			name:         "extraneous data",
+			data:         mustHexDecode("c074323031332d30332d32315432303a30343a30305a00"),
+			wantErrorMsg: "cbor: 1 bytes of extraneous data starting at index 22",
 		},
 	}
 
@@ -1642,8 +1643,8 @@ func TestUnmarshalRawTagOnBadData(t *testing.T) {
 				if err == nil {
 					t.Errorf("UnmarshalCBOR(%x) didn't return error", tc.data)
 				}
-				if !strings.HasPrefix(err.Error(), tc.errMsg) {
-					t.Errorf("UnmarshalCBOR(%x) returned error %q, want %q", tc.data, err.Error(), tc.errMsg)
+				if !strings.HasPrefix(err.Error(), tc.wantErrorMsg) {
+					t.Errorf("UnmarshalCBOR(%x) returned error %q, want %q", tc.data, err.Error(), tc.wantErrorMsg)
 				}
 			}
 			// Test Unmarshal(data, *RawTag), which calls RawTag.unmarshalCBOR() under the hood
@@ -1654,8 +1655,8 @@ func TestUnmarshalRawTagOnBadData(t *testing.T) {
 				if err == nil {
 					t.Errorf("Unmarshal(%x) didn't return error", tc.data)
 				}
-				if !strings.HasPrefix(err.Error(), tc.errMsg) {
-					t.Errorf("Unmarshal(%x) returned error %q, want %q", tc.data, err.Error(), tc.errMsg)
+				if !strings.HasPrefix(err.Error(), tc.wantErrorMsg) {
+					t.Errorf("Unmarshal(%x) returned error %q, want %q", tc.data, err.Error(), tc.wantErrorMsg)
 				}
 			}
 		})

--- a/valid.go
+++ b/valid.go
@@ -113,7 +113,7 @@ func (d *decoder) wellformedInternal(depth int, checkBuiltinTags bool) (int, err
 			}
 			return d.wellformedIndefiniteString(t, depth, checkBuiltinTags)
 		}
-		valInt := int(val)
+		valInt := int(val) //nolint:gosec
 		if valInt < 0 {
 			// Detect integer overflow
 			return 0, errors.New("cbor: " + t.String() + " length " + strconv.FormatUint(val, 10) + " is too large, causing integer overflow")
@@ -136,7 +136,7 @@ func (d *decoder) wellformedInternal(depth int, checkBuiltinTags bool) (int, err
 			return d.wellformedIndefiniteArrayOrMap(t, depth, checkBuiltinTags)
 		}
 
-		valInt := int(val)
+		valInt := int(val) //nolint:gosec
 		if valInt < 0 {
 			// Detect integer overflow
 			return 0, errors.New("cbor: " + t.String() + " length " + strconv.FormatUint(val, 10) + " is too large, it would cause integer overflow")
@@ -326,7 +326,7 @@ func (d *decoder) wellformedHead() (t cborType, ai byte, val uint64, err error) 
 		val = uint64(binary.BigEndian.Uint16(d.data[d.off : d.off+argumentSize]))
 		d.off += argumentSize
 		if t == cborTypePrimitives {
-			if err := d.acceptableFloat(float64(float16.Frombits(uint16(val)).Float32())); err != nil {
+			if err := d.acceptableFloat(float64(float16.Frombits(uint16(val)).Float32())); err != nil { //nolint:gosec
 				return 0, 0, 0, err
 			}
 		}
@@ -341,7 +341,7 @@ func (d *decoder) wellformedHead() (t cborType, ai byte, val uint64, err error) 
 		val = uint64(binary.BigEndian.Uint32(d.data[d.off : d.off+argumentSize]))
 		d.off += argumentSize
 		if t == cborTypePrimitives {
-			if err := d.acceptableFloat(float64(math.Float32frombits(uint32(val)))); err != nil {
+			if err := d.acceptableFloat(float64(math.Float32frombits(uint32(val)))); err != nil { //nolint:gosec
 				return 0, 0, 0, err
 			}
 		}

--- a/valid.go
+++ b/valid.go
@@ -54,7 +54,7 @@ func (e *MaxMapPairsError) Error() string {
 	return "cbor: exceeded max number of key-value pairs " + strconv.Itoa(e.maxMapPairs) + " for CBOR map"
 }
 
-// IndefiniteLengthError indicates found disallowed indefinite length items.
+// IndefiniteLengthError indicates found disallowed indefinite-length items.
 type IndefiniteLengthError struct {
 	t cborType
 }
@@ -212,7 +212,7 @@ func (d *decoder) wellformedInternal(depth int, checkBuiltinTags bool) (int, err
 	return depth, nil
 }
 
-// wellformedIndefiniteString checks indefinite length byte/text string's well-formedness and returns max depth and error.
+// wellformedIndefiniteString checks indefinite-length byte/text string's well-formedness and returns max depth and error.
 func (d *decoder) wellformedIndefiniteString(t cborType, depth int, checkBuiltinTags bool) (int, error) {
 	var err error
 	for {
@@ -223,7 +223,7 @@ func (d *decoder) wellformedIndefiniteString(t cborType, depth int, checkBuiltin
 			d.off++
 			break
 		}
-		// Peek ahead to get next type and indefinite length status.
+		// Peek ahead to get next type and indefinite-length status.
 		nt, ai := parseInitialByte(d.data[d.off])
 		if t != nt {
 			return 0, &SyntaxError{"cbor: wrong element type " + nt.String() + " for indefinite-length " + t.String()}
@@ -238,7 +238,7 @@ func (d *decoder) wellformedIndefiniteString(t cborType, depth int, checkBuiltin
 	return depth, nil
 }
 
-// wellformedIndefiniteArrayOrMap checks indefinite length array/map's well-formedness and returns max depth and error.
+// wellformedIndefiniteArrayOrMap checks indefinite-length array/map's well-formedness and returns max depth and error.
 func (d *decoder) wellformedIndefiniteArrayOrMap(t cborType, depth int, checkBuiltinTags bool) (int, error) {
 	var err error
 	maxDepth := depth
@@ -379,12 +379,12 @@ func (d *decoder) wellformedHead() (t cborType, ai byte, val uint64, err error) 
 
 func (d *decoder) acceptableFloat(f float64) error {
 	switch {
-	case d.dm.nanDec == NaNDecodeForbidden && math.IsNaN(f):
+	case d.dm.nan == NaNDecodeForbidden && math.IsNaN(f):
 		return &UnacceptableDataItemError{
 			CBORType: cborTypePrimitives.String(),
 			Message:  "floating-point NaN",
 		}
-	case d.dm.infDec == InfDecodeForbidden && math.IsInf(f, 0):
+	case d.dm.inf == InfDecodeForbidden && math.IsInf(f, 0):
 		return &UnacceptableDataItemError{
 			CBORType: cborTypePrimitives.String(),
 			Message:  "floating-point infinity",

--- a/valid_test.go
+++ b/valid_test.go
@@ -9,17 +9,17 @@ import (
 )
 
 func TestValid1(t *testing.T) {
-	for _, mt := range marshalTests {
-		if err := Wellformed(mt.wantData); err != nil {
+	for _, tc := range marshalTestCases {
+		if err := Wellformed(tc.wantData); err != nil {
 			t.Errorf("Wellformed() returned error %v", err)
 		}
 	}
 }
 
 func TestValid2(t *testing.T) {
-	for _, mt := range marshalTests {
+	for _, tc := range marshalTestCases {
 		dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
-		if err := dm.Wellformed(mt.wantData); err != nil {
+		if err := dm.Wellformed(tc.wantData); err != nil {
 			t.Errorf("Wellformed() returned error %v", err)
 		}
 	}
@@ -73,11 +73,11 @@ func TestValidExtraneousData(t *testing.T) {
 
 func TestValidOnStreamingData(t *testing.T) {
 	var buf bytes.Buffer
-	for _, t := range marshalTests {
-		buf.Write(t.wantData)
+	for _, tc := range marshalTestCases {
+		buf.Write(tc.wantData)
 	}
 	d := decoder{data: buf.Bytes(), dm: defaultDecMode}
-	for i := 0; i < len(marshalTests); i++ {
+	for i := 0; i < len(marshalTestCases); i++ {
 		if err := d.wellformed(true, false); err != nil {
 			t.Errorf("wellformed() returned error %v", err)
 		}
@@ -121,7 +121,7 @@ func TestDepth(t *testing.T) {
 			wantDepth: 0,
 		}, // []byte{}
 		{
-			name:      "indefinite length byte string",
+			name:      "indefinite-length byte string",
 			data:      mustHexDecode("5f42010243030405ff"),
 			wantDepth: 0,
 		}, // []byte{1, 2, 3, 4, 5}
@@ -131,7 +131,7 @@ func TestDepth(t *testing.T) {
 			wantDepth: 0,
 		}, // ""
 		{
-			name:      "indefinite length text string",
+			name:      "indefinite-length text string",
 			data:      mustHexDecode("7f657374726561646d696e67ff"),
 			wantDepth: 0,
 		}, // "streaming"
@@ -141,7 +141,7 @@ func TestDepth(t *testing.T) {
 			wantDepth: 1,
 		}, // []
 		{
-			name:      "indefinite length empty array",
+			name:      "indefinite-length empty array",
 			data:      mustHexDecode("9fff"),
 			wantDepth: 1,
 		}, // []
@@ -151,7 +151,7 @@ func TestDepth(t *testing.T) {
 			wantDepth: 1,
 		}, // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
 		{
-			name:      "indefinite length array",
+			name:      "indefinite-length array",
 			data:      mustHexDecode("9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff"),
 			wantDepth: 1,
 		}, // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
@@ -161,7 +161,7 @@ func TestDepth(t *testing.T) {
 			wantDepth: 2,
 		}, // [1,[2,3],[4,5]]
 		{
-			name:      "indefinite length nested array",
+			name:      "indefinite-length nested array",
 			data:      mustHexDecode("83018202039f0405ff"),
 			wantDepth: 2,
 		}, // [1,[2,3],[4,5]]
@@ -171,7 +171,7 @@ func TestDepth(t *testing.T) {
 			wantDepth: 2,
 		}, // [a", {"b": "c"}]
 		{
-			name:      "indefinite length array and map",
+			name:      "indefinite-length array and map",
 			data:      mustHexDecode("826161bf61626163ff"),
 			wantDepth: 2,
 		}, // [a", {"b": "c"}]
@@ -181,7 +181,7 @@ func TestDepth(t *testing.T) {
 			wantDepth: 1,
 		}, // {}
 		{
-			name:      "indefinite length empty map",
+			name:      "indefinite-length empty map",
 			data:      mustHexDecode("bfff"),
 			wantDepth: 1,
 		}, // {}
@@ -196,7 +196,7 @@ func TestDepth(t *testing.T) {
 			wantDepth: 2,
 		}, // {"a": 1, "b": [2, 3]}
 		{
-			name:      "indefinite length nested map",
+			name:      "indefinite-length nested map",
 			data:      mustHexDecode("bf61610161629f0203ffff"),
 			wantDepth: 2,
 		}, // {"a": 1, "b": [2, 3]}
@@ -231,7 +231,7 @@ func TestDepth(t *testing.T) {
 			wantDepth: 32,
 		},
 		{
-			name:      "32-level indefinite length array",
+			name:      "32-level indefinite-length array",
 			data:      mustHexDecode("9f018181818181818181818181818181818181818181818181818181818181818101ff"),
 			wantDepth: 32,
 		},
@@ -241,7 +241,7 @@ func TestDepth(t *testing.T) {
 			wantDepth: 32,
 		},
 		{
-			name:      "32-level indefinite length map",
+			name:      "32-level indefinite-length map",
 			data:      mustHexDecode("bf018181818181818181818181818181818181818181818181818181818181818101ff"),
 			wantDepth: 32,
 		},
@@ -291,7 +291,7 @@ func TestDepthError(t *testing.T) {
 			wantErrorMsg: "cbor: exceeded max nested level 32",
 		},
 		{
-			name:         "33-level indefinite length array",
+			name:         "33-level indefinite-length array",
 			data:         mustHexDecode("9f01818181818181818181818181818181818181818181818181818181818181818101ff"),
 			opts:         DecOptions{},
 			wantErrorMsg: "cbor: exceeded max nested level 32",
@@ -303,7 +303,7 @@ func TestDepthError(t *testing.T) {
 			wantErrorMsg: "cbor: exceeded max nested level 32",
 		},
 		{
-			name:         "33-level indefinite length map",
+			name:         "33-level indefinite-length map",
 			data:         mustHexDecode("bf01818181818181818181818181818181818181818181818181818181818181818101ff"),
 			opts:         DecOptions{},
 			wantErrorMsg: "cbor: exceeded max nested level 32",


### PR DESCRIPTION
This PR merges v2.9.1 into `feature/stream-mode` branch.  v2.9.1 was tagged on Monday morning, March 30, 2026.

v2.9.1 includes important bugfixes, defensive checks, improved code quality, and more tests. Although not public, the fuzzer was also improved by adding more fuzz tests.

See [v2.9.1 release notes](https://github.com/fxamacker/cbor/releases/tag/v2.9.1) for more details.

<details><summary>Conflict Resolution</summary>

```diff
commit 6fc4b610f8f69a74d3ce9e1539ffa1172ddc475d
Merge: 39888e6 63d1c66
Author: Faye Amacker <33205765+fxamacker@users.noreply.github.com>
Date:   Mon Mar 30 12:25:16 2026 -0500

    Merge tag 'v2.9.1' into fxamacker/update-streammode-to-release-v291

diff --git a/decode_test.go b/decode_test.go
remerge CONFLICT (content): Merge conflict in decode_test.go
index 8be9555..8f66eb7 100644
--- a/decode_test.go
+++ b/decode_test.go
@@ -3500,28 +3500,27 @@ var invalidCBORUnmarshalTestCases = []struct {
 		data:         mustHexDecode("00830102"),
 		wantErrorMsg: "cbor: 3 bytes of extraneous data starting at index 1",
 	},
-<<<<<<< 39888e6 (Merge pull request #715 from fxamacker/fxamacker/sync-stream-mode-branch-with-master)
-	// more
+	// End of input
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("59"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("5b"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("d8"),
 		wantErrorMsg: "unexpected EOF",
 	},
 	{
-		name:         "End of input in a head",
+		name:         "end of input in a head",
 		data:         mustHexDecode("d9"),
 		wantErrorMsg: "unexpected EOF",
-=======
+	},
 	// Indefinite-length map
 	{
 		name:         "indefinite-length map with one key and no value",
@@ -3532,7 +3531,6 @@ var invalidCBORUnmarshalTestCases = []struct {
 		name:         "indefinite-length map with two keys and one value",
 		data:         []byte{0xbf, 0x61, 'a', 0x01, 0x61, 'b', 0xff},
 		wantErrorMsg: `cbor: unexpected "break" code`,
->>>>>>> 63d1c66 (Merge pull request #758 from fxamacker/fxamacker/update-readme-for-release)
 	},
 }
 
diff --git a/stream.go b/stream.go
remerge CONFLICT (content): Merge conflict in stream.go
index 6c48b46..a61928b 100644
--- a/stream.go
+++ b/stream.go
@@ -175,9 +175,8 @@ func NewEncoder(w io.Writer) *Encoder {
 	return defaultEncMode.NewEncoder(w)
 }
 
-<<<<<<< 39888e6 (Merge pull request #715 from fxamacker/fxamacker/sync-stream-mode-branch-with-master)
 func (enc *Encoder) checkIndefiniteLengthDataItemTypeIfNeeded(v interface{}) error {
-	if len(enc.indefTypes) == 0 || v == nil {
+	if len(enc.indefTypes) == 0 {
 		return nil
 	}
 
@@ -187,15 +186,6 @@ func (enc *Encoder) checkIndefiniteLengthDataItemTypeIfNeeded(v interface{}) err
 
 func checkIndefiniteLengthDataItemType(indefType cborType, v interface{}) error {
 	switch indefType {
-	case cborTypeTextString:
-		k := reflect.TypeOf(v).Kind()
-		if k != reflect.String {
-			return errors.New("cbor: cannot encode item type " + k.String() + " for indefinite-length text string")
-=======
-// Encode writes the CBOR encoding of v.
-func (enc *Encoder) Encode(v any) error {
-	if len(enc.indefTypes) > 0 {
-		switch enc.indefTypes[len(enc.indefTypes)-1] {
 	case cborTypeTextString:
 		if v == nil {
 			return errors.New("cbor: cannot encode nil for indefinite-length text string")
@@ -204,6 +194,7 @@ func (enc *Encoder) Encode(v any) error {
 		if k != reflect.String {
 			return errors.New("cbor: cannot encode item type " + k.String() + " for indefinite-length text string")
 		}
+
 	case cborTypeByteString:
 		if v == nil {
 			return errors.New("cbor: cannot encode nil for indefinite-length byte string")
@@ -213,15 +204,6 @@ func (enc *Encoder) Encode(v any) error {
 		if (k != reflect.Array && k != reflect.Slice) || t.Elem().Kind() != reflect.Uint8 {
 			return errors.New("cbor: cannot encode item type " + k.String() + " for indefinite-length byte string")
 		}
->>>>>>> 63d1c66 (Merge pull request #758 from fxamacker/fxamacker/update-readme-for-release)
-		}
-
-	case cborTypeByteString:
-		t := reflect.TypeOf(v)
-		k := t.Kind()
-		if (k != reflect.Array && k != reflect.Slice) || t.Elem().Kind() != reflect.Uint8 {
-			return errors.New("cbor: cannot encode item type " + k.String() + " for indefinite-length byte string")
-		}
 	}
 
 	return nil
```

</details>