### PR TITLE
Reject encoding indefinite-length data item as a chunk inside indefinite-length byte string or text string

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -5753,60 +5753,80 @@ func TestEncModeInvalidFieldNameMode(t *testing.T) {
 }
 
 func TestEncIndefiniteLengthOption(t *testing.T) {
-	// Default option allows indefinite-length items
-	var buf bytes.Buffer
-	enc := NewEncoder(&buf)
-	if err := enc.StartIndefiniteByteString(); err != nil {
-		t.Errorf("StartIndefiniteByteString() returned an error %v", err)
-	}
-	if err := enc.StartIndefiniteTextString(); err != nil {
-		t.Errorf("StartIndefiniteTextString() returned an error %v", err)
-	}
-	if err := enc.StartIndefiniteArray(); err != nil {
-		t.Errorf("StartIndefiniteArray() returned an error %v", err)
-	}
-	if err := enc.StartIndefiniteMap(); err != nil {
-		t.Errorf("StartIndefiniteMap() returned an error %v", err)
-	}
+	// Default option allows indefinite-length items.
+	t.Run("default option", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := NewEncoder(&buf)
+		if err := enc.StartIndefiniteByteString(); err != nil {
+			t.Errorf("StartIndefiniteByteString() returned an error %v", err)
+		}
+		if err := enc.EndIndefinite(); err != nil {
+			t.Errorf("EndIndefinite() returned an error %v", err)
+		}
+
+		if err := enc.StartIndefiniteTextString(); err != nil {
+			t.Errorf("StartIndefiniteTextString() returned an error %v", err)
+		}
+		if err := enc.EndIndefinite(); err != nil {
+			t.Errorf("EndIndefinite() returned an error %v", err)
+		}
+
+		if err := enc.StartIndefiniteArray(); err != nil {
+			t.Errorf("StartIndefiniteArray() returned an error %v", err)
+		}
+		if err := enc.EndIndefinite(); err != nil {
+			t.Errorf("EndIndefinite() returned an error %v", err)
+		}
+
+		if err := enc.StartIndefiniteMap(); err != nil {
+			t.Errorf("StartIndefiniteMap() returned an error %v", err)
+		}
+		if err := enc.EndIndefinite(); err != nil {
+			t.Errorf("EndIndefinite() returned an error %v", err)
+		}
+	})
 
 	// StartIndefiniteXXX returns error when IndefLength = IndefLengthForbidden
-	em, _ := EncOptions{IndefLength: IndefLengthForbidden}.EncMode()
-	enc = em.NewEncoder(&buf)
-	wantErrorMsg := "cbor: indefinite-length byte string isn't allowed"
-	if err := enc.StartIndefiniteByteString(); err == nil {
-		t.Errorf("StartIndefiniteByteString() didn't return an error")
-	} else if _, ok := err.(*IndefiniteLengthError); !ok {
-		t.Errorf("StartIndefiniteByteString() error type %T, want *IndefiniteLengthError", err)
-	} else if err.Error() != wantErrorMsg {
-		t.Errorf("StartIndefiniteByteString() returned error %q, want %q", err.Error(), wantErrorMsg)
-	}
+	t.Run("forbid indefinite length", func(t *testing.T) {
+		var buf bytes.Buffer
+		em, _ := EncOptions{IndefLength: IndefLengthForbidden}.EncMode()
+		enc := em.NewEncoder(&buf)
+		wantErrorMsg := "cbor: indefinite-length byte string isn't allowed"
+		if err := enc.StartIndefiniteByteString(); err == nil {
+			t.Errorf("StartIndefiniteByteString() didn't return an error")
+		} else if _, ok := err.(*IndefiniteLengthError); !ok {
+			t.Errorf("StartIndefiniteByteString() error type %T, want *IndefiniteLengthError", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("StartIndefiniteByteString() returned error %q, want %q", err.Error(), wantErrorMsg)
+		}
 
-	wantErrorMsg = "cbor: indefinite-length UTF-8 text string isn't allowed"
-	if err := enc.StartIndefiniteTextString(); err == nil {
-		t.Errorf("StartIndefiniteTextString() didn't return an error")
-	} else if _, ok := err.(*IndefiniteLengthError); !ok {
-		t.Errorf("StartIndefiniteTextString() error type %T, want *IndefiniteLengthError", err)
-	} else if err.Error() != wantErrorMsg {
-		t.Errorf("StartIndefiniteTextString() returned error %q, want %q", err.Error(), wantErrorMsg)
-	}
+		wantErrorMsg = "cbor: indefinite-length UTF-8 text string isn't allowed"
+		if err := enc.StartIndefiniteTextString(); err == nil {
+			t.Errorf("StartIndefiniteTextString() didn't return an error")
+		} else if _, ok := err.(*IndefiniteLengthError); !ok {
+			t.Errorf("StartIndefiniteTextString() error type %T, want *IndefiniteLengthError", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("StartIndefiniteTextString() returned error %q, want %q", err.Error(), wantErrorMsg)
+		}
 
-	wantErrorMsg = "cbor: indefinite-length array isn't allowed"
-	if err := enc.StartIndefiniteArray(); err == nil {
-		t.Errorf("StartIndefiniteArray() didn't return an error")
-	} else if _, ok := err.(*IndefiniteLengthError); !ok {
-		t.Errorf("StartIndefiniteArray() error type %T, want *IndefiniteLengthError", err)
-	} else if err.Error() != wantErrorMsg {
-		t.Errorf("StartIndefiniteArray() returned error %q, want %q", err.Error(), wantErrorMsg)
-	}
+		wantErrorMsg = "cbor: indefinite-length array isn't allowed"
+		if err := enc.StartIndefiniteArray(); err == nil {
+			t.Errorf("StartIndefiniteArray() didn't return an error")
+		} else if _, ok := err.(*IndefiniteLengthError); !ok {
+			t.Errorf("StartIndefiniteArray() error type %T, want *IndefiniteLengthError", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("StartIndefiniteArray() returned error %q, want %q", err.Error(), wantErrorMsg)
+		}
 
-	wantErrorMsg = "cbor: indefinite-length map isn't allowed"
-	if err := enc.StartIndefiniteMap(); err == nil {
-		t.Errorf("StartIndefiniteMap() didn't return an error")
-	} else if _, ok := err.(*IndefiniteLengthError); !ok {
-		t.Errorf("StartIndefiniteMap() error type %T, want *IndefiniteLengthError", err)
-	} else if err.Error() != wantErrorMsg {
-		t.Errorf("StartIndefiniteMap() returned error %q, want %q", err.Error(), wantErrorMsg)
-	}
+		wantErrorMsg = "cbor: indefinite-length map isn't allowed"
+		if err := enc.StartIndefiniteMap(); err == nil {
+			t.Errorf("StartIndefiniteMap() didn't return an error")
+		} else if _, ok := err.(*IndefiniteLengthError); !ok {
+			t.Errorf("StartIndefiniteMap() error type %T, want *IndefiniteLengthError", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("StartIndefiniteMap() returned error %q, want %q", err.Error(), wantErrorMsg)
+		}
+	})
 }
 
 func TestEncTagsMdOption(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -286,6 +286,13 @@ func (enc *Encoder) startIndefinite(typ cborType) error {
 	if enc.em.indefLength == IndefLengthForbidden {
 		return &IndefiniteLengthError{typ}
 	}
+	if len(enc.indefs) > 0 {
+		parent := enc.indefs[len(enc.indefs)-1].typ
+		if parent == cborTypeByteString || parent == cborTypeTextString {
+			return errors.New("cbor: cannot encode indefinite-length " + typ.String() +
+				" as chunk of indefinite-length " + parent.String())
+		}
+	}
 	var head byte
 	switch typ {
 	case cborTypeByteString:

--- a/stream_test.go
+++ b/stream_test.go
@@ -844,21 +844,72 @@ func TestIndefiniteByteString(t *testing.T) {
 	}
 }
 
-func TestIndefiniteByteStringError(t *testing.T) {
-	var w bytes.Buffer
-	encoder := NewEncoder(&w)
-	if err := encoder.StartIndefiniteByteString(); err != nil {
-		t.Fatalf("StartIndefiniteByteString() returned error %v", err)
+func TestIndefiniteByteStringWithInvalidChunk(t *testing.T) {
+	t.Run("array as chunk", func(t *testing.T) {
+		var w bytes.Buffer
+		encoder := NewEncoder(&w)
+		if err := encoder.StartIndefiniteByteString(); err != nil {
+			t.Fatalf("StartIndefiniteByteString() returned error %v", err)
+		}
+		if err := encoder.Encode([]int{1, 2}); err == nil {
+			t.Errorf("Encode() didn't return an error")
+		} else if err.Error() != "cbor: cannot encode item type slice for indefinite-length byte string" {
+			t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type slice for indefinite-length byte string")
+		}
+	})
+
+	t.Run("text string as chunk", func(t *testing.T) {
+		var w bytes.Buffer
+		encoder := NewEncoder(&w)
+		if err := encoder.StartIndefiniteByteString(); err != nil {
+			t.Fatalf("StartIndefiniteByteString() returned error %v", err)
+		}
+		if err := encoder.Encode("hello"); err == nil {
+			t.Errorf("Encode() didn't return an error")
+		} else if err.Error() != "cbor: cannot encode item type string for indefinite-length byte string" {
+			t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type string for indefinite-length byte string")
+		}
+	})
+
+	t.Run("nil as chunk", func(t *testing.T) {
+		var w bytes.Buffer
+		encoder := NewEncoder(&w)
+		if err := encoder.StartIndefiniteByteString(); err != nil {
+			t.Fatalf("StartIndefiniteByteString() returned error %v", err)
+		}
+		if err := encoder.Encode(nil); err == nil {
+			t.Errorf("Encode() didn't return an error")
+		} else if err.Error() != "cbor: cannot encode nil for indefinite-length byte string" {
+			t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode nil for indefinite-length byte string")
+		}
+	})
+
+	children := []struct {
+		start func(*Encoder) error
+		typ   string
+	}{
+		{(*Encoder).StartIndefiniteByteString, "byte string"},
+		{(*Encoder).StartIndefiniteTextString, "UTF-8 text string"},
+		{(*Encoder).StartIndefiniteArray, "array"},
+		{(*Encoder).StartIndefiniteMap, "map"},
 	}
-	if err := encoder.Encode([]int{1, 2}); err == nil {
-		t.Errorf("Encode() didn't return an error")
-	} else if err.Error() != "cbor: cannot encode item type slice for indefinite-length byte string" {
-		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type slice for indefinite-length byte string")
-	}
-	if err := encoder.Encode("hello"); err == nil {
-		t.Errorf("Encode() didn't return an error")
-	} else if err.Error() != "cbor: cannot encode item type string for indefinite-length byte string" {
-		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type string for indefinite-length byte string")
+	for _, child := range children {
+		t.Run("indefinite-length "+child.typ+" as chunk", func(t *testing.T) {
+			var w bytes.Buffer
+			encoder := NewEncoder(&w)
+			if err := encoder.StartIndefiniteByteString(); err != nil {
+				t.Fatalf("StartIndefiniteByteString() returned error %v", err)
+			}
+			err := child.start(encoder)
+			if err == nil {
+				t.Fatalf("encoding nested indefinite-length %s didn't return an error", child.typ)
+			}
+			wantErrMsg := "cbor: cannot encode indefinite-length " + child.typ +
+				" as chunk of indefinite-length byte string"
+			if err.Error() != wantErrMsg {
+				t.Errorf("error message = %q, want %q", err.Error(), wantErrMsg)
+			}
+		})
 	}
 }
 
@@ -883,47 +934,72 @@ func TestIndefiniteTextString(t *testing.T) {
 	}
 }
 
-func TestIndefiniteByteStringNilError(t *testing.T) {
-	var w bytes.Buffer
-	encoder := NewEncoder(&w)
-	if err := encoder.StartIndefiniteByteString(); err != nil {
-		t.Fatalf("StartIndefiniteByteString() returned error %v", err)
-	}
-	if err := encoder.Encode(nil); err == nil {
-		t.Errorf("Encode() didn't return an error")
-	} else if err.Error() != "cbor: cannot encode nil for indefinite-length byte string" {
-		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode nil for indefinite-length byte string")
-	}
-}
+func TestIndefiniteTextStringWithInvalidChunk(t *testing.T) {
+	t.Run("array as chunk", func(t *testing.T) {
+		var w bytes.Buffer
+		encoder := NewEncoder(&w)
+		if err := encoder.StartIndefiniteTextString(); err != nil {
+			t.Fatalf("StartIndefiniteTextString() returned error %v", err)
+		}
+		if err := encoder.Encode([]byte{1, 2}); err == nil {
+			t.Errorf("Encode() didn't return an error")
+		} else if err.Error() != "cbor: cannot encode item type slice for indefinite-length text string" {
+			t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type slice for indefinite-length text string")
+		}
+	})
 
-func TestIndefiniteTextStringError(t *testing.T) {
-	var w bytes.Buffer
-	encoder := NewEncoder(&w)
-	if err := encoder.StartIndefiniteTextString(); err != nil {
-		t.Fatalf("StartIndefiniteTextString() returned error %v", err)
-	}
-	if err := encoder.Encode([]byte{1, 2}); err == nil {
-		t.Errorf("Encode() didn't return an error")
-	} else if err.Error() != "cbor: cannot encode item type slice for indefinite-length text string" {
-		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type slice for indefinite-length text string")
-	}
-	if err := encoder.Encode(123); err == nil {
-		t.Errorf("Encode() didn't return an error")
-	} else if err.Error() != "cbor: cannot encode item type int for indefinite-length text string" {
-		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type int for indefinite-length text string")
-	}
-}
+	t.Run("integer as chunk", func(t *testing.T) {
+		var w bytes.Buffer
+		encoder := NewEncoder(&w)
+		if err := encoder.StartIndefiniteTextString(); err != nil {
+			t.Fatalf("StartIndefiniteTextString() returned error %v", err)
+		}
+		if err := encoder.Encode(123); err == nil {
+			t.Errorf("Encode() didn't return an error")
+		} else if err.Error() != "cbor: cannot encode item type int for indefinite-length text string" {
+			t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type int for indefinite-length text string")
+		}
+	})
 
-func TestIndefiniteTextStringNilError(t *testing.T) {
-	var w bytes.Buffer
-	encoder := NewEncoder(&w)
-	if err := encoder.StartIndefiniteTextString(); err != nil {
-		t.Fatalf("StartIndefiniteTextString() returned error %v", err)
+	t.Run("nil as chunk", func(t *testing.T) {
+		var w bytes.Buffer
+		encoder := NewEncoder(&w)
+		if err := encoder.StartIndefiniteTextString(); err != nil {
+			t.Fatalf("StartIndefiniteTextString() returned error %v", err)
+		}
+		if err := encoder.Encode(nil); err == nil {
+			t.Errorf("Encode() didn't return an error")
+		} else if err.Error() != "cbor: cannot encode nil for indefinite-length text string" {
+			t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode nil for indefinite-length text string")
+		}
+	})
+
+	children := []struct {
+		start func(*Encoder) error
+		typ   string
+	}{
+		{(*Encoder).StartIndefiniteByteString, "byte string"},
+		{(*Encoder).StartIndefiniteTextString, "UTF-8 text string"},
+		{(*Encoder).StartIndefiniteArray, "array"},
+		{(*Encoder).StartIndefiniteMap, "map"},
 	}
-	if err := encoder.Encode(nil); err == nil {
-		t.Errorf("Encode() didn't return an error")
-	} else if err.Error() != "cbor: cannot encode nil for indefinite-length text string" {
-		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode nil for indefinite-length text string")
+	for _, child := range children {
+		t.Run("indefinite-length "+child.typ+" as chunk", func(t *testing.T) {
+			var w bytes.Buffer
+			encoder := NewEncoder(&w)
+			if err := encoder.StartIndefiniteTextString(); err != nil {
+				t.Fatalf("StartIndefiniteTextString() returned error %v", err)
+			}
+			err := child.start(encoder)
+			if err == nil {
+				t.Fatalf("encoding nested indefinite-length %s didn't return an error", child.typ)
+			}
+			wantErrMsg := "cbor: cannot encode indefinite-length " + child.typ +
+				" as chunk of indefinite-length UTF-8 text string"
+			if err.Error() != wantErrMsg {
+				t.Errorf("error message = %q, want %q", err.Error(), wantErrMsg)
+			}
+		})
 	}
 }
 
@@ -1187,6 +1263,45 @@ func TestIndefiniteLengthError(t *testing.T) {
 	if err := encoder.EndIndefinite(); err == nil {
 		t.Fatalf("EndIndefinite() didn't return an error")
 	}
+}
+
+func TestEncodeNestedIndefiniteStringInArrayAndMap(t *testing.T) {
+	t.Run("indefinite-length byte string in indefinite-length array", func(t *testing.T) {
+		var w bytes.Buffer
+		encoder := NewEncoder(&w)
+		if err := encoder.StartIndefiniteArray(); err != nil {
+			t.Fatalf("StartIndefiniteArray() returned error %v", err)
+		}
+		if err := encoder.StartIndefiniteByteString(); err != nil {
+			t.Fatalf("StartIndefiniteByteString() inside array returned error %v", err)
+		}
+		if err := encoder.EndIndefinite(); err != nil {
+			t.Fatalf("inner EndIndefinite() returned error %v", err)
+		}
+		if err := encoder.EndIndefinite(); err != nil {
+			t.Fatalf("outer EndIndefinite() returned error %v", err)
+		}
+	})
+
+	t.Run("indefinite-length text string in indefinite-length map", func(t *testing.T) {
+		var w bytes.Buffer
+		encoder := NewEncoder(&w)
+		if err := encoder.StartIndefiniteMap(); err != nil {
+			t.Fatalf("StartIndefiniteMap() returned error %v", err)
+		}
+		if err := encoder.Encode("k"); err != nil {
+			t.Fatalf("Encode(key) returned error %v", err)
+		}
+		if err := encoder.StartIndefiniteTextString(); err != nil {
+			t.Fatalf("StartIndefiniteTextString() as map value returned error %v", err)
+		}
+		if err := encoder.EndIndefinite(); err != nil {
+			t.Fatalf("inner EndIndefinite() returned error %v", err)
+		}
+		if err := encoder.EndIndefinite(); err != nil {
+			t.Fatalf("outer EndIndefinite() returned error %v", err)
+		}
+	})
 }
 
 func TestEncoderStructTag(t *testing.T) {


### PR DESCRIPTION
Previously, the encoder did not prevent the user from encoding indefinite-length data item as a chunk inside an indefinite-length byte string or text string.

The decoder has always rejected such indefinite-length strings as malformed CBOR, and the encoder must not be allowed to produce them.

This PR makes the encoder check parent-type and reject any indefinite-length data item when an indefinite-length byte or text string is the parent open data item.

This additional check combined with existing checks, accepts definite-length byte string or text string as chunks while encoding indefinite-length bytes string or text string.
