### PR TITLE
feat: add toindefarray struct tag option for CBOR indefinite-length arrays

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -111,9 +111,16 @@ func getDecodingStructType(t reflect.Type) (*decodingStructType, error) {
 
 	flds, structOptions := getFields(t)
 
-	toArray := hasToArrayOption(structOptions)
-
-	if toArray {
+	hasToArray, hasToIndefArray, err := arrayStructOptions(t, structOptions)
+	if err != nil {
+		structType := &decodingStructType{err: err}
+		decodingStructTypeCache.Store(t, structType)
+		return nil, err
+	}
+	// Both options describe a struct laid out as a CBOR array. The decoder
+	// accepts definite- and indefinite-length arrays interchangeably, so
+	// the same code path serves both options.
+	if hasToArray || hasToIndefArray {
 		return getDecodingStructToArrayType(t, flds)
 	}
 
@@ -205,11 +212,12 @@ func getDecodingStructToArrayType(t reflect.Type, flds fields) (*decodingStructT
 
 type encodingStructType struct {
 	fields             encodingFields
-	bytewiseFields     encodingFields // Only populated if toArray is false
-	lengthFirstFields  encodingFields // Only populated if toArray is false
-	omitEmptyFieldsIdx []int          // Only populated if toArray is false
+	bytewiseFields     encodingFields // Only populated if struct is not array-shaped
+	lengthFirstFields  encodingFields // Only populated if struct is not array-shaped
+	omitEmptyFieldsIdx []int          // Only populated if struct is not array-shaped
 	err                error
-	toArray            bool
+	toArray            bool // True iff the struct declares the `toarray` option
+	toIndefArray       bool // True iff the struct declares the `toindefarray` option
 }
 
 func (st *encodingStructType) getFields(em *encMode) encodingFields {
@@ -245,8 +253,14 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 
 	flds, structOptions := getFields(t)
 
-	if hasToArrayOption(structOptions) {
-		return getEncodingStructToArrayType(t, flds)
+	hasToArray, hasToIndefArray, err := arrayStructOptions(t, structOptions)
+	if err != nil {
+		structType := &encodingStructType{err: err}
+		encodingStructTypeCache.Store(t, structType)
+		return nil, err
+	}
+	if hasToArray || hasToIndefArray {
+		return getEncodingStructToArrayType(t, flds, hasToArray, hasToIndefArray)
 	}
 
 	var hasKeyAsInt bool
@@ -344,7 +358,7 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 	return structType, nil
 }
 
-func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructType, error) {
+func getEncodingStructToArrayType(t reflect.Type, flds fields, toArray, toIndefArray bool) (*encodingStructType, error) {
 	encFlds := make(encodingFields, len(flds))
 	for i, f := range flds {
 		encFlds[i] = &encodingField{field: *f}
@@ -357,8 +371,9 @@ func getEncodingStructToArrayType(t reflect.Type, flds fields) (*encodingStructT
 	}
 
 	structType := &encodingStructType{
-		fields:  encFlds,
-		toArray: true,
+		fields:       encFlds,
+		toArray:      toArray,
+		toIndefArray: toIndefArray,
 	}
 	encodingStructTypeCache.Store(t, structType)
 	return structType, nil
@@ -387,4 +402,22 @@ func hasToArrayOption(tag string) bool {
 	s := ",toarray"
 	idx := strings.Index(tag, s)
 	return idx >= 0 && (len(tag) == idx+len(s) || tag[idx+len(s)] == ',')
+}
+
+func hasToIndefArrayOption(tag string) bool {
+	s := ",toindefarray"
+	idx := strings.Index(tag, s)
+	return idx >= 0 && (len(tag) == idx+len(s) || tag[idx+len(s)] == ',')
+}
+
+// arrayStructOptions reports whether the struct options request encoding as
+// a CBOR array (definite- or indefinite-length), and returns an error if the
+// two options are specified together (they are mutually exclusive).
+func arrayStructOptions(t reflect.Type, structOptions string) (hasToArray, hasToIndefArray bool, err error) {
+	hasToArray = hasToArrayOption(structOptions)
+	hasToIndefArray = hasToIndefArrayOption(structOptions)
+	if hasToArray && hasToIndefArray {
+		return false, false, fmt.Errorf("cbor: struct %v cannot have both \"toarray\" and \"toindefarray\" options", t)
+	}
+	return hasToArray, hasToIndefArray, nil
 }

--- a/encode.go
+++ b/encode.go
@@ -546,6 +546,25 @@ func (tmm TextMarshalerMode) valid() bool {
 	return tmm >= 0 && tmm < maxTextMarshalerMode
 }
 
+// ToIndefArrayStructTagMode specifies whether to honor the `toindefarray`
+// struct tag option. Indefinite-length encoding via the streaming API is
+// governed separately by IndefLength.
+type ToIndefArrayStructTagMode int
+
+const (
+	// ToIndefArrayStructTagForbidden rejects encoding of structs tagged with `toindefarray`.
+	ToIndefArrayStructTagForbidden ToIndefArrayStructTagMode = iota
+
+	// ToIndefArrayStructTagAllowed encodes structs tagged with `toindefarray` as indefinite-length arrays.
+	ToIndefArrayStructTagAllowed
+
+	maxToIndefArrayStructTagMode
+)
+
+func (m ToIndefArrayStructTagMode) valid() bool {
+	return m >= 0 && m < maxToIndefArrayStructTagMode
+}
+
 // EncOptions specifies encoding options.
 type EncOptions struct {
 	// Sort specifies sorting order.
@@ -611,6 +630,9 @@ type EncOptions struct {
 	// json.Marshaler but do not also implement cbor.Marshaler. If nil, encoding behavior is not
 	// influenced by whether or not a type implements json.Marshaler.
 	JSONMarshalerTranscoder Transcoder
+
+	// ToIndefArrayStructTag specifies whether the `toindefarray` struct tag option is honored.
+	ToIndefArrayStructTag ToIndefArrayStructTagMode
 }
 
 // CanonicalEncOptions returns EncOptions for "Canonical CBOR" encoding,
@@ -824,6 +846,12 @@ func (opts EncOptions) encMode() (*encMode, error) { //nolint:gocritic // ignore
 	if !opts.TextMarshaler.valid() {
 		return nil, errors.New("cbor: invalid TextMarshaler " + strconv.Itoa(int(opts.TextMarshaler)))
 	}
+	if !opts.ToIndefArrayStructTag.valid() {
+		return nil, errors.New("cbor: invalid ToIndefArrayStructTag " + strconv.Itoa(int(opts.ToIndefArrayStructTag)))
+	}
+	if opts.IndefLength == IndefLengthForbidden && opts.ToIndefArrayStructTag == ToIndefArrayStructTagAllowed {
+		return nil, errors.New("cbor: cannot set ToIndefArrayStructTag to ToIndefArrayStructTagAllowed when IndefLength is IndefLengthForbidden")
+	}
 	em := encMode{
 		sort:                      opts.Sort,
 		shortestFloat:             opts.ShortestFloat,
@@ -845,6 +873,7 @@ func (opts EncOptions) encMode() (*encMode, error) { //nolint:gocritic // ignore
 		binaryMarshaler:           opts.BinaryMarshaler,
 		textMarshaler:             opts.TextMarshaler,
 		jsonMarshalerTranscoder:   opts.JSONMarshalerTranscoder,
+		toIndefArrayStructTag:     opts.ToIndefArrayStructTag,
 	}
 	return &em, nil
 }
@@ -892,6 +921,7 @@ type encMode struct {
 	binaryMarshaler           BinaryMarshalerMode
 	textMarshaler             TextMarshalerMode
 	jsonMarshalerTranscoder   Transcoder
+	toIndefArrayStructTag     ToIndefArrayStructTagMode
 }
 
 var defaultEncMode, _ = EncOptions{}.encMode()
@@ -986,6 +1016,7 @@ func (em *encMode) EncOptions() EncOptions {
 		BinaryMarshaler:         em.binaryMarshaler,
 		TextMarshaler:           em.textMarshaler,
 		JSONMarshalerTranscoder: em.jsonMarshalerTranscoder,
+		ToIndefArrayStructTag:   em.toIndefArrayStructTag,
 	}
 }
 
@@ -1457,13 +1488,22 @@ func encodeStructToArray(e *bytes.Buffer, em *encMode, v reflect.Value) (err err
 		return err
 	}
 
+	if structType.toIndefArray && em.toIndefArrayStructTag != ToIndefArrayStructTagAllowed {
+		return errors.New("cbor: cannot encode struct " + v.Type().String() +
+			" with `toindefarray` when ToIndefArrayStructTag is not ToIndefArrayStructTagAllowed")
+	}
+
 	if b := em.encTagBytes(v.Type()); b != nil {
 		e.Write(b)
 	}
 
 	flds := structType.fields
 
-	encodeHead(e, byte(cborTypeArray), uint64(len(flds)))
+	if structType.toIndefArray {
+		e.WriteByte(cborArrayWithIndefiniteLengthHead)
+	} else {
+		encodeHead(e, byte(cborTypeArray), uint64(len(flds)))
+	}
 	for i := range flds {
 		f := flds[i]
 
@@ -1485,6 +1525,9 @@ func encodeStructToArray(e *bytes.Buffer, em *encMode, v reflect.Value) (err err
 		if err := f.ef(e, em, fv); err != nil {
 			return err
 		}
+	}
+	if structType.toIndefArray {
+		e.WriteByte(cborBreakFlag)
 	}
 	return nil
 }
@@ -2050,7 +2093,7 @@ func getEncodeFuncInternal(t reflect.Type) (ef encodeFunc, ief isEmptyFunc, izf 
 		if f, ok := t.FieldByName("_"); ok {
 			tag := f.Tag.Get("cbor")
 			if tag != "-" {
-				if hasToArrayOption(tag) {
+				if hasToArrayOption(tag) || hasToIndefArrayOption(tag) {
 					return encodeStructToArray, isEmptyStruct, isZeroFieldStruct
 				}
 			}
@@ -2133,7 +2176,7 @@ func isEmptyStruct(em *encMode, v reflect.Value) (bool, error) {
 		return false, nil
 	}
 
-	if structType.toArray {
+	if structType.toArray || structType.toIndefArray {
 		return len(structType.fields) == 0, nil
 	}
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -5633,6 +5633,13 @@ func TestEncOptions(t *testing.T) {
 				// non-zero value for other options (e.g. TimeTag).
 				continue
 			}
+			if fn == "ToIndefArrayStructTag" {
+				// Roundtripping non-zero values for ToIndefArrayStructTag is tested
+				// separately since the non-zero value (ToIndefArrayStructTagAllowed)
+				// is incompatible with IndefLengthForbidden, which is the non-zero
+				// value used by IndefLength above.
+				continue
+			}
 			t.Errorf("options field %q is unset or set to the zero value for its type", fn)
 		}
 	}

--- a/toindefarray_test.go
+++ b/toindefarray_test.go
@@ -1,0 +1,331 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// allowToIndefArrayMode returns an EncMode with the toindefarray struct tag
+// option allowed. It is a small helper to keep tests focused on behavior.
+func allowToIndefArrayMode(t *testing.T) EncMode {
+	t.Helper()
+	em, err := EncOptions{ToIndefArrayStructTag: ToIndefArrayStructTagAllowed}.EncMode()
+	if err != nil {
+		t.Fatalf("EncMode() returned error: %v", err)
+	}
+	return em
+}
+
+// TestEncodeStructToIndefArrayBasic verifies the encoded bytes for a
+// typical struct and that the data roundtrips through the default decoder.
+func TestEncodeStructToIndefArrayBasic(t *testing.T) {
+	type S struct {
+		_     struct{} `cbor:",toindefarray"`
+		Data  []byte
+		Count int
+	}
+
+	in := S{Data: []byte{0x73, 0xf7, 0x2d, 0xbe}, Count: 3}
+
+	em := allowToIndefArrayMode(t)
+	got, err := em.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	// EDN: [_ h'73f72dbe', 3]
+	want := []byte{0x9f, 0x44, 0x73, 0xf7, 0x2d, 0xbe, 0x03, 0xff}
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %x, want %x", got, want)
+	}
+
+	// Roundtrip: decoder accepts both definite and indefinite arrays for
+	// toindefarray-tagged structs (the tag treats them the same way as
+	// `toarray` for decoding).
+	var out S
+	if err := Unmarshal(got, &out); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("roundtrip mismatch: got %+v, want %+v", out, in)
+	}
+}
+
+// TestEncodeStructToIndefArrayEmpty verifies that an empty struct produces
+// exactly the two bytes 0x9f 0xff (no inner fields).
+func TestEncodeStructToIndefArrayEmpty(t *testing.T) {
+	type Empty struct {
+		_ struct{} `cbor:",toindefarray"`
+	}
+
+	em := allowToIndefArrayMode(t)
+	in := Empty{}
+	got, err := em.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	// EDN: [_]
+	want := []byte{0x9f, 0xff}
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %x, want %x", got, want)
+	}
+
+	var out Empty
+	if err := Unmarshal(got, &out); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("roundtrip mismatch: got %+v, want %+v", out, in)
+	}
+}
+
+// TestEncodeStructToIndefArrayNested verifies the byte layout and roundtrip
+// of a struct with toindefarray containing another struct with toindefarray.
+func TestEncodeStructToIndefArrayNested(t *testing.T) {
+	type Inner struct {
+		_ struct{} `cbor:",toindefarray"`
+		X []byte
+		Y int
+	}
+	type Outer struct {
+		_     struct{} `cbor:",toindefarray"`
+		Inner Inner
+		Z     int
+	}
+
+	in := Outer{
+		Inner: Inner{X: []byte{0xab, 0xcd}, Y: 42},
+		Z:     7,
+	}
+
+	em := allowToIndefArrayMode(t)
+	got, err := em.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	// EDN: [_ [_ h'abcd', 42], 7]
+	want := []byte{0x9f, 0x9f, 0x42, 0xab, 0xcd, 0x18, 0x2a, 0xff, 0x07, 0xff}
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %x, want %x", got, want)
+	}
+
+	var out Outer
+	if err := Unmarshal(got, &out); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("roundtrip mismatch: got %+v, want %+v", out, in)
+	}
+}
+
+// TestEncodeStructToIndefArrayForbiddenByDefault verifies that the default
+// EncOptions (zero value) refuses to encode a struct tagged with
+// `toindefarray`. The error message references the struct type and the
+// option name to give callers a clear remediation path.
+func TestEncodeStructToIndefArrayForbiddenByDefault(t *testing.T) {
+	type S struct {
+		_ struct{} `cbor:",toindefarray"`
+		A int
+	}
+
+	_, err := Marshal(S{A: 1})
+	if err == nil {
+		t.Fatal("expected error from default Marshal, got nil")
+	}
+	if !strings.Contains(err.Error(), "ToIndefArrayStructTag") {
+		t.Errorf("error should mention ToIndefArrayStructTag, got: %v", err)
+	}
+}
+
+// TestEncodeStructToIndefArrayMutuallyExclusive verifies that a struct
+// declaring both `toarray` and `toindefarray` is rejected at encode time
+// regardless of mode (the rejection comes from the type cache itself).
+func TestEncodeStructToIndefArrayMutuallyExclusive(t *testing.T) {
+	type Bad struct {
+		_ struct{} `cbor:",toarray,toindefarray"`
+		A int
+	}
+
+	em := allowToIndefArrayMode(t)
+	_, err := em.Marshal(Bad{A: 1})
+	if err == nil {
+		t.Fatal("expected error for struct declaring both toarray and toindefarray, got nil")
+	}
+	if !strings.Contains(err.Error(), "toarray") || !strings.Contains(err.Error(), "toindefarray") {
+		t.Errorf("error should mention both options, got: %v", err)
+	}
+}
+
+// TestToIndefArrayStructTagOptionsRoundTrip verifies that an EncOptions
+// value containing the non-zero value of ToIndefArrayStructTag round-trips
+// through EncOptions -> EncMode -> EncOptions with all fields preserved.
+// TestEncOptions cannot cover this case because the non-zero values of
+// IndefLength and ToIndefArrayStructTag are mutually exclusive.
+func TestToIndefArrayStructTagOptionsRoundTrip(t *testing.T) {
+	opts := EncOptions{ToIndefArrayStructTag: ToIndefArrayStructTagAllowed}
+	em, err := opts.EncMode()
+	if err != nil {
+		t.Fatalf("EncMode() returned error: %v", err)
+	}
+	got := em.EncOptions()
+	if !reflect.DeepEqual(opts, got) {
+		t.Errorf("EncOptions round-trip mismatch:\n got: %#v\nwant: %#v", got, opts)
+	}
+}
+
+// TestInvalidToIndefArrayStructTagMode verifies that EncOptions rejects
+// out-of-range values for ToIndefArrayStructTagMode at mode construction time.
+func TestInvalidToIndefArrayStructTagMode(t *testing.T) {
+	for _, m := range []ToIndefArrayStructTagMode{-1, maxToIndefArrayStructTagMode, maxToIndefArrayStructTagMode + 1} {
+		_, err := EncOptions{ToIndefArrayStructTag: m}.EncMode()
+		if err == nil {
+			t.Errorf("expected error for mode %d, got nil", m)
+			continue
+		}
+		if !strings.Contains(err.Error(), "ToIndefArrayStructTag") {
+			t.Errorf("error for mode %d should mention ToIndefArrayStructTag, got: %v", m, err)
+		}
+	}
+}
+
+// TestToIndefArrayStructTagRejectsIndefLengthForbidden verifies that
+// EncOptions rejects the combination of IndefLengthForbidden and
+// ToIndefArrayStructTagAllowed at mode construction time, since the two
+// settings are contradictory.
+func TestToIndefArrayStructTagRejectsIndefLengthForbidden(t *testing.T) {
+	_, err := EncOptions{
+		IndefLength:           IndefLengthForbidden,
+		ToIndefArrayStructTag: ToIndefArrayStructTagAllowed,
+	}.EncMode()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ToIndefArrayStructTag") || !strings.Contains(err.Error(), "IndefLength") {
+		t.Errorf("error should mention both options, got: %v", err)
+	}
+}
+
+// TestEncodeStructToIndefArrayEmbeddedField verifies that fields promoted
+// from an embedded struct are encoded as elements of the indefinite-length
+// array, in the same order they would appear under toarray.
+func TestEncodeStructToIndefArrayEmbeddedField(t *testing.T) {
+	type Inner struct {
+		A uint64
+		B uint64
+	}
+	type Outer struct {
+		_ struct{} `cbor:",toindefarray"`
+		Inner
+		C uint64
+	}
+
+	em := allowToIndefArrayMode(t)
+	got, err := em.Marshal(Outer{Inner: Inner{A: 1, B: 2}, C: 3})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	// EDN: [_ 1, 2, 3]  (promoted A, B, then C)
+	want := []byte{0x9f, 0x01, 0x02, 0x03, 0xff}
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %x, want %x", got, want)
+	}
+}
+
+// TestEncodeStructToIndefArrayParentIndefChildArray verifies that a struct
+// using toindefarray can contain a struct using toarray, and the inner
+// struct still encodes as a definite-length array.
+func TestEncodeStructToIndefArrayParentIndefChildArray(t *testing.T) {
+	type Inner struct {
+		_ struct{} `cbor:",toarray"`
+		A uint64
+		B uint64
+	}
+	type Outer struct {
+		_     struct{} `cbor:",toindefarray"`
+		Inner Inner
+		C     uint64
+	}
+
+	em := allowToIndefArrayMode(t)
+	got, err := em.Marshal(Outer{Inner: Inner{A: 1, B: 2}, C: 3})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	// EDN: [_ [1, 2], 3]
+	want := []byte{0x9f, 0x82, 0x01, 0x02, 0x03, 0xff}
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %x, want %x", got, want)
+	}
+}
+
+// TestEncodeStructToIndefArrayParentArrayChildIndef verifies the symmetric
+// case: a parent with toarray containing a child with toindefarray.
+func TestEncodeStructToIndefArrayParentArrayChildIndef(t *testing.T) {
+	type Inner struct {
+		_ struct{} `cbor:",toindefarray"`
+		A uint64
+		B uint64
+	}
+	type Outer struct {
+		_     struct{} `cbor:",toarray"`
+		Inner Inner
+		C     uint64
+	}
+
+	em := allowToIndefArrayMode(t)
+	got, err := em.Marshal(Outer{Inner: Inner{A: 1, B: 2}, C: 3})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	// EDN: [[_ 1, 2], 3]
+	want := []byte{0x82, 0x9f, 0x01, 0x02, 0xff, 0x03}
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %x, want %x", got, want)
+	}
+}
+
+// TestEncodeStructToIndefArrayWithCBORTag verifies that a struct registered
+// with a CBOR tag through TagSet and tagged `toindefarray` produces the tag
+// header followed by an indefinite-length array of its fields.
+func TestEncodeStructToIndefArrayWithCBORTag(t *testing.T) {
+	type S struct {
+		_      struct{} `cbor:",toindefarray"`
+		Field1 uint64
+		Field2 uint64
+	}
+
+	tags := NewTagSet()
+	if err := tags.Add(
+		TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired},
+		reflect.TypeOf(S{}),
+		121,
+	); err != nil {
+		t.Fatalf("TagSet.Add returned error: %v", err)
+	}
+
+	em, err := EncOptions{ToIndefArrayStructTag: ToIndefArrayStructTagAllowed}.EncModeWithTags(tags)
+	if err != nil {
+		t.Fatalf("EncModeWithTags returned error: %v", err)
+	}
+
+	got, err := em.Marshal(S{Field1: 1, Field2: 2})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	// EDN: 121([_ 1, 2])
+	want := []byte{0xd8, 0x79, 0x9f, 0x01, 0x02, 0xff}
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %x, want %x", got, want)
+	}
+}


### PR DESCRIPTION
### Description

Adds the `toindefarray` struct tag option, gated by a new `EncOptions.ToIndefArrayStructTag` field. When enabled, a tagged struct encodes as a CBOR indefinite-length array (head `0x9f`, break `0xff`) instead of a definite-length array. This was discussed and welcomed in issue #762.

**Motivation**: Cardano Plutus Data interoperability. The reference `plutus-core` data encoder emits `Constr` field lists as indefinite-length arrays for non-empty payloads, and consumers in that ecosystem accept only that exact byte layout.

**Public API additions** (encode-side only):

```go
type ToIndefArrayStructTagMode int

const (
    ToIndefArrayStructTagForbidden ToIndefArrayStructTagMode = iota // default
    ToIndefArrayStructTagAllowed
)

// EncOptions adds:
//   ToIndefArrayStructTag ToIndefArrayStructTagMode
```

**Struct usage**:

```go
type Constr0 struct {
    _      struct{} `cbor:",toindefarray"`
    Field1 uint64
    Field2 uint64
}
// With EncOptions.ToIndefArrayStructTag = ToIndefArrayStructTagAllowed:
//   Marshal(Constr0{1, 2})    => 9f 01 02 ff
```

**Behavior contract**:

- Default `ToIndefArrayStructTagForbidden` rejects encoding a struct tagged with `toindefarray` and returns a clear error pointing at the option name. Existing users see no change.
- Setting `ToIndefArrayStructTag = ToIndefArrayStructTagAllowed` together with `IndefLength = IndefLengthForbidden` is rejected at `EncMode()` time as a contradictory combination.
- `toarray` and `toindefarray` on the same struct are mutually exclusive and rejected at type-cache time, on both encoder and decoder side, with the same error message.
- The decoder is unchanged at the byte level: it accepts both definite- and indefinite-length arrays for `toindefarray`-tagged structs (same as it does for `toarray`).
- An empty struct produces exactly two bytes: `0x9f 0xff`.
- The new option only governs the struct tag mechanism. Indefinite-length encoding via the streaming API (`(*Encoder).StartIndefiniteArray`) continues to be governed by `IndefLength`.

**Files changed**:

- `cache.go` — `hasToIndefArrayOption`, `getEncodingStructToIndefArrayType`, mutual-exclusion check on both encoder and decoder cache, route `toindefarray` through the existing array decode path.
- `encode.go` — `ToIndefArrayStructTagMode` enum, `EncOptions` field, `encMode` field, validation in `encMode()` (including the cross-option check against `IndefLengthForbidden`), `encodeStructToIndefArray` with runtime gate, dispatch in `getEncodeFuncInternal`.
- `toindefarray_test.go` — new tests (see below).
- `encode_test.go` — extended `TestEncOptions` to skip `ToIndefArrayStructTag` for the non-zero invariant (its non-zero value conflicts with `IndefLengthForbidden`, mirroring the existing escape hatch for `TagsMd`).

**Test coverage**:

- `TestEncodeStructToIndefArrayBasic` — header/break/roundtrip on a typical struct.
- `TestEncodeStructToIndefArrayEmpty` — empty struct emits exactly `0x9f 0xff`.
- `TestEncodeStructToIndefArrayNested` — nested `toindefarray` structs roundtrip.
- `TestEncodeStructToIndefArrayEmbeddedField` — fields promoted from an embedded struct are encoded in order.
- `TestEncodeStructToIndefArrayParentIndefChildArray` — parent `toindefarray` containing child `toarray` produces nested `9f 82 ... ff`.
- `TestEncodeStructToIndefArrayParentArrayChildIndef` — parent `toarray` containing child `toindefarray` produces nested `82 9f ... ff ...`.
- `TestEncodeStructToIndefArrayForbiddenByDefault` — default `EncOptions{}` rejects with an error mentioning `ToIndefArrayStructTag`.
- `TestEncodeStructToIndefArrayMutuallyExclusive` — struct with both `toarray` and `toindefarray` is rejected.
- `TestToIndefArrayStructTagOptionsRoundTrip` — non-zero value of the option round-trips through `EncOptions -> EncMode -> EncOptions`.
- `TestInvalidToIndefArrayStructTagMode` — out-of-range mode values are rejected by `EncMode()`.
- `TestToIndefArrayStructTagRejectsIndefLengthForbidden` — combination with `IndefLengthForbidden` is rejected at `EncMode()` time.
- `TestEncodeStructToIndefArrayWithCBORTag` — verifies a struct registered with a CBOR tag through `TagSet` and tagged `toindefarray` produces the tag header followed by an indefinite-length array.

#### PR Was Proposed and Welcomed in Currently Open Issue

- [x] This PR was proposed and welcomed by maintainer(s) in issue #762
- [x] Closes or Updates Issue #762

#### Checklist (for code PR only, ignore for docs PR)

- [x] Include unit tests that cover the new code
- [x] Pass all unit tests (verified locally with `go test ./...` and `go test -race -short ./...`; coverage held at 97.0%)
- [x] Pass all lint checks in CI (goimports, gosec, staticcheck, etc.)
- [x] Sign each commit with your real name and email.
- [x] Certify the Developer's Certificate of Origin 1.1
      (see next section).

#### Certify the Developer's Certificate of Origin 1.1

- [x] By marking this item as completed, I certify
      the Developer Certificate of Origin 1.1.