### PR TITLE
Reject encoding indefinite-length map with odd item count

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -6,6 +6,7 @@ package cbor
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 )
@@ -157,11 +158,31 @@ func (dec *Decoder) overwriteBuf(newBuf []byte) {
 	dec.off = 0
 }
 
+// indefDataItem tracks open indefinite-length data item during encoding.
+// typ is the CBOR type of the indefinite-length data item.
+// count is the number of items written so far.
+// For indefinite-length maps, count must be even (key/value pairs) when
+// the container is closed.
+type indefDataItem struct {
+	typ   cborType
+	count int
+}
+
+// IndefiniteLengthMapOddItemCountError indicates that EndIndefinite was
+// called on an open indefinite-length map with an odd number of items.
+type IndefiniteLengthMapOddItemCountError struct {
+	count int
+}
+
+func (e *IndefiniteLengthMapOddItemCountError) Error() string {
+	return fmt.Sprintf("cbor: cannot end indefinite-length map with %d item(s)", e.count)
+}
+
 // Encoder writes CBOR values to io.Writer.
 type Encoder struct {
-	w          io.Writer
-	em         *encMode
-	indefTypes []cborType
+	w      io.Writer
+	em     *encMode
+	indefs []indefDataItem
 }
 
 // NewEncoder returns a new encoder that writes to w using the default encoding options.
@@ -171,8 +192,8 @@ func NewEncoder(w io.Writer) *Encoder {
 
 // Encode writes the CBOR encoding of v.
 func (enc *Encoder) Encode(v any) error {
-	if len(enc.indefTypes) > 0 {
-		switch enc.indefTypes[len(enc.indefTypes)-1] {
+	if len(enc.indefs) > 0 {
+		switch enc.indefs[len(enc.indefs)-1].typ {
 		case cborTypeTextString:
 			if v == nil {
 				return errors.New("cbor: cannot encode nil for indefinite-length text string")
@@ -201,6 +222,10 @@ func (enc *Encoder) Encode(v any) error {
 	}
 
 	putEncodeBuffer(buf)
+
+	if err == nil && len(enc.indefs) > 0 {
+		enc.indefs[len(enc.indefs)-1].count++
+	}
 	return err
 }
 
@@ -233,13 +258,26 @@ func (enc *Encoder) StartIndefiniteMap() error {
 }
 
 // EndIndefinite closes last opened indefinite-length value.
+// It returns *IndefiniteLengthMapOddItemCountError without writing the
+// "break" code if the open indefinite-length map has an odd number of
+// items; the encoder state is unchanged so the caller can write the
+// missing value and retry.
 func (enc *Encoder) EndIndefinite() error {
-	if len(enc.indefTypes) == 0 {
+	if len(enc.indefs) == 0 {
 		return errors.New("cbor: cannot encode \"break\" code outside indefinite length values")
+	}
+	top := enc.indefs[len(enc.indefs)-1]
+	if top.typ == cborTypeMap && top.count%2 != 0 {
+		return &IndefiniteLengthMapOddItemCountError{count: top.count}
 	}
 	_, err := enc.w.Write([]byte{cborBreakFlag})
 	if err == nil {
-		enc.indefTypes = enc.indefTypes[:len(enc.indefTypes)-1]
+		enc.indefs = enc.indefs[:len(enc.indefs)-1]
+		// Increment parent container's item count because the child
+		// (indefinite-length data item) is fully written to the stream.
+		if len(enc.indefs) > 0 {
+			enc.indefs[len(enc.indefs)-1].count++
+		}
 	}
 	return err
 }
@@ -261,7 +299,7 @@ func (enc *Encoder) startIndefinite(typ cborType) error {
 	}
 	_, err := enc.w.Write([]byte{head})
 	if err == nil {
-		enc.indefTypes = append(enc.indefTypes, typ)
+		enc.indefs = append(enc.indefs, indefDataItem{typ: typ})
 	}
 	return err
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -1071,6 +1071,110 @@ func TestIndefiniteMapWithNilElement(t *testing.T) {
 	}
 }
 
+func TestIndefiniteLengthMapItemCount(t *testing.T) {
+	t.Run("odd item count", func(t *testing.T) {
+		var buf bytes.Buffer
+		encoder := NewEncoder(&buf)
+		if err := encoder.StartIndefiniteMap(); err != nil {
+			t.Fatalf("StartIndefiniteMap() returned error %v", err)
+		}
+		if err := encoder.Encode("a"); err != nil {
+			t.Fatalf("Encode() returned error %v", err)
+		}
+		err := encoder.EndIndefinite()
+		if err == nil {
+			t.Fatalf("EndIndefinite() returned nil error for indefinite-length map with odd number of items")
+		}
+		var oddErr *IndefiniteLengthMapOddItemCountError
+		if !errors.As(err, &oddErr) {
+			t.Fatalf("EndIndefinite() returned error of type %T, want *IndefiniteLengthMapOddItemCountError", err)
+		}
+		wantErrorMsg := "cbor: cannot end indefinite-length map with 1 item(s)"
+		if oddErr.Error() != wantErrorMsg {
+			t.Errorf("IndefiniteLengthMapOddItemCountError message = %q, want %q", oddErr.Error(), wantErrorMsg)
+		}
+		// Write the missing value.
+		if err := encoder.Encode(1); err != nil {
+			t.Fatalf("Encode() after odd-count error returned %v", err)
+		}
+		if err := encoder.EndIndefinite(); err != nil {
+			t.Fatalf("EndIndefinite() after recovery returned %v", err)
+		}
+		wantData := mustHexDecode("bf616101ff") // {_ "a": 1}
+		if !bytes.Equal(buf.Bytes(), wantData) {
+			t.Errorf("Encode returns %x, want %x", buf.Bytes(), wantData)
+		}
+	})
+
+	t.Run("even item count with nested container", func(t *testing.T) {
+		var buf bytes.Buffer
+		encoder := NewEncoder(&buf)
+		if err := encoder.StartIndefiniteMap(); err != nil {
+			t.Fatalf("StartIndefiniteMap() returned error %v", err)
+		}
+		if err := encoder.Encode("a"); err != nil {
+			t.Fatalf("Encode() returned error %v", err)
+		}
+		if err := encoder.StartIndefiniteMap(); err != nil {
+			t.Fatalf("nested StartIndefiniteMap() returned error %v", err)
+		}
+		if err := encoder.Encode("b"); err != nil {
+			t.Fatalf("Encode() returned error %v", err)
+		}
+		if err := encoder.Encode(1); err != nil {
+			t.Fatalf("Encode() returned error %v", err)
+		}
+		if err := encoder.EndIndefinite(); err != nil {
+			t.Fatalf("nested EndIndefinite() returned error %v", err)
+		}
+		if err := encoder.EndIndefinite(); err != nil {
+			t.Fatalf("outer EndIndefinite() returned error %v", err)
+		}
+		wantData := mustHexDecode("bf6161bf616201ffff") // {_ "a": {_ "b": 1}}
+		if !bytes.Equal(buf.Bytes(), wantData) {
+			t.Errorf("Encode returns %x, want %x", buf.Bytes(), wantData)
+		}
+	})
+
+	t.Run("odd item count with nested container", func(t *testing.T) {
+		var buf bytes.Buffer
+		encoder := NewEncoder(&buf)
+		if err := encoder.StartIndefiniteMap(); err != nil {
+			t.Fatalf("StartIndefiniteMap() returned error %v", err)
+		}
+		if err := encoder.Encode("a"); err != nil {
+			t.Fatalf("Encode() returned error %v", err)
+		}
+		if err := encoder.StartIndefiniteMap(); err != nil {
+			t.Fatalf("nested StartIndefiniteMap() returned error %v", err)
+		}
+		if err := encoder.Encode("b"); err != nil {
+			t.Fatalf("Encode() returned error %v", err)
+		}
+		if err := encoder.Encode(1); err != nil {
+			t.Fatalf("Encode() returned error %v", err)
+		}
+		if err := encoder.EndIndefinite(); err != nil {
+			t.Fatalf("nested EndIndefinite() returned error %v", err)
+		}
+		if err := encoder.Encode("c"); err != nil {
+			t.Fatalf("Encode() returned error %v", err)
+		}
+		err := encoder.EndIndefinite()
+		if err == nil {
+			t.Fatalf("outer EndIndefinite() didn't return error")
+		}
+		var oddErr *IndefiniteLengthMapOddItemCountError
+		if !errors.As(err, &oddErr) {
+			t.Fatalf("EndIndefinite() returned error of type %T, want *IndefiniteLengthMapOddItemCountError", err)
+		}
+		wantErrorMsg := "cbor: cannot end indefinite-length map with 3 item(s)"
+		if oddErr.Error() != wantErrorMsg {
+			t.Errorf("IndefiniteLengthMapOddItemCountError message = %q, want %q", oddErr.Error(), wantErrorMsg)
+		}
+	})
+}
+
 func TestIndefiniteLengthError(t *testing.T) {
 	var w bytes.Buffer
 	encoder := NewEncoder(&w)


### PR DESCRIPTION
Previously, the encoder did not prevent the user from using `StartIndefinitMap()` and `EndIndefinte()` to create an indefinite-length map having odd number of items.

The decoder has always rejected such maps for being malformed CBOR, and the encoder must not be allowed to produce them.

This PR makes the encoder track the number of items written into each open indefinite-length data item and return an error if `EndIndefinite()` is called on an indefinite-length map with an odd item count. The check runs before the "break" code is written, and the encoder state is unchanged on error, so the caller can write the missing value and call `EndIndefinite()` again.