### PR TITLE
Update to require go 1.24 and modernize code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: ['1.20', 1.21, 1.22, 1.23, 1.24, 1.25]
+        go-version: [1.24, 1.25, 1.26]
     steps:
     - name: Install Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/bench_test.go
+++ b/bench_test.go
@@ -306,37 +306,37 @@ func BenchmarkUnmarshal(b *testing.B) {
 		{
 			name:         "CBOR map to Go map[string]interface{}",
 			data:         mustHexDecode("a86154f56255691bffffffffffffffff61493903e76146fbc0106666666666666142581a0102030405060708090a0b0c0d0e0f101112131415161718191a6153782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6764536c6369981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a634d7373ad6163614361656145616661466167614761686148616e614e616d614d61616141616261426164614461696149616a614a616c614c"),
-			decodeToType: reflect.TypeOf(map[string]any{}),
+			decodeToType: reflect.TypeFor[map[string]any](),
 		},
 		// Unmarshal CBOR map with string key to struct.
 		{
 			name:         "CBOR map to Go struct",
 			data:         mustHexDecode("a86154f56255491bffffffffffffffff61493903e76146fbc0106666666666666142581a0102030405060708090a0b0c0d0e0f101112131415161718191a6153782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6764536c6369981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a634d7373ad6163614361656145616661466167614761686148616e614e616d614d61616141616261426164614461696149616a614a616c614c"),
-			decodeToType: reflect.TypeOf(T1{}),
+			decodeToType: reflect.TypeFor[T1](),
 		},
 		// Unmarshal CBOR map with integer key, such as COSE Key and SenML, to map[int]interface{}.
 		{
 			name:         "CBOR map to Go map[int]interface{}",
 			data:         mustHexDecode("a801f5021bffffffffffffffff033903e704fbc01066666666666605581a0102030405060708090a0b0c0d0e0f101112131415161718191a06782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6707981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a08ad61646144616661466167614761686148616d614d616e614e6161614161626142616361436165614561696149616a614a616c614c"),
-			decodeToType: reflect.TypeOf(map[int]any{}),
+			decodeToType: reflect.TypeFor[map[int]any](),
 		},
 		// Unmarshal CBOR map with integer key, such as COSE Key and SenML, to struct.
 		{
 			name:         "CBOR map to Go struct keyasint",
 			data:         mustHexDecode("a801f5021bffffffffffffffff033903e704fbc01066666666666605581a0102030405060708090a0b0c0d0e0f101112131415161718191a06782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6707981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a08ad61646144616661466167614761686148616d614d616e614e6161614161626142616361436165614561696149616a614a616c614c"),
-			decodeToType: reflect.TypeOf(T2{}),
+			decodeToType: reflect.TypeFor[T2](),
 		},
 		// Unmarshal CBOR array of known sequence of data types, such as signed/maced/encrypted CWT, to []interface{}.
 		{
 			name:         "CBOR array to Go []interface{}",
 			data:         mustHexDecode("88f51bffffffffffffffff3903e7fbc010666666666666581a0102030405060708090a0b0c0d0e0f101112131415161718191a782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67981a0102030405060708090a0b0c0d0e0f101112131415161718181819181aad616261426163614361646144616561456166614661696149616e614e616161416167614761686148616a614a616c614c616d614d"),
-			decodeToType: reflect.TypeOf([]any{}),
+			decodeToType: reflect.TypeFor[[]any](),
 		},
 		// Unmarshal CBOR array of known sequence of data types, such as signed/maced/encrypted CWT, to struct.
 		{
 			name:         "CBOR array to Go struct toarray",
 			data:         mustHexDecode("88f51bffffffffffffffff3903e7fbc010666666666666581a0102030405060708090a0b0c0d0e0f101112131415161718191a782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67981a0102030405060708090a0b0c0d0e0f101112131415161718181819181aad616261426163614361646144616561456166614661696149616e614e616161416167614761686148616a614a616c614c616d614d"),
-			decodeToType: reflect.TypeOf(T3{}),
+			decodeToType: reflect.TypeFor[T3](),
 		},
 	}
 	for _, bm := range moreBenchmarks {
@@ -429,11 +429,10 @@ func BenchmarkDecodeStream(b *testing.B) {
 		}
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		buf := bytes.NewReader(data)
 		decoder := NewDecoder(buf)
-		for j := 0; j < rounds; j++ {
+		for range rounds {
 			for _, bm := range decodeBenchmarks {
 				for _, t := range bm.decodeToTypes {
 					vPtr := reflect.New(t).Interface()
@@ -702,9 +701,9 @@ func BenchmarkEncode(b *testing.B) {
 }
 
 func BenchmarkEncodeStream(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		encoder := NewEncoder(io.Discard)
-		for i := 0; i < rounds; i++ {
+		for range rounds {
 			for _, bm := range encodeBenchmarks {
 				for _, v := range bm.values {
 					if err := encoder.Encode(v); err != nil {
@@ -784,7 +783,7 @@ func BenchmarkMarshalCOSE(b *testing.B) {
 func BenchmarkUnmarshalCWTClaims(b *testing.B) {
 	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
 	data := mustHexDecode("a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b71")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var v claims
 		if err := Unmarshal(data, &v); err != nil {
 			b.Fatal("Unmarshal:", err)
@@ -796,7 +795,7 @@ func BenchmarkUnmarshalCWTClaimsWithDupMapKeyOpt(b *testing.B) {
 	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
 	data := mustHexDecode("a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b71")
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var v claims
 		if err := dm.Unmarshal(data, &v); err != nil {
 			b.Fatal("Unmarshal:", err)
@@ -811,7 +810,7 @@ func BenchmarkMarshalCWTClaims(b *testing.B) {
 	if err := Unmarshal(data, &v); err != nil {
 		b.Fatal("Unmarshal:", err)
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := Marshal(v); err != nil {
 			b.Fatal("Unmarshal:", err)
 		}
@@ -821,7 +820,7 @@ func BenchmarkMarshalCWTClaims(b *testing.B) {
 func BenchmarkUnmarshalSenML(b *testing.B) {
 	// Data from https://tools.ietf.org/html/rfc8428#section-6
 	data := mustHexDecode("87a721781b75726e3a6465763a6f773a3130653230373361303130383030363a22fb41d303a15b00106223614120050067766f6c7461676501615602fb405e066666666666a3006763757272656e74062402fb3ff3333333333333a3006763757272656e74062302fb3ff4cccccccccccda3006763757272656e74062202fb3ff6666666666666a3006763757272656e74062102f93e00a3006763757272656e74062002fb3ff999999999999aa3006763757272656e74060002fb3ffb333333333333")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var v []SenMLRecord
 		if err := Unmarshal(data, &v); err != nil {
 			b.Fatal("Unmarshal:", err)
@@ -836,7 +835,7 @@ func BenchmarkMarshalSenML(b *testing.B) {
 	if err := Unmarshal(data, &v); err != nil {
 		b.Fatal("Unmarshal:", err)
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := Marshal(v); err != nil {
 			b.Fatal("Unmarshal:", err)
 		}
@@ -851,7 +850,7 @@ func BenchmarkMarshalSenMLShortestFloat16(b *testing.B) {
 		b.Fatal("Unmarshal:", err)
 	}
 	em, _ := EncOptions{ShortestFloat: ShortestFloat16}.EncMode()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := em.Marshal(v); err != nil {
 			b.Fatal("Unmarshal:", err)
 		}
@@ -861,7 +860,7 @@ func BenchmarkMarshalSenMLShortestFloat16(b *testing.B) {
 func BenchmarkUnmarshalWebAuthn(b *testing.B) {
 	// Data generated from Yubico security key
 	data := mustHexDecode("a363666d74686669646f2d7532666761747453746d74a26373696758483046022100e7ab373cfbd99fcd55fd59b0f6f17fef5b77a20ddec3db7f7e4d55174e366236022100828336b4822125fb56541fb14a8a273876acd339395ec2dad95cf41c1dd2a9ae637835638159024e3082024a30820132a0030201020204124a72fe300d06092a864886f70d01010b0500302e312c302a0603550403132359756269636f2055324620526f6f742043412053657269616c203435373230303633313020170d3134303830313030303030305a180f32303530303930343030303030305a302c312a302806035504030c2159756269636f205532462045452053657269616c203234393431343937323135383059301306072a8648ce3d020106082a8648ce3d030107034200043d8b1bbd2fcbf6086e107471601468484153c1c6d3b4b68a5e855e6e40757ee22bcd8988bf3befd7cdf21cb0bf5d7a150d844afe98103c6c6607d9faae287c02a33b3039302206092b0601040182c40a020415312e332e362e312e342e312e34313438322e312e313013060b2b0601040182e51c020101040403020520300d06092a864886f70d01010b05000382010100a14f1eea0076f6b8476a10a2be72e60d0271bb465b2dfbfc7c1bd12d351989917032631d795d097fa30a26a325634e85721bc2d01a86303f6bc075e5997319e122148b0496eec8d1f4f94cf4110de626c289443d1f0f5bbb239ca13e81d1d5aa9df5af8e36126475bfc23af06283157252762ff68879bcf0ef578d55d67f951b4f32b63c8aea5b0f99c67d7d814a7ff5a6f52df83e894a3a5d9c8b82e7f8bc8daf4c80175ff8972fda79333ec465d806eacc948f1bab22045a95558a48c20226dac003d41fbc9e05ea28a6bb5e10a49de060a0a4f6a2676a34d68c4abe8c61874355b9027e828ca9e064b002d62e8d8cf0744921753d35e3c87c5d5779453e7768617574684461746158c449960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d976341000000000000000000000000000000000000000000408903fd7dfd2c9770e98cae0123b13a2c27828a106349bc6277140e7290b7e9eb7976aa3c04ed347027caf7da3a2fa76304751c02208acfc4e7fc6c7ebbc375c8a5010203262001215820ad7f7992c335b90d882b2802061b97a4fabca7e2ee3e7a51e728b8055e4eb9c7225820e0966ba7005987fece6f0e0e13447aa98cec248e4000a594b01b74c1cb1d40b3")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var v attestationObject
 		if err := Unmarshal(data, &v); err != nil {
 			b.Fatal("Unmarshal:", err)
@@ -876,7 +875,7 @@ func BenchmarkMarshalWebAuthn(b *testing.B) {
 	if err := Unmarshal(data, &v); err != nil {
 		b.Fatal("Unmarshal:", err)
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := Marshal(v); err != nil {
 			b.Fatal("Marshal:", err)
 		}
@@ -887,7 +886,7 @@ func BenchmarkUnmarshalCOSEMAC(b *testing.B) {
 	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.4
 	data := mustHexDecode("d83dd18443a10104a1044c53796d6d65747269633235365850a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b7148093101ef6d789200")
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var v macedCOSE
 		if err := Unmarshal(data, &v); err != nil {
 			b.Fatal("Unmarshal:", err)
@@ -901,14 +900,14 @@ func BenchmarkUnmarshalCOSEMACWithTag(b *testing.B) {
 
 	// Register tag CBOR Web Token (CWT) 61 and COSE_Mac0 17 with macedCOSE type
 	tags := NewTagSet()
-	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeOf(macedCOSE{}), 61, 17); err != nil {
+	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeFor[macedCOSE](), 61, 17); err != nil {
 		b.Fatal("TagSet.Add:", err)
 	}
 
 	// Create DecMode with tags
 	dm, _ := DecOptions{}.DecModeWithTags(tags)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var v macedCOSE
 		if err := dm.Unmarshal(data, &v); err != nil {
 			b.Fatal("Unmarshal:", err)
@@ -924,7 +923,7 @@ func BenchmarkMarshalCOSEMAC(b *testing.B) {
 		b.Fatal("Unmarshal():", err)
 	}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := Marshal(v); err != nil {
 			b.Fatal("Marshal():", v, err)
 		}
@@ -937,7 +936,7 @@ func BenchmarkMarshalCOSEMACWithTag(b *testing.B) {
 
 	// Register tag CBOR Web Token (CWT) 61 and COSE_Mac0 17 with macedCOSE type
 	tags := NewTagSet()
-	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeOf(macedCOSE{}), 61, 17); err != nil {
+	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeFor[macedCOSE](), 61, 17); err != nil {
 		b.Fatal("TagSet.Add:", err)
 	}
 
@@ -950,7 +949,7 @@ func BenchmarkMarshalCOSEMACWithTag(b *testing.B) {
 		b.Fatal("Unmarshal():", err)
 	}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := em.Marshal(v); err != nil {
 			b.Fatal("Marshal():", v, err)
 		}
@@ -980,7 +979,7 @@ func BenchmarkUnmarshalMapToStruct(b *testing.B) {
 		// An EncOption that accepts a function to sort or shuffle keys might be useful for
 		// cases like this. Here we are manually encoding the fields in reverse order to
 		// target worst-case key-to-field matching.
-		rt := reflect.TypeOf(ManyFields{})
+		rt := reflect.TypeFor[ManyFields]()
 		var buf bytes.Buffer
 		if rt.NumField() > 255 {
 			b.Fatalf("invalid test assumption: ManyFields expected to have no more than 255 fields, has %d", rt.NumField())

--- a/decode.go
+++ b/decode.go
@@ -611,7 +611,7 @@ func WithRejectedSimpleValue(sv SimpleValue) func(*SimpleValueRegistry) error {
 	}
 }
 
-// Creates a new SimpleValueRegistry. The registry state is initialized by executing the provided
+// NewSimpleValueRegistryFromDefaults creates a new SimpleValueRegistry. The registry state is initialized by executing the provided
 // functions in order against a registry that is pre-populated with the defaults for all well-formed
 // simple value numbers.
 func NewSimpleValueRegistryFromDefaults(fns ...func(*SimpleValueRegistry) error) (*SimpleValueRegistry, error) {

--- a/decode.go
+++ b/decode.go
@@ -1954,7 +1954,7 @@ func (d *decoder) parse(skipSelfDescribedTag bool) (any, error) { //nolint:gocyc
 			if val > math.MaxInt64 {
 				return nil, &UnmarshalTypeError{
 					CBORType: t.String(),
-					GoType:   reflect.TypeOf(int64(0)).String(),
+					GoType:   reflect.TypeFor[int64]().String(),
 					errorMsg: strconv.FormatUint(val, 10) + " overflows Go's int64",
 				}
 			}
@@ -1988,7 +1988,7 @@ func (d *decoder) parse(skipSelfDescribedTag bool) (any, error) { //nolint:gocyc
 			if d.dm.intDec == IntDecConvertSignedOrFail {
 				return nil, &UnmarshalTypeError{
 					CBORType: t.String(),
-					GoType:   reflect.TypeOf(int64(0)).String(),
+					GoType:   reflect.TypeFor[int64]().String(),
 					errorMsg: bi.String() + " overflows Go's int64",
 				}
 			}
@@ -2494,7 +2494,7 @@ func (d *decoder) parseMapToMap(v reflect.Value, tInfo *typeInfo) error { //noli
 		existingKeys = make(map[any]bool, keyCount)
 		if keyCount > 0 {
 			vKeys := v.MapKeys()
-			for i := 0; i < len(vKeys); i++ {
+			for i := range vKeys {
 				existingKeys[vKeys[i].Interface()] = true
 			}
 		}
@@ -2810,7 +2810,7 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 					if err == nil {
 						err = &UnmarshalTypeError{
 							CBORType: t.String(),
-							GoType:   reflect.TypeOf(int64(0)).String(),
+							GoType:   reflect.TypeFor[int64]().String(),
 							errorMsg: strconv.FormatUint(val, 10) + " overflows Go's int64",
 						}
 					}
@@ -2824,7 +2824,7 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 					if err == nil {
 						err = &UnmarshalTypeError{
 							CBORType: t.String(),
-							GoType:   reflect.TypeOf(int64(0)).String(),
+							GoType:   reflect.TypeFor[int64]().String(),
 							errorMsg: "-1-" + strconv.FormatUint(val, 10) + " overflows Go's int64",
 						}
 					}
@@ -2863,7 +2863,7 @@ func (d *decoder) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //n
 			if err == nil {
 				err = &UnmarshalTypeError{
 					CBORType: t.String(),
-					GoType:   reflect.TypeOf("").String(),
+					GoType:   reflect.TypeFor[string]().String(),
 					errorMsg: "map key is of type " + t.String() + " and cannot be used to match struct field name",
 				}
 			}
@@ -2941,12 +2941,12 @@ func (d *decoder) skip() {
 		d.off += int(val) //nolint:gosec
 
 	case cborTypeArray:
-		for i := 0; i < int(val); i++ { //nolint:gosec
+		for range int(val) { //nolint:gosec
 			d.skip()
 		}
 
 	case cborTypeMap:
-		for i := 0; i < int(val)*2; i++ { //nolint:gosec
+		for range int(val) * 2 { //nolint:gosec
 			d.skip()
 		}
 
@@ -3044,16 +3044,16 @@ func (d *decoder) nextCBORNil() bool {
 type jsonUnmarshaler interface{ UnmarshalJSON([]byte) error }
 
 var (
-	typeIntf                  = reflect.TypeOf([]any(nil)).Elem()
-	typeTime                  = reflect.TypeOf(time.Time{})
-	typeBigInt                = reflect.TypeOf(big.Int{})
-	typeUnmarshaler           = reflect.TypeOf((*Unmarshaler)(nil)).Elem()
-	typeUnexportedUnmarshaler = reflect.TypeOf((*unmarshaler)(nil)).Elem()
-	typeBinaryUnmarshaler     = reflect.TypeOf((*encoding.BinaryUnmarshaler)(nil)).Elem()
-	typeTextUnmarshaler       = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
-	typeJSONUnmarshaler       = reflect.TypeOf((*jsonUnmarshaler)(nil)).Elem()
-	typeString                = reflect.TypeOf("")
-	typeByteSlice             = reflect.TypeOf([]byte(nil))
+	typeIntf                  = reflect.TypeFor[any]()
+	typeTime                  = reflect.TypeFor[time.Time]()
+	typeBigInt                = reflect.TypeFor[big.Int]()
+	typeUnmarshaler           = reflect.TypeFor[Unmarshaler]()
+	typeUnexportedUnmarshaler = reflect.TypeFor[unmarshaler]()
+	typeBinaryUnmarshaler     = reflect.TypeFor[encoding.BinaryUnmarshaler]()
+	typeTextUnmarshaler       = reflect.TypeFor[encoding.TextUnmarshaler]()
+	typeJSONUnmarshaler       = reflect.TypeFor[jsonUnmarshaler]()
+	typeString                = reflect.TypeFor[string]()
+	typeByteSlice             = reflect.TypeFor[[]byte]()
 )
 
 func fillNil(_ cborType, v reflect.Value) error {

--- a/decode_test.go
+++ b/decode_test.go
@@ -20,24 +20,24 @@ import (
 )
 
 var (
-	typeBool            = reflect.TypeOf(true)
-	typeUint8           = reflect.TypeOf(uint8(0))
-	typeUint16          = reflect.TypeOf(uint16(0))
-	typeUint32          = reflect.TypeOf(uint32(0))
-	typeUint64          = reflect.TypeOf(uint64(0))
-	typeInt8            = reflect.TypeOf(int8(0))
-	typeInt16           = reflect.TypeOf(int16(0))
-	typeInt32           = reflect.TypeOf(int32(0))
-	typeInt64           = reflect.TypeOf(int64(0))
-	typeFloat32         = reflect.TypeOf(float32(0))
-	typeFloat64         = reflect.TypeOf(float64(0))
-	typeByteArray       = reflect.TypeOf([5]byte{})
-	typeIntSlice        = reflect.TypeOf([]int{})
-	typeStringSlice     = reflect.TypeOf([]string{})
-	typeMapIntfIntf     = reflect.TypeOf(map[any]any{})
-	typeMapStringInt    = reflect.TypeOf(map[string]int{})
-	typeMapStringString = reflect.TypeOf(map[string]string{})
-	typeMapStringIntf   = reflect.TypeOf(map[string]any{})
+	typeBool            = reflect.TypeFor[bool]()
+	typeUint8           = reflect.TypeFor[uint8]()
+	typeUint16          = reflect.TypeFor[uint16]()
+	typeUint32          = reflect.TypeFor[uint32]()
+	typeUint64          = reflect.TypeFor[uint64]()
+	typeInt8            = reflect.TypeFor[int8]()
+	typeInt16           = reflect.TypeFor[int16]()
+	typeInt32           = reflect.TypeFor[int32]()
+	typeInt64           = reflect.TypeFor[int64]()
+	typeFloat32         = reflect.TypeFor[float32]()
+	typeFloat64         = reflect.TypeFor[float64]()
+	typeByteArray       = reflect.TypeFor[[5]byte]()
+	typeIntSlice        = reflect.TypeFor[[]int]()
+	typeStringSlice     = reflect.TypeFor[[]string]()
+	typeMapIntfIntf     = reflect.TypeFor[map[any]any]()
+	typeMapStringInt    = reflect.TypeFor[map[string]int]()
+	typeMapStringString = reflect.TypeFor[map[string]string]()
+	typeMapStringIntf   = reflect.TypeFor[map[string]any]()
 )
 
 type unmarshalTestCase struct {
@@ -893,7 +893,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 			typeBool,
 			typeStringSlice,
 			typeMapStringInt,
-			reflect.TypeOf([3]string{}),
+			reflect.TypeFor[[3]string](),
 			typeTag,
 			typeRawTag,
 			typeBigInt,
@@ -923,7 +923,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 			typeBool,
 			typeStringSlice,
 			typeMapStringInt,
-			reflect.TypeOf([3]string{}),
+			reflect.TypeFor[[3]string](),
 			typeTag,
 			typeRawTag,
 			typeBigInt,
@@ -953,7 +953,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 			typeBool,
 			typeStringSlice,
 			typeMapStringInt,
-			reflect.TypeOf([3]string{}),
+			reflect.TypeFor[[3]string](),
 			typeTag,
 			typeRawTag,
 			typeBigInt,
@@ -983,7 +983,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 			typeBool,
 			typeStringSlice,
 			typeMapStringInt,
-			reflect.TypeOf([3]string{}),
+			reflect.TypeFor[[3]string](),
 			typeTag,
 			typeRawTag,
 			typeBigInt,
@@ -1020,7 +1020,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 			typeBool,
 			typeStringSlice,
 			typeMapStringInt,
-			reflect.TypeOf([3]string{}),
+			reflect.TypeFor[[3]string](),
 			typeTag,
 			typeRawTag,
 			typeBigInt,
@@ -1085,7 +1085,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 			typeBool,
 			typeStringSlice,
 			typeMapStringInt,
-			reflect.TypeOf([3]string{}),
+			reflect.TypeFor[[3]string](),
 			typeTag,
 			typeRawTag,
 			typeBigInt,
@@ -1115,7 +1115,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 			typeBool,
 			typeStringSlice,
 			typeMapStringInt,
-			reflect.TypeOf([3]string{}),
+			reflect.TypeFor[[3]string](),
 			typeTag,
 			typeRawTag,
 			typeBigInt,
@@ -1152,7 +1152,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 			typeBool,
 			typeStringSlice,
 			typeMapStringInt,
-			reflect.TypeOf([3]string{}),
+			reflect.TypeFor[[3]string](),
 			typeTag,
 			typeRawTag,
 			typeBigInt,
@@ -1183,7 +1183,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 			typeByteArray,
 			typeStringSlice,
 			typeMapStringInt,
-			reflect.TypeOf([3]string{}),
+			reflect.TypeFor[[3]string](),
 			typeTag,
 			typeRawTag,
 			typeBigInt,
@@ -1214,7 +1214,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 			typeByteArray,
 			typeStringSlice,
 			typeMapStringInt,
-			reflect.TypeOf([3]string{}),
+			reflect.TypeFor[[3]string](),
 			typeTag,
 			typeRawTag,
 			typeBigInt,
@@ -2035,7 +2035,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 			typeBool,
 			typeStringSlice,
 			typeMapStringInt,
-			reflect.TypeOf([3]string{}),
+			reflect.TypeFor[[3]string](),
 			typeByteString,
 			typeSimpleValue,
 		},
@@ -2667,7 +2667,7 @@ func TestUnmarshalIntoPtrArrayPtrElem(t *testing.T) {
 
 	// Unmarshal CBOR array into a non-nil pointer.
 	if err := Unmarshal(data, &ppslc); err != nil {
-		t.Errorf("Unmarshal(0x%x, %s) returned error %v", data, reflect.TypeOf(ppslc), err)
+		t.Errorf("Unmarshal(0x%x, %s) returned error %v", data, reflect.TypeFor[**[]*int](), err)
 	} else if !reflect.DeepEqual(slc, wantArray) {
 		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", data, slc, slc, wantArray)
 	}
@@ -2694,7 +2694,7 @@ func TestUnmarshalIntoPtrMapPtrElem(t *testing.T) {
 
 	// Unmarshal CBOR map into a non-nil pointer.
 	if err := Unmarshal(data, &ppm); err != nil {
-		t.Errorf("Unmarshal(0x%x, %s) returned error %v", data, reflect.TypeOf(ppm), err)
+		t.Errorf("Unmarshal(0x%x, %s) returned error %v", data, reflect.TypeFor[**map[int]*int](), err)
 	} else if !reflect.DeepEqual(m, wantMap) {
 		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", data, m, m, wantMap)
 	}
@@ -2728,7 +2728,7 @@ func TestUnmarshalIntoPtrStructPtrElem(t *testing.T) {
 
 	// Unmarshal CBOR map into a non-nil pointer.
 	if err := Unmarshal(data, &pps); err != nil {
-		t.Errorf("Unmarshal(0x%x, %s) returned error %v", data, reflect.TypeOf(pps), err)
+		t.Errorf("Unmarshal(0x%x, %s) returned error %v", data, reflect.TypeFor[**s1](), err)
 	} else if !reflect.DeepEqual(s, wantObj) {
 		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", data, s, s, wantObj)
 	}
@@ -4304,7 +4304,7 @@ func TestDecodeTimeError(t *testing.T) {
 			name: "untagged byte string content cannot be decoded into time.Time with DefaultByteStringType string",
 			opts: DecOptions{
 				TimeTag:               DecTagOptional,
-				DefaultByteStringType: reflect.TypeOf(""),
+				DefaultByteStringType: reflect.TypeFor[string](),
 			},
 			data:         mustHexDecode("54323031332d30332d32315432303a30343a30305a"),
 			wantErrorMsg: "cbor: cannot unmarshal byte string into Go value of type time.Time",
@@ -4332,7 +4332,7 @@ func TestDecodeTimeError(t *testing.T) {
 }
 
 func TestDecodeInvalidTagTime(t *testing.T) {
-	typeTimeSlice := reflect.TypeOf([]time.Time{})
+	typeTimeSlice := reflect.TypeFor[[]time.Time]()
 
 	testCases := []struct {
 		name          string
@@ -4878,13 +4878,13 @@ func TestBinaryUnmarshalerError(t *testing.T) { //nolint:dupl
 	}{
 		{
 			name:         "primitive type",
-			typ:          reflect.TypeOf(number(0)),
+			typ:          reflect.TypeFor[number](),
 			data:         mustHexDecode("44499602d2"),
 			wantErrorMsg: "number:UnmarshalBinary: invalid length",
 		},
 		{
 			name:         "struct type",
-			typ:          reflect.TypeOf(stru{}),
+			typ:          reflect.TypeFor[stru](),
 			data:         mustHexDecode("47612C622C632C64"),
 			wantErrorMsg: "stru:UnmarshalBinary: invalid element count",
 		},
@@ -4986,13 +4986,13 @@ func TestUnmarshalerError(t *testing.T) { //nolint:dupl
 	}{
 		{
 			name:         "primitive type",
-			typ:          reflect.TypeOf(number2(0)),
+			typ:          reflect.TypeFor[number2](),
 			data:         mustHexDecode("44499602d2"),
 			wantErrorMsg: "cbor: cannot unmarshal byte string into Go value of type map[string]uint64",
 		},
 		{
 			name:         "struct type",
-			typ:          reflect.TypeOf(stru2{}),
+			typ:          reflect.TypeFor[stru2](),
 			data:         mustHexDecode("47612C622C632C64"),
 			wantErrorMsg: "cbor: cannot unmarshal byte string into Go value of type []string",
 		},
@@ -5425,7 +5425,7 @@ func TestUnmarshalDeepNesting(t *testing.T) {
 	}
 	n := &TestNode{Value: 0}
 	root := n
-	for i := 0; i < 65534; i++ {
+	for i := range 65534 {
 		child := &TestNode{Value: i}
 		n.Child = child
 		n = child
@@ -5540,11 +5540,11 @@ func TestDecOptions(t *testing.T) {
 		IntDec:                    IntDecConvertSigned,
 		MapKeyByteString:          MapKeyByteStringForbidden,
 		ExtraReturnErrors:         ExtraDecErrorUnknownField,
-		DefaultMapType:            reflect.TypeOf(map[string]any(nil)),
+		DefaultMapType:            reflect.TypeFor[map[string]any](),
 		UTF8:                      UTF8DecodeInvalid,
 		FieldNameMatching:         FieldNameMatchingCaseSensitive,
 		BigIntDec:                 BigIntDecodePointer,
-		DefaultByteStringType:     reflect.TypeOf(""),
+		DefaultByteStringType:     reflect.TypeFor[string](),
 		ByteStringToString:        ByteStringToStringAllowed,
 		FieldNameByteString:       FieldNameByteStringAllowed,
 		UnrecognizedTagToAny:      UnrecognizedTagContentToAny,
@@ -5957,14 +5957,14 @@ func TestStreamDupMapKeyToEmptyInterface(t *testing.T) {
 	data := mustHexDecode("a6616161416162614261636143616161466164614461656145") // map with duplicate key "c": {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
 
 	var b []byte
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		b = append(b, data...)
 	}
 
 	// Duplicate key overwrites previous value (default).
 	wantV := map[any]any{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E"}
 	dec := NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var v1 any
 		if err := dec.Decode(&v1); err != nil {
 			t.Errorf("Decode() returned error %v", err)
@@ -5983,7 +5983,7 @@ func TestStreamDupMapKeyToEmptyInterface(t *testing.T) {
 	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	dec = dm.NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var v2 any
 		if err := dec.Decode(&v2); err == nil {
 			t.Errorf("Decode() didn't return an error")
@@ -6035,14 +6035,14 @@ func TestStreamDupMapKeyToEmptyMap(t *testing.T) {
 	data := mustHexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
 
 	var b []byte
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		b = append(b, data...)
 	}
 
 	// Duplicate key overwrites previous value (default).
 	wantM := map[string]string{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E"}
 	dec := NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var m1 map[string]string
 		if err := dec.Decode(&m1); err != nil {
 			t.Errorf("Decode() returned error %v", err)
@@ -6061,7 +6061,7 @@ func TestStreamDupMapKeyToEmptyMap(t *testing.T) {
 	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	dec = dm.NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var m2 map[string]string
 		if err := dec.Decode(&m2); err == nil {
 			t.Errorf("Decode() didn't return an error")
@@ -6113,14 +6113,14 @@ func TestStreamDupMapKeyToNotEmptyMap(t *testing.T) {
 	data := mustHexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
 
 	var b []byte
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		b = append(b, data...)
 	}
 
 	// Duplicate key overwrites previous value (default).
 	wantM := map[string]string{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E", "f": "Z"}
 	dec := NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		m1 := map[string]string{"a": "Z", "b": "Z", "c": "Z", "d": "Z", "e": "Z", "f": "Z"}
 		if err := dec.Decode(&m1); err != nil {
 			t.Errorf("Decode() returned error %v", err)
@@ -6139,7 +6139,7 @@ func TestStreamDupMapKeyToNotEmptyMap(t *testing.T) {
 	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	dec = dm.NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		m2 := map[string]string{"a": "Z", "b": "Z", "c": "Z", "d": "Z", "e": "Z", "f": "Z"}
 		if err := dec.Decode(&m2); err == nil {
 			t.Errorf("Decode() didn't return an error")
@@ -6254,14 +6254,14 @@ func TestStreamDupMapKeyToStruct(t *testing.T) {
 	data := mustHexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
 
 	var b []byte
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		b = append(b, data...)
 	}
 
 	// Duplicate key overwrites previous value (default).
 	wantS := s{A: "A", B: "B", C: "C", D: "D", E: "E"}
 	dec := NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var s1 s
 		if err := dec.Decode(&s1); err != nil {
 			t.Errorf("Decode() returned error %v", err)
@@ -6280,7 +6280,7 @@ func TestStreamDupMapKeyToStruct(t *testing.T) {
 	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	dec = dm.NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var s2 s
 		if err := dec.Decode(&s2); err == nil {
 			t.Errorf("Decode() didn't return an error")
@@ -6323,7 +6323,7 @@ func TestUnmarshalDupMapKeyToStructKeyAsInt(t *testing.T) {
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	var s2 s
 	if err := dm.Unmarshal(data, &s2); err == nil {
-		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeOf(s2))
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeFor[s]())
 	} else if _, ok := err.(*DupMapKeyError); !ok {
 		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", data, err)
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -6343,14 +6343,14 @@ func TestStreamDupMapKeyToStructKeyAsInt(t *testing.T) {
 	data := mustHexDecode("a40102030401030506") // {1:2, 3:4, 1:3, 5:6}
 
 	var b []byte
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		b = append(b, data...)
 	}
 
 	// Duplicate key overwrites previous value (default).
 	wantS := s{A: 2, B: 4, C: 6}
 	dec := NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var s1 s
 		if err := dec.Decode(&s1); err != nil {
 			t.Errorf("Decode() returned error %v", err)
@@ -6369,7 +6369,7 @@ func TestStreamDupMapKeyToStructKeyAsInt(t *testing.T) {
 	wantErrorMsg := "cbor: found duplicate map key 1 at map element index 2"
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	dec = dm.NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var s2 s
 		if err := dec.Decode(&s2); err == nil {
 			t.Errorf("Decode() didn't return an error")
@@ -6411,7 +6411,7 @@ func TestUnmarshalDupMapKeyToStructNoMatchingField(t *testing.T) {
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	var s2 s
 	if err := dm.Unmarshal(data, &s2); err == nil {
-		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeOf(s2))
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeFor[s]())
 	} else if _, ok := err.(*DupMapKeyError); !ok {
 		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", data, err)
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -6432,14 +6432,14 @@ func TestStreamDupMapKeyToStructNoMatchingField(t *testing.T) {
 	data := mustHexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
 
 	var b []byte
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		b = append(b, data...)
 	}
 
 	// Duplicate key overwrites previous value (default).
 	wantS := s{B: "B", C: "C", D: "D", E: "E"}
 	dec := NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var s1 s
 		if err := dec.Decode(&s1); err != nil {
 			t.Errorf("Decode() returned error %v", err)
@@ -6458,7 +6458,7 @@ func TestStreamDupMapKeyToStructNoMatchingField(t *testing.T) {
 	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	dec = dm.NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var s2 s
 		if err := dec.Decode(&s2); err == nil {
 			t.Errorf("Decode() didn't return an error")
@@ -6498,7 +6498,7 @@ func TestUnmarshalDupMapKeyToStructKeyAsIntNoMatchingField(t *testing.T) {
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	var s2 s
 	if err := dm.Unmarshal(data, &s2); err == nil {
-		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeOf(s2))
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeFor[s]())
 	} else if _, ok := err.(*DupMapKeyError); !ok {
 		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", data, err)
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -6517,14 +6517,14 @@ func TestStreamDupMapKeyToStructKeyAsIntNoMatchingField(t *testing.T) {
 	data := mustHexDecode("a40102030401030506") // {1:2, 3:4, 1:3, 5:6}
 
 	var b []byte
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		b = append(b, data...)
 	}
 
 	// Duplicate key overwrites previous value (default).
 	wantS := s{B: 4, C: 6}
 	dec := NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var s1 s
 		if err := dec.Decode(&s1); err != nil {
 			t.Errorf("Decode() returned error %v", err)
@@ -6543,7 +6543,7 @@ func TestStreamDupMapKeyToStructKeyAsIntNoMatchingField(t *testing.T) {
 	wantErrorMsg := "cbor: found duplicate map key 1 at map element index 2"
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	dec = dm.NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var s2 s
 		if err := dec.Decode(&s2); err == nil {
 			t.Errorf("Decode() didn't return an error")
@@ -6590,7 +6590,7 @@ func TestUnmarshalDupMapKeyToStructWrongType(t *testing.T) {
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	var s2 s
 	if err := dm.Unmarshal(data, &s2); err == nil {
-		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeOf(s2))
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeFor[s]())
 	} else if _, ok := err.(*DupMapKeyError); !ok {
 		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", data, err)
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -6612,14 +6612,14 @@ func TestStreamDupMapKeyToStructWrongType(t *testing.T) {
 	data := mustHexDecode("a861616141fa47c35000026162614261636143fa47c3500003616161466164614461656145") // {"a": "A", 100000.0:2, "b": "B", "c": "C", 100000.0:3, "a": "F", "d": "D", "e": "E"}
 
 	var b []byte
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		b = append(b, data...)
 	}
 
 	wantS := s{A: "A", B: "B", C: "C", D: "D", E: "E"}
 	wantErrorMsg := "cbor: cannot unmarshal"
 	dec := NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var s1 s
 		if err := dec.Decode(&s1); err == nil {
 			t.Errorf("Unmarshal(0x%x) didn't return an error", data)
@@ -6642,7 +6642,7 @@ func TestStreamDupMapKeyToStructWrongType(t *testing.T) {
 	wantErrorMsg = "cbor: found duplicate map key 100000 at map element index 4"
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	dec = dm.NewDecoder(bytes.NewReader(b))
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var s2 s
 		if err := dec.Decode(&s2); err == nil {
 			t.Errorf("Decode() didn't return an error")
@@ -6689,7 +6689,7 @@ func TestUnmarshalDupMapKeyToStructStringParseError(t *testing.T) {
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	var s2 s
 	if err := dm.Unmarshal(data, &s2); err == nil {
-		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeOf(s2))
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeFor[s]())
 	} else if _, ok := err.(*SemanticError); !ok {
 		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*SemanticError)", data, err)
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -6727,7 +6727,7 @@ func TestUnmarshalDupMapKeyToStructIntParseError(t *testing.T) {
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	var s2 s
 	if err := dm.Unmarshal(data, &s2); err == nil {
-		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeOf(s2))
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeFor[s]())
 	} else if _, ok := err.(*UnmarshalTypeError); !ok {
 		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", data, err)
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -6767,7 +6767,7 @@ func TestUnmarshalDupMapKeyToStructWrongTypeParseError(t *testing.T) {
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	var s2 s
 	if err := dm.Unmarshal(data, &s2); err == nil {
-		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeOf(s2))
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeFor[s]())
 	} else if _, ok := err.(*UnmarshalTypeError); !ok {
 		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", data, err)
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -6807,7 +6807,7 @@ func TestUnmarshalDupMapKeyToStructWrongTypeUnhashableError(t *testing.T) {
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	var s2 s
 	if err := dm.Unmarshal(data, &s2); err == nil {
-		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeOf(s2))
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeFor[s]())
 	} else if _, ok := err.(*UnmarshalTypeError); !ok {
 		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", data, err)
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -6847,7 +6847,7 @@ func TestUnmarshalDupMapKeyToStructTagTypeError(t *testing.T) {
 	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
 	var s2 s
 	if err := dm.Unmarshal(data, &s2); err == nil {
-		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeOf(s2))
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", data, reflect.TypeFor[s]())
 	} else if _, ok := err.(*UnmarshalTypeError); !ok {
 		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", data, err)
 	} else if !strings.Contains(err.Error(), wantErrorMsg) {
@@ -7682,7 +7682,7 @@ func TestUnmarshalTagNum55799AsElement(t *testing.T) {
 			data:                mustHexDecode("d9d9f783d9d9f701d9d9f702d9d9f703"), // 55799([55799(1), 55799(2), 55799(3)])
 			emptyInterfaceValue: []any{uint64(1), uint64(2), uint64(3)},
 			values:              []any{[]any{uint64(1), uint64(2), uint64(3)}, []byte{1, 2, 3}, []int{1, 2, 3}, []uint{1, 2, 3}, [0]int{}, [1]int{1}, [3]int{1, 2, 3}, [5]int{1, 2, 3, 0, 0}, []float32{1, 2, 3}, []float64{1, 2, 3}},
-			wrongTypes:          []reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
+			wrongTypes:          []reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeFor[[3]string](), typeTag, typeRawTag},
 		},
 		{
 			name:                "map",
@@ -7767,7 +7767,7 @@ func TestUnmarshalTagNum55799ToUnmarshaler(t *testing.T) {
 
 func TestUnmarshalTagNum55799ToRegisteredGoType(t *testing.T) {
 	type myInt int
-	typ := reflect.TypeOf(myInt(0))
+	typ := reflect.TypeFor[myInt]()
 
 	tags := NewTagSet()
 	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, typ, 125); err != nil {
@@ -7863,7 +7863,7 @@ func TestUnmarshalNestedTagNum55799ToUnmarshaler(t *testing.T) {
 
 func TestUnmarshalNestedTagNum55799ToRegisteredGoType(t *testing.T) {
 	type myInt int
-	typ := reflect.TypeOf(myInt(0))
+	typ := reflect.TypeFor[myInt]()
 
 	tags := NewTagSet()
 	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, typ, 125); err != nil {
@@ -8089,7 +8089,7 @@ func TestUnmarshalTag3(t *testing.T) {
 }
 
 func TestUnmarshalInvalidTagBignum(t *testing.T) {
-	typeBigIntSlice := reflect.TypeOf([]big.Int{})
+	typeBigIntSlice := reflect.TypeFor[[]big.Int]()
 
 	testCases := []struct {
 		name          string
@@ -8311,7 +8311,7 @@ func TestUnmarshalTaggedDataToInterface(t *testing.T) {
 	var tags = NewTagSet()
 	err := tags.Add(
 		TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired},
-		reflect.TypeOf(&Bar{}),
+		reflect.TypeFor[*Bar](),
 		4,
 	)
 	if err != nil {
@@ -8381,11 +8381,11 @@ type A2 struct {
 func TestUnmarshalRegisteredTagToInterface(t *testing.T) {
 	var err error
 	tags := NewTagSet()
-	err = tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeOf(C{}), 279)
+	err = tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeFor[C](), 279)
 	if err != nil {
 		t.Error(err)
 	}
-	err = tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeOf(D{}), 280)
+	err = tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeFor[D](), 280)
 	if err != nil {
 		t.Error(err)
 	}
@@ -8452,17 +8452,17 @@ func TestDecModeInvalidDefaultMapType(t *testing.T) {
 	}{
 		{
 			name:         "byte slice",
-			opts:         DecOptions{DefaultMapType: reflect.TypeOf([]byte(nil))},
+			opts:         DecOptions{DefaultMapType: reflect.TypeFor[[]byte]()},
 			wantErrorMsg: "cbor: invalid DefaultMapType []uint8",
 		},
 		{
 			name:         "int slice",
-			opts:         DecOptions{DefaultMapType: reflect.TypeOf([]int(nil))},
+			opts:         DecOptions{DefaultMapType: reflect.TypeFor[[]int]()},
 			wantErrorMsg: "cbor: invalid DefaultMapType []int",
 		},
 		{
 			name:         "string",
-			opts:         DecOptions{DefaultMapType: reflect.TypeOf("")},
+			opts:         DecOptions{DefaultMapType: reflect.TypeFor[string]()},
 			wantErrorMsg: "cbor: invalid DefaultMapType string",
 		},
 		{
@@ -8491,9 +8491,9 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 	cborDataNestedMap := mustHexDecode("a268496e744669656c6401684d61704669656c64a2616101616202") // {"IntField": 1, "MapField": {"a": 1, "b": 2}}
 
 	decOptionsDefault := DecOptions{}
-	decOptionsMapIntfIntfType := DecOptions{DefaultMapType: reflect.TypeOf(map[any]any(nil))}
-	decOptionsMapStringIntType := DecOptions{DefaultMapType: reflect.TypeOf(map[string]int(nil))}
-	decOptionsMapStringIntfType := DecOptions{DefaultMapType: reflect.TypeOf(map[string]any(nil))}
+	decOptionsMapIntfIntfType := DecOptions{DefaultMapType: reflect.TypeFor[map[any]any]()}
+	decOptionsMapStringIntType := DecOptions{DefaultMapType: reflect.TypeFor[map[string]int]()}
+	decOptionsMapStringIntfType := DecOptions{DefaultMapType: reflect.TypeFor[map[string]any]()}
 
 	testCases := []struct {
 		name         string
@@ -8914,22 +8914,22 @@ func TestDecModeInvalidDefaultByteStringType(t *testing.T) {
 	}{
 		{
 			name:         "neither slice nor string",
-			opts:         DecOptions{DefaultByteStringType: reflect.TypeOf(int(42))},
+			opts:         DecOptions{DefaultByteStringType: reflect.TypeFor[int]()},
 			wantErrorMsg: "cbor: invalid DefaultByteStringType: int is not of kind string or []uint8",
 		},
 		{
 			name:         "slice of non-byte",
-			opts:         DecOptions{DefaultByteStringType: reflect.TypeOf([]int{})},
+			opts:         DecOptions{DefaultByteStringType: reflect.TypeFor[[]int]()},
 			wantErrorMsg: "cbor: invalid DefaultByteStringType: []int is not of kind string or []uint8",
 		},
 		{
 			name:         "pointer to byte array",
-			opts:         DecOptions{DefaultByteStringType: reflect.TypeOf(&[42]byte{})},
+			opts:         DecOptions{DefaultByteStringType: reflect.TypeFor[*[42]byte]()},
 			wantErrorMsg: "cbor: invalid DefaultByteStringType: *[42]uint8 is not of kind string or []uint8",
 		},
 		{
 			name:         "byte array",
-			opts:         DecOptions{DefaultByteStringType: reflect.TypeOf([42]byte{})},
+			opts:         DecOptions{DefaultByteStringType: reflect.TypeFor[[42]byte]()},
 			wantErrorMsg: "cbor: invalid DefaultByteStringType: [42]uint8 is not of kind string or []uint8",
 		},
 	} {
@@ -8961,25 +8961,25 @@ func TestUnmarshalDefaultByteStringType(t *testing.T) {
 		},
 		{
 			name: "explicitly []byte",
-			opts: DecOptions{DefaultByteStringType: reflect.TypeOf([]byte(nil))},
+			opts: DecOptions{DefaultByteStringType: reflect.TypeFor[[]byte]()},
 			data: mustHexDecode("43414243"),
 			want: []byte("ABC"),
 		},
 		{
 			name: "string",
-			opts: DecOptions{DefaultByteStringType: reflect.TypeOf("")},
+			opts: DecOptions{DefaultByteStringType: reflect.TypeFor[string]()},
 			data: mustHexDecode("43414243"),
 			want: "ABC",
 		},
 		{
 			name: "ByteString",
-			opts: DecOptions{DefaultByteStringType: reflect.TypeOf(ByteString(""))},
+			opts: DecOptions{DefaultByteStringType: reflect.TypeFor[ByteString]()},
 			data: mustHexDecode("43414243"),
 			want: ByteString("ABC"),
 		},
 		{
 			name: "named []byte type",
-			opts: DecOptions{DefaultByteStringType: reflect.TypeOf(namedByteSliceType(nil))},
+			opts: DecOptions{DefaultByteStringType: reflect.TypeFor[namedByteSliceType]()},
 			data: mustHexDecode("43414243"),
 			want: namedByteSliceType("ABC"),
 		},
@@ -9266,7 +9266,7 @@ func TestUnmarshalWithUnrecognizedTagToAnyModeForSupportedTags(t *testing.T) {
 func TestUnmarshalWithUnrecognizedTagToAnyModeForSharedTag(t *testing.T) {
 
 	type myInt int
-	typ := reflect.TypeOf(myInt(0))
+	typ := reflect.TypeFor[myInt]()
 
 	tags := NewTagSet()
 	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, typ, 125); err != nil {
@@ -10231,7 +10231,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			name: "base64url encoding tag ignored by default",
 			opts: DecOptions{},
 			tags: func(tags TagSet) error {
-				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 21)
+				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeFor[empty](), 21)
 			},
 			wantErrorMsg: "",
 		},
@@ -10239,7 +10239,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			name: "base64url encoding tag conflicts in ByteStringToStringAllowedWithExpectedLaterEncoding mode",
 			opts: DecOptions{ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding},
 			tags: func(tags TagSet) error {
-				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 21)
+				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeFor[empty](), 21)
 			},
 			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 21 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
@@ -10247,7 +10247,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			name: "base64url encoding tag conflicts with non-default ByteSliceExpectedEncoding option",
 			opts: DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase16},
 			tags: func(tags TagSet) error {
-				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 21)
+				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeFor[empty](), 21)
 			},
 			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 21 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
@@ -10255,7 +10255,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			name: "base64 encoding tag ignored by default",
 			opts: DecOptions{},
 			tags: func(tags TagSet) error {
-				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 22)
+				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeFor[empty](), 22)
 			},
 			wantErrorMsg: "",
 		},
@@ -10263,7 +10263,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			name: "base64 encoding tag conflicts in ByteStringToStringAllowedWithExpectedLaterEncoding mode",
 			opts: DecOptions{ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding},
 			tags: func(tags TagSet) error {
-				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 22)
+				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeFor[empty](), 22)
 			},
 			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 22 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
@@ -10271,7 +10271,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			name: "base64 encoding tag conflicts with non-default ByteSliceExpectedEncoding option",
 			opts: DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase16},
 			tags: func(tags TagSet) error {
-				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 22)
+				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeFor[empty](), 22)
 			},
 			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 22 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
@@ -10279,7 +10279,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			name: "base16 encoding tag ignored by default",
 			opts: DecOptions{},
 			tags: func(tags TagSet) error {
-				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 23)
+				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeFor[empty](), 23)
 			},
 			wantErrorMsg: "",
 		},
@@ -10287,7 +10287,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			name: "base16 encoding tag conflicts in ByteStringToStringAllowedWithExpectedLaterEncoding mode",
 			opts: DecOptions{ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding},
 			tags: func(tags TagSet) error {
-				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 23)
+				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeFor[empty](), 23)
 			},
 			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 23 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
@@ -10295,7 +10295,7 @@ func TestDecOptionsConflictWithRegisteredTags(t *testing.T) {
 			name: "base16 encoding tag conflicts with non-default ByteSliceExpectedEncoding option",
 			opts: DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase16},
 			tags: func(tags TagSet) error {
-				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeOf(empty{}), 23)
+				return tags.Add(TagOptions{DecTag: DecTagOptional}, reflect.TypeFor[empty](), 23)
 			},
 			wantErrorMsg: "cbor: DecMode with non-default StringExpectedEncoding or ByteSliceExpectedEncoding treats tag 23 as built-in and conflicts with the provided TagSet's registration of cbor.empty",
 		},
@@ -10344,42 +10344,42 @@ func TestUnmarshalByteStringTextConversionError(t *testing.T) {
 		{
 			name:         "reject untagged byte string containing invalid base64url",
 			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64URL},
-			dstType:      reflect.TypeOf([]byte{}),
+			dstType:      reflect.TypeFor[[]byte](),
 			data:         []byte{0x41, 0x00},
 			wantErrorMsg: "cbor: failed to decode base64url from byte string: illegal base64 data at input byte 0",
 		},
 		{
 			name:         "reject untagged byte string containing invalid base64url",
 			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64},
-			dstType:      reflect.TypeOf([]byte{}),
+			dstType:      reflect.TypeFor[[]byte](),
 			data:         []byte{0x41, 0x00},
 			wantErrorMsg: "cbor: failed to decode base64 from byte string: illegal base64 data at input byte 0",
 		},
 		{
 			name:         "reject untagged byte string containing invalid base16",
 			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase16},
-			dstType:      reflect.TypeOf([]byte{}),
+			dstType:      reflect.TypeFor[[]byte](),
 			data:         []byte{0x41, 0x00},
 			wantErrorMsg: "cbor: failed to decode hex from byte string: encoding/hex: invalid byte: U+0000",
 		},
 		{
 			name:         "accept tagged byte string containing invalid base64url",
 			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64URL},
-			dstType:      reflect.TypeOf([]byte{}),
+			dstType:      reflect.TypeFor[[]byte](),
 			data:         []byte{0xd5, 0x41, 0x00},
 			wantErrorMsg: "",
 		},
 		{
 			name:         "accept tagged byte string containing invalid base64url",
 			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase64},
-			dstType:      reflect.TypeOf([]byte{}),
+			dstType:      reflect.TypeFor[[]byte](),
 			data:         []byte{0xd5, 0x41, 0x00},
 			wantErrorMsg: "",
 		},
 		{
 			name:         "accept tagged byte string containing invalid base16",
 			opts:         DecOptions{ByteStringExpectedFormat: ByteStringExpectedBase16},
-			dstType:      reflect.TypeOf([]byte{}),
+			dstType:      reflect.TypeFor[[]byte](),
 			data:         []byte{0xd5, 0x41, 0x00},
 			wantErrorMsg: "",
 		},
@@ -10418,7 +10418,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0x41, 0xff}, // h'ff'
 			want:    "\xff",
 		},
@@ -10427,7 +10427,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0xd5, 0x41, 0xff}, // 21(h'ff')
 			want:    "_w",
 		},
@@ -10436,7 +10436,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0xd5, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 21(55799(h'ff'))
 			want:    "_w",
 		},
@@ -10445,7 +10445,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowed,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0xd5, 0x41, 0xff}, // 21(h'ff')
 			want:    "\xff",
 		},
@@ -10454,7 +10454,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringExpectedFormat: ByteStringExpectedBase64URL,
 			},
-			dstType: reflect.TypeOf([]byte{}),
+			dstType: reflect.TypeFor[[]byte](),
 			data:    []byte{0xd5, 0x41, 0xff}, // 21(h'ff')
 			want:    []byte{0xff},
 		},
@@ -10463,7 +10463,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringExpectedFormat: ByteStringExpectedBase64URL,
 			},
-			dstType: reflect.TypeOf([]byte{}),
+			dstType: reflect.TypeFor[[]byte](),
 			data:    []byte{0xd5, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 21(55799(h'ff'))
 			want:    []byte{0xff},
 		},
@@ -10472,7 +10472,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringExpectedFormat: ByteStringExpectedBase64URL,
 			},
-			dstType: reflect.TypeOf([]byte{}),
+			dstType: reflect.TypeFor[[]byte](),
 			data:    []byte{0x42, '_', 'w'}, // '_w'
 			want:    []byte{0xff},
 		},
@@ -10481,7 +10481,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0xd6, 0x41, 0xff}, // 22(h'ff')
 			want:    "/w==",
 		},
@@ -10490,7 +10490,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0xd6, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 22(55799(h'ff'))
 			want:    "/w==",
 		},
@@ -10499,7 +10499,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowed,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0xd6, 0x41, 0xff}, // 22(h'ff')
 			want:    "\xff",
 		},
@@ -10508,7 +10508,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringExpectedFormat: ByteStringExpectedBase64,
 			},
-			dstType: reflect.TypeOf([]byte{}),
+			dstType: reflect.TypeFor[[]byte](),
 			data:    []byte{0xd6, 0x41, 0xff}, // 22(h'ff')
 			want:    []byte{0xff},
 		},
@@ -10517,7 +10517,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringExpectedFormat: ByteStringExpectedBase64,
 			},
-			dstType: reflect.TypeOf([]byte{}),
+			dstType: reflect.TypeFor[[]byte](),
 			data:    []byte{0xd6, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 22(55799(h'ff'))
 			want:    []byte{0xff},
 		},
@@ -10526,7 +10526,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringExpectedFormat: ByteStringExpectedBase64,
 			},
-			dstType: reflect.TypeOf([]byte{}),
+			dstType: reflect.TypeFor[[]byte](),
 			data:    []byte{0x44, '/', 'w', '=', '='}, // '/w=='
 			want:    []byte{0xff},
 		},
@@ -10535,7 +10535,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0xd7, 0x41, 0xff}, // 23(h'ff')
 			want:    "ff",
 		},
@@ -10544,7 +10544,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0xd7, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 23(55799(h'ff'))
 			want:    "ff",
 		},
@@ -10553,7 +10553,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowed,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0xd7, 0x41, 0xff}, // 23(h'ff')
 			want:    "\xff",
 		},
@@ -10562,7 +10562,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringExpectedFormat: ByteStringExpectedBase16,
 			},
-			dstType: reflect.TypeOf([]byte{}),
+			dstType: reflect.TypeFor[[]byte](),
 			data:    []byte{0xd7, 0x41, 0xff}, // 23(h'ff')
 			want:    []byte{0xff},
 		},
@@ -10571,7 +10571,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringExpectedFormat: ByteStringExpectedBase16,
 			},
-			dstType: reflect.TypeOf([]byte{}),
+			dstType: reflect.TypeFor[[]byte](),
 			data:    []byte{0xd7, 0xd9, 0xd9, 0xf7, 0x41, 0xff}, // 23(55799(h'ff'))
 			want:    []byte{0xff},
 		},
@@ -10580,7 +10580,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringExpectedFormat: ByteStringExpectedBase16,
 			},
-			dstType: reflect.TypeOf([]byte{}),
+			dstType: reflect.TypeFor[[]byte](),
 			data:    []byte{0x42, 'f', 'f'},
 			want:    []byte{0xff},
 		},
@@ -10589,7 +10589,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0xd5, 0xd6, 0x42, 0x01, 0x02}, // 21(22(h'0102'))
 			want:    "AQI=",                               // base64 of [0x01, 0x02] with padding
 		},
@@ -10598,7 +10598,7 @@ func TestUnmarshalByteStringTextConversion(t *testing.T) {
 			opts: DecOptions{
 				ByteStringToString: ByteStringToStringAllowedWithExpectedLaterEncoding,
 			},
-			dstType: reflect.TypeOf(""),
+			dstType: reflect.TypeFor[string](),
 			data:    []byte{0xd6, 0xd5, 0x42, 0x01, 0x02}, // 22(21(h'0102'))
 			want:    "AQI",                                // base64 of [0x01, 0x02] without padding
 		},
@@ -10935,7 +10935,7 @@ func TestJSONUnmarshalerTranscoder(t *testing.T) {
 			want: json.RawMessage("true"),
 			wantErrorMsg: TranscodeError{
 				err:          errors.New("test"),
-				rtype:        reflect.TypeOf((*json.RawMessage)(nil)),
+				rtype:        reflect.TypeFor[*json.RawMessage](),
 				sourceFormat: "cbor",
 				targetFormat: "json",
 			}.Error(),

--- a/diagnose.go
+++ b/diagnose.go
@@ -170,7 +170,7 @@ func Diagnose(data []byte) (string, error) {
 	return defaultDiagMode.Diagnose(data)
 }
 
-// Diagnose returns extended diagnostic notation (EDN) of the first CBOR data item using the DiagMode. Any remaining bytes are returned in rest.
+// DiagnoseFirst returns extended diagnostic notation (EDN) of the first CBOR data item using the DiagMode. Any remaining bytes are returned in rest.
 func DiagnoseFirst(data []byte) (diagNotation string, rest []byte, err error) {
 	return defaultDiagMode.DiagnoseFirst(data)
 }

--- a/diagnose.go
+++ b/diagnose.go
@@ -360,7 +360,7 @@ func (di *diagnose) item() error { //nolint:gocyclo
 		count := int(val) //nolint:gosec
 		di.w.WriteByte('[')
 
-		for i := 0; i < count; i++ {
+		for i := range count {
 			if i > 0 {
 				di.w.WriteString(", ")
 			}
@@ -376,7 +376,7 @@ func (di *diagnose) item() error { //nolint:gocyclo
 		count := int(val) //nolint:gosec
 		di.w.WriteByte('{')
 
-		for i := 0; i < count; i++ {
+		for i := range count {
 			if i > 0 {
 				di.w.WriteString(", ")
 			}

--- a/encode.go
+++ b/encode.go
@@ -1300,7 +1300,7 @@ func encodeByteString(e *bytes.Buffer, em *encMode, v reflect.Value) error {
 	}
 	encodeHead(e, byte(cborTypeByteString), uint64(slen)) //nolint:gosec
 	if vk == reflect.Array {
-		for i := 0; i < slen; i++ {
+		for i := range slen {
 			e.WriteByte(byte(v.Index(i).Uint())) //nolint:gosec
 		}
 		return nil
@@ -1339,7 +1339,7 @@ func (ae arrayEncodeFunc) encode(e *bytes.Buffer, em *encMode, v reflect.Value) 
 		return e.WriteByte(byte(cborTypeArray))
 	}
 	encodeHead(e, byte(cborTypeArray), uint64(alen)) //nolint:gosec
-	for i := 0; i < alen; i++ {
+	for i := range alen {
 		if err := ae.f(e, em, v.Index(i)); err != nil {
 			return err
 		}
@@ -1494,7 +1494,7 @@ func encodeStructToArray(e *bytes.Buffer, em *encMode, v reflect.Value) (err err
 	flds := structType.fields
 
 	encodeHead(e, byte(cborTypeArray), uint64(len(flds)))
-	for i := 0; i < len(flds); i++ {
+	for i := range flds {
 		f := flds[i]
 
 		var fv reflect.Value
@@ -1542,7 +1542,7 @@ func encodeStruct(e *bytes.Buffer, em *encMode, v reflect.Value) (err error) {
 
 	kvBeginOffset := e.Len()
 	kvCount := 0
-	for offset := 0; offset < len(flds); offset++ {
+	for offset := range flds {
 		f := flds[(start+offset)%len(flds)]
 
 		var fv reflect.Value
@@ -1969,12 +1969,12 @@ func encodeHead(e *bytes.Buffer, t byte, n uint64) int {
 type jsonMarshaler interface{ MarshalJSON() ([]byte, error) }
 
 var (
-	typeMarshaler       = reflect.TypeOf((*Marshaler)(nil)).Elem()
-	typeBinaryMarshaler = reflect.TypeOf((*encoding.BinaryMarshaler)(nil)).Elem()
-	typeTextMarshaler   = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
-	typeJSONMarshaler   = reflect.TypeOf((*jsonMarshaler)(nil)).Elem()
-	typeRawMessage      = reflect.TypeOf(RawMessage(nil))
-	typeByteString      = reflect.TypeOf(ByteString(""))
+	typeMarshaler       = reflect.TypeFor[Marshaler]()
+	typeBinaryMarshaler = reflect.TypeFor[encoding.BinaryMarshaler]()
+	typeTextMarshaler   = reflect.TypeFor[encoding.TextMarshaler]()
+	typeJSONMarshaler   = reflect.TypeFor[jsonMarshaler]()
+	typeRawMessage      = reflect.TypeFor[RawMessage]()
+	typeByteString      = reflect.TypeFor[ByteString]()
 )
 
 func getEncodeFuncInternal(t reflect.Type) (ef encodeFunc, ief isEmptyFunc, izf isZeroFunc) {
@@ -2210,7 +2210,7 @@ func float32NaNFromReflectValue(v reflect.Value) float32 {
 	// Keith Randall's workaround for issue https://github.com/golang/go/issues/36400
 	p := reflect.New(v.Type())
 	p.Elem().Set(v)
-	f32 := p.Convert(reflect.TypeOf((*float32)(nil))).Elem().Interface().(float32)
+	f32 := p.Convert(reflect.TypeFor[*float32]()).Elem().Interface().(float32)
 	return f32
 }
 
@@ -2218,7 +2218,7 @@ type isZeroer interface {
 	IsZero() bool
 }
 
-var isZeroerType = reflect.TypeOf((*isZeroer)(nil)).Elem()
+var isZeroerType = reflect.TypeFor[isZeroer]()
 
 // getIsZeroFunc returns a function for the given type that can be called to determine if a given value is zero.
 // Types that implement `IsZero() bool` are delegated to for non-nil values.

--- a/encode.go
+++ b/encode.go
@@ -186,7 +186,7 @@ const (
 	// in RFC 7049bis.
 	SortBytewiseLexical SortMode = 2
 
-	// SortShuffle encodes map pairs and struct fields in a shuffled
+	// SortFastShuffle encodes map pairs and struct fields in a shuffled
 	// order. This mode does not guarantee an unbiased permutation, but it
 	// does guarantee that the runtime of the shuffle algorithm used will be
 	// constant.
@@ -1027,7 +1027,7 @@ func (em *encMode) Marshal(v any) ([]byte, error) {
 // See Marshal for more details.
 func (em *encMode) MarshalToBuffer(v any, buf *bytes.Buffer) error {
 	if buf == nil {
-		return fmt.Errorf("cbor: encoding buffer provided by user is nil")
+		return errors.New("cbor: encoding buffer provided by user is nil")
 	}
 	return encode(buf, em, reflect.ValueOf(v))
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -560,7 +560,7 @@ func TestMarshalLargeByteString(t *testing.T) {
 	for i, length := range lengths {
 		data := bytes.NewBuffer(encodeCborHeader(cborTypeByteString, uint64(length)))
 		value := make([]byte, length)
-		for j := 0; j < length; j++ {
+		for j := range length {
 			data.WriteByte(100)
 			value[j] = 100
 		}
@@ -577,7 +577,7 @@ func TestMarshalLargeTextString(t *testing.T) {
 	for i, length := range lengths {
 		data := bytes.NewBuffer(encodeCborHeader(cborTypeTextString, uint64(length)))
 		value := make([]byte, length)
-		for j := 0; j < length; j++ {
+		for j := range length {
 			data.WriteByte(100)
 			value[j] = 100
 		}
@@ -594,7 +594,7 @@ func TestMarshalLargeArray(t *testing.T) {
 	for i, length := range lengths {
 		data := bytes.NewBuffer(encodeCborHeader(cborTypeArray, uint64(length)))
 		value := make([]string, length)
-		for j := 0; j < length; j++ {
+		for j := range length {
 			data.Write([]byte{0x63, 0xe6, 0xb0, 0xb4})
 			value[j] = "水"
 		}
@@ -611,7 +611,7 @@ func TestMarshalLargeMapCanonical(t *testing.T) {
 	for i, length := range lengths {
 		data := bytes.NewBuffer(encodeCborHeader(cborTypeMap, uint64(length)))
 		value := make(map[int]int, length)
-		for j := 0; j < length; j++ {
+		for j := range length {
 			d := encodeCborHeader(cborTypePositiveInt, uint64(j))
 			data.Write(d)
 			data.Write(d)
@@ -628,7 +628,7 @@ func TestMarshalLargeMap(t *testing.T) {
 	lengths := []int{0, 1, 2, 22, 23, 24, 254, 255, 256, 65534, 65535, 65536, 131072}
 	for _, length := range lengths {
 		m1 := make(map[int]int, length)
-		for i := 0; i < length; i++ {
+		for i := range length {
 			m1[i] = i
 		}
 
@@ -2199,91 +2199,91 @@ func TestIsZero(t *testing.T) {
 		},
 		{
 			name: "string-zero",
-			t:    reflect.TypeOf(""),
+			t:    reflect.TypeFor[string](),
 			v:    reflect.ValueOf(""),
 			want: true,
 		},
 
 		{
 			name: "string-nonzero",
-			t:    reflect.TypeOf(""),
+			t:    reflect.TypeFor[string](),
 			v:    reflect.ValueOf("a"),
 			want: false,
 		},
 		{
 			name: "int-zero",
-			t:    reflect.TypeOf(0),
+			t:    reflect.TypeFor[int](),
 			v:    reflect.ValueOf(0),
 			want: true,
 		},
 		{
 			name: "int-nonzero",
-			t:    reflect.TypeOf(0),
+			t:    reflect.TypeFor[int](),
 			v:    reflect.ValueOf(1),
 			want: false,
 		},
 
 		{
 			name: "bool-zero",
-			t:    reflect.TypeOf(false),
+			t:    reflect.TypeFor[bool](),
 			v:    reflect.ValueOf(false),
 			want: true,
 		},
 		{
 			name: "bool-nonzero",
-			t:    reflect.TypeOf(false),
+			t:    reflect.TypeFor[bool](),
 			v:    reflect.ValueOf(true),
 			want: false,
 		},
 
 		{
 			name: "slice-zero",
-			t:    reflect.TypeOf([]string(nil)),
+			t:    reflect.TypeFor[[]string](),
 			v:    reflect.ValueOf([]string(nil)),
 			want: true,
 		},
 		{
 			name: "slice-nonzero",
-			t:    reflect.TypeOf([]string(nil)),
+			t:    reflect.TypeFor[[]string](),
 			v:    reflect.ValueOf([]string{}),
 			want: false,
 		},
 
 		{
 			name: "map-zero",
-			t:    reflect.TypeOf(map[string]string(nil)),
+			t:    reflect.TypeFor[map[string]string](),
 			v:    reflect.ValueOf(map[string]string(nil)),
 			want: true,
 		},
 		{
 			name: "map-nonzero",
-			t:    reflect.TypeOf(map[string]string(nil)),
+			t:    reflect.TypeFor[map[string]string](),
 			v:    reflect.ValueOf(map[string]string{}),
 			want: false,
 		},
 
 		{
 			name: "struct-zero",
-			t:    reflect.TypeOf(zeroTestType{}),
+			t:    reflect.TypeFor[zeroTestType](),
 			v:    reflect.ValueOf(zeroTestType{}),
 			want: true,
 		},
 		{
 			name: "struct-nonzero",
-			t:    reflect.TypeOf(zeroTestType{}),
+			t:    reflect.TypeFor[zeroTestType](),
 			v:    reflect.ValueOf(zeroTestType{value: 42}),
 			want: false,
 		},
 
 		{
 			name: "pointer-zero",
-			t:    reflect.TypeOf((*zeroTestType)(nil)),
+			t:    reflect.TypeFor[*zeroTestType](),
 			v:    reflect.ValueOf((*zeroTestType)(nil)),
 			want: true,
 		},
 		{
 			name: "pointer-nonzero",
-			t:    reflect.TypeOf((*zeroTestType)(nil)),
+			t:    reflect.TypeFor[*zeroTestType](),
 			v:    reflect.ValueOf(&zeroTestType{}),
 			want: false,
 		},
@@ -2316,70 +2316,70 @@ func TestIsZero(t *testing.T) {
 
 		{
 			name: "custom-structreceiver-zero-structvalue",
-			t:    reflect.TypeOf(zeroTestTypeCustom{}),
+			t:    reflect.TypeFor[zeroTestTypeCustom](),
 			v:    reflect.ValueOf(zeroTestTypeCustom{value: 42}),
 			want: true,
 		},
 		{
 			name: "custom-structreceiver-nonzero-structvalue",
-			t:    reflect.TypeOf(zeroTestTypeCustom{}),
+			t:    reflect.TypeFor[zeroTestTypeCustom](),
 			v:    reflect.ValueOf(zeroTestTypeCustom{value: 1}),
 			want: false,
 		},
 		{
 			name: "custom-structreceiver-zero-pointervalue",
-			t:    reflect.TypeOf(zeroTestTypeCustom{}),
+			t:    reflect.TypeFor[zeroTestTypeCustom](),
 			v:    reflect.ValueOf(&zeroTestTypeCustom{value: 42}),
 			want: true,
 		},
 		{
 			name: "custom-structreceiver-nonzero-pointervalue",
-			t:    reflect.TypeOf(zeroTestTypeCustom{}),
+			t:    reflect.TypeFor[zeroTestTypeCustom](),
 			v:    reflect.ValueOf(&zeroTestTypeCustom{value: 1}),
 			want: false,
 		},
 
 		{
 			name: "custom-structreceiver-zero-pointervalue",
-			t:    reflect.TypeOf(&zeroTestTypeCustom{}),
+			t:    reflect.TypeFor[*zeroTestTypeCustom](),
 			v:    reflect.ValueOf(&zeroTestTypeCustom{value: 42}),
 			want: true,
 		},
 		{
 			name: "custom-structreceiver-nonzero-pointervalue",
-			t:    reflect.TypeOf(&zeroTestTypeCustom{}),
+			t:    reflect.TypeFor[*zeroTestTypeCustom](),
 			v:    reflect.ValueOf(&zeroTestTypeCustom{value: 1}),
 			want: false,
 		},
 		{
 			name: "custom-structreceiver-zero-nil-pointervalue",
-			t:    reflect.TypeOf(&zeroTestTypeCustom{}),
+			t:    reflect.TypeFor[*zeroTestTypeCustom](),
 			v:    reflect.ValueOf((*zeroTestTypeCustom)(nil)),
 			want: true,
 		},
 
 		{
 			name: "custom-pointerreceiver-zero-structvalue",
-			t:    reflect.TypeOf(zeroTestTypeCustomPointer{}),
+			t:    reflect.TypeFor[zeroTestTypeCustomPointer](),
 			v:    reflect.ValueOf(zeroTestTypeCustomPointer{value: 42}),
 			want: true,
 		},
 		{
 			name: "custom-pointerreceiver-nonzero-structvalue",
-			t:    reflect.TypeOf(zeroTestTypeCustomPointer{}),
+			t:    reflect.TypeFor[zeroTestTypeCustomPointer](),
 			v:    reflect.ValueOf(zeroTestTypeCustomPointer{value: 1}),
 			want: false,
 		},
 
 		{
 			name: "custom-pointerreceiver-zero-pointervalue",
-			t:    reflect.TypeOf(&zeroTestTypeCustomPointer{}),
+			t:    reflect.TypeFor[*zeroTestTypeCustomPointer](),
 			v:    reflect.ValueOf(&zeroTestTypeCustomPointer{value: 42}),
 			want: true,
 		},
 		{
 			name: "custom-pointerreceiver-nonzero-pointervalue",
-			t:    reflect.TypeOf(&zeroTestTypeCustomPointer{}),
+			t:    reflect.TypeFor[*zeroTestTypeCustomPointer](),
 			v:    reflect.ValueOf(&zeroTestTypeCustomPointer{value: 1}),
 			want: false,
 		},
@@ -2475,58 +2475,24 @@ func TestJSONStdlibOmitZero(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name   string
-		stdlib bool
-		obj    any
-		want   []byte
+		name string
+		obj  any
+		want []byte
 	}{
 		{
-			name:   "cbor-stdlib-off",
-			stdlib: false,
-			obj:    CBOR{},
-			want:   []byte{0xa0}, // {}
+			name: "cbor tag",
+			obj:  CBOR{},
+			want: []byte{0xa0}, // {}
 		},
 		{
-			name:   "cbor-stdlib-on",
-			stdlib: true,
-			obj:    CBOR{},
-			want:   []byte{0xa0}, // {}
+			name: "json stag",
+			obj:  JSON{},
+			want: []byte{0xa0}, // {}
 		},
-		{
-			name:   "json-stdlib-off",
-			stdlib: false,
-			obj:    JSON{},
-			want:   []byte{0xa1, 0x61, 0x73, 0x60}, // {"s":""}
-		},
-		{
-			name:   "json-stdlib-on",
-			stdlib: true,
-			obj:    JSON{},
-			want:   []byte{0xa0}, // {}
-		},
-	}
-
-	original := jsonStdlibSupportsOmitzero
-	reset := func() {
-		// reset to original
-		jsonStdlibSupportsOmitzero = original
-		// clear type caches
-		encodingStructTypeCache.Range(func(key, _ any) bool {
-			encodingStructTypeCache.Delete(key)
-			return true
-		})
-		typeInfoCache.Range(func(key, _ any) bool {
-			typeInfoCache.Delete(key)
-			return true
-		})
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			reset()
-			jsonStdlibSupportsOmitzero = tc.stdlib
-			t.Cleanup(reset)
-
 			em, _ := EncOptions{}.EncMode()
 			dm, _ := DecOptions{}.DecMode()
 			testRoundTrip(t, []roundTripTestCase{{tc.name, tc.obj, tc.want}}, em, dm)
@@ -6532,7 +6498,7 @@ func TestMarshalByteArrayMode(t *testing.T) {
 func TestMarshalByteSliceMode(t *testing.T) {
 	type namedByteSlice []byte
 	ts := NewTagSet()
-	if err := ts.Add(TagOptions{EncTag: EncTagRequired}, reflect.TypeOf(namedByteSlice{}), 0xcc); err != nil {
+	if err := ts.Add(TagOptions{EncTag: EncTagRequired}, reflect.TypeFor[namedByteSlice](), 0xcc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -6783,7 +6749,7 @@ func (tm *testTextMarshaler) MarshalText() ([]byte, error) {
 
 func TestTextMarshalerMode(t *testing.T) {
 	testTags := NewTagSet()
-	if err := testTags.Add(TagOptions{EncTag: EncTagRequired}, reflect.TypeOf(testTextMarshaler{}), 9999); err != nil {
+	if err := testTags.Add(TagOptions{EncTag: EncTagRequired}, reflect.TypeFor[testTextMarshaler](), 9999); err != nil {
 		t.Fatal(err)
 	}
 
@@ -6863,7 +6829,7 @@ func TestTextMarshalerMode(t *testing.T) {
 
 func TestTextMarshalerModeError(t *testing.T) {
 	testTags := NewTagSet()
-	if err := testTags.Add(TagOptions{EncTag: EncTagRequired}, reflect.TypeOf(testTextMarshaler{}), 9999); err != nil {
+	if err := testTags.Add(TagOptions{EncTag: EncTagRequired}, reflect.TypeFor[testTextMarshaler](), 9999); err != nil {
 		t.Fatal(err)
 	}
 
@@ -6969,7 +6935,7 @@ func TestJSONMarshalerTranscoderNil(t *testing.T) {
 
 func TestJSONMarshalerTranscoder(t *testing.T) {
 	testTags := NewTagSet()
-	if err := testTags.Add(TagOptions{EncTag: EncTagRequired}, reflect.TypeOf(stubJSONMarshaler{}), 9999); err != nil {
+	if err := testTags.Add(TagOptions{EncTag: EncTagRequired}, reflect.TypeFor[stubJSONMarshaler](), 9999); err != nil {
 		t.Fatal(err)
 	}
 
@@ -6999,7 +6965,7 @@ func TestJSONMarshalerTranscoder(t *testing.T) {
 			transcodeError: errors.New("test"),
 			wantErrorMsg: TranscodeError{
 				err:          errors.New("test"),
-				rtype:        reflect.TypeOf(stubJSONMarshaler{}),
+				rtype:        reflect.TypeFor[stubJSONMarshaler](),
 				sourceFormat: "json",
 				targetFormat: "cbor",
 			}.Error(),
@@ -7011,7 +6977,7 @@ func TestJSONMarshalerTranscoder(t *testing.T) {
 			transcodeOutput: []byte{0xff},
 			wantErrorMsg: TranscodeError{
 				err:          errors.New(`cbor: unexpected "break" code`),
-				rtype:        reflect.TypeOf(stubJSONMarshaler{}),
+				rtype:        reflect.TypeFor[stubJSONMarshaler](),
 				sourceFormat: "json",
 				targetFormat: "cbor",
 			}.Error(),
@@ -7023,7 +6989,7 @@ func TestJSONMarshalerTranscoder(t *testing.T) {
 			transcodeOutput: []byte{0x61},
 			wantErrorMsg: TranscodeError{
 				err:          io.ErrUnexpectedEOF,
-				rtype:        reflect.TypeOf(stubJSONMarshaler{}),
+				rtype:        reflect.TypeFor[stubJSONMarshaler](),
 				sourceFormat: "json",
 				targetFormat: "cbor",
 			}.Error(),
@@ -7035,7 +7001,7 @@ func TestJSONMarshalerTranscoder(t *testing.T) {
 			transcodeOutput: []byte{0x61, 'a', 0x61, 'b'},
 			wantErrorMsg: TranscodeError{
 				err:          &ExtraneousDataError{numOfBytes: 2, index: 2},
-				rtype:        reflect.TypeOf(stubJSONMarshaler{}),
+				rtype:        reflect.TypeFor[stubJSONMarshaler](),
 				sourceFormat: "json",
 				targetFormat: "cbor",
 			}.Error(),
@@ -7135,7 +7101,7 @@ func TestMarshalerErrorUnwrap(t *testing.T) {
 	}
 	// The marshalCBORError type returns the raw error, not a MarshalerError,
 	// so also test Unwrap directly by constructing a MarshalerError.
-	me2 := &MarshalerError{typ: reflect.TypeOf(0), err: innerErr}
+	me2 := &MarshalerError{typ: reflect.TypeFor[int](), err: innerErr}
 	if unwrapped := me2.Unwrap(); unwrapped != innerErr {
 		t.Errorf("MarshalerError.Unwrap() = %v, want %v", unwrapped, innerErr)
 	}
@@ -7143,7 +7109,7 @@ func TestMarshalerErrorUnwrap(t *testing.T) {
 
 func TestTranscodeErrorUnwrap(t *testing.T) {
 	innerErr := errors.New("transcode failed")
-	te := TranscodeError{err: innerErr, rtype: reflect.TypeOf(0), sourceFormat: "json", targetFormat: "cbor"}
+	te := TranscodeError{err: innerErr, rtype: reflect.TypeFor[int](), sourceFormat: "json", targetFormat: "cbor"}
 	if unwrapped := te.Unwrap(); unwrapped != innerErr {
 		t.Errorf("TranscodeError.Unwrap() = %v, want %v", unwrapped, innerErr)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -456,7 +456,7 @@ func Example_signedCWTWithTag() {
 	tags := cbor.NewTagSet()
 	if err := tags.Add(
 		cbor.TagOptions{EncTag: cbor.EncTagRequired, DecTag: cbor.DecTagRequired},
-		reflect.TypeOf(signedCWT{}),
+		reflect.TypeFor[signedCWT](),
 		18); err != nil {
 		fmt.Println("error:", err)
 	}

--- a/example_transcoding_test.go
+++ b/example_transcoding_test.go
@@ -66,7 +66,7 @@ func ExampleTranscoder_fromJSON() {
 func ExampleTranscoder_toJSON() {
 	var dec cbor.DecMode
 	dec, _ = cbor.DecOptions{
-		DefaultMapType: reflect.TypeOf(map[string]any{}),
+		DefaultMapType: reflect.TypeFor[map[string]any](),
 		JSONUnmarshalerTranscoder: TranscoderFunc(func(w io.Writer, r io.Reader) error {
 			var tmp any
 			if err := dec.NewDecoder(r).Decode(&tmp); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/fxamacker/cbor/v2
 
-go 1.20
+go 1.24
 
 require github.com/x448/float16 v0.8.4

--- a/json_test.go
+++ b/json_test.go
@@ -27,7 +27,7 @@ func TestStdlibJSONCompatibility(t *testing.T) {
 	}
 
 	dec, err := cbor.DecOptions{
-		DefaultByteStringType:    reflect.TypeOf(""),
+		DefaultByteStringType:    reflect.TypeFor[string](),
 		ByteStringToString:       cbor.ByteStringToStringAllowedWithExpectedLaterEncoding,
 		ByteStringExpectedFormat: cbor.ByteStringExpectedBase64,
 	}.DecMode()

--- a/omitzero_go124.go
+++ b/omitzero_go124.go
@@ -1,8 +1,0 @@
-// Copyright (c) Faye Amacker. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-//go:build go1.24
-
-package cbor
-
-var jsonStdlibSupportsOmitzero = true

--- a/omitzero_pre_go124.go
+++ b/omitzero_pre_go124.go
@@ -1,8 +1,0 @@
-// Copyright (c) Faye Amacker. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-
-//go:build !go1.24
-
-package cbor
-
-var jsonStdlibSupportsOmitzero = false

--- a/simplevalue.go
+++ b/simplevalue.go
@@ -21,7 +21,7 @@ import (
 type SimpleValue uint8
 
 var (
-	typeSimpleValue = reflect.TypeOf(SimpleValue(0))
+	typeSimpleValue = reflect.TypeFor[SimpleValue]()
 )
 
 // MarshalCBOR encodes SimpleValue as CBOR simple value (major type 7).

--- a/stream_test.go
+++ b/stream_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestDecoder(t *testing.T) {
 	var buf bytes.Buffer
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		for _, tc := range unmarshalTestCases {
 			buf.Write(tc.data)
 		}
@@ -44,7 +44,7 @@ func TestDecoder(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				for _, tc := range unmarshalTestCases {
 					var v any
 					if err := decoder.Decode(&v); err != nil {
@@ -63,7 +63,7 @@ func TestDecoder(t *testing.T) {
 					}
 				}
 			}
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				// no more data
 				var v any
 				err := decoder.Decode(&v)
@@ -80,7 +80,7 @@ func TestDecoder(t *testing.T) {
 
 func TestDecoderUnmarshalTypeError(t *testing.T) {
 	var buf bytes.Buffer
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		for _, tc := range unmarshalTestCases {
 			for j := 0; j < len(tc.wrongTypes)*2; j++ {
 				buf.Write(tc.data)
@@ -110,7 +110,7 @@ func TestDecoderUnmarshalTypeError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				for _, tc := range unmarshalTestCases {
 					for _, typ := range tc.wrongTypes {
 						v := reflect.New(typ)
@@ -142,7 +142,7 @@ func TestDecoderUnmarshalTypeError(t *testing.T) {
 					}
 				}
 			}
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				// no more data
 				var v any
 				err := decoder.Decode(&v)
@@ -205,7 +205,7 @@ func TestDecoderUnexpectedEOFError(t *testing.T) {
 					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
 				}
 			}
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				// truncated data
 				var v any
 				err := decoder.Decode(&v)
@@ -269,7 +269,7 @@ func TestDecoderReadError(t *testing.T) {
 					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
 				}
 			}
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				// truncated data because Reader returned error
 				var v any
 				err := decoder.Decode(&v)
@@ -312,7 +312,7 @@ func TestDecoderNoData(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				var v any
 				err := decoder.Decode(&v)
 				if v != nil {
@@ -382,7 +382,7 @@ func TestDecoderInvalidData(t *testing.T) {
 
 func TestDecoderSkip(t *testing.T) {
 	var buf bytes.Buffer
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		for _, tc := range unmarshalTestCases {
 			buf.Write(tc.data)
 		}
@@ -410,7 +410,7 @@ func TestDecoderSkip(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				for _, tc := range unmarshalTestCases {
 					if err := decoder.Skip(); err != nil {
 						t.Fatalf("Skip() returned error %v", err)
@@ -421,7 +421,7 @@ func TestDecoderSkip(t *testing.T) {
 					}
 				}
 			}
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				// no more data
 				err := decoder.Skip()
 				if err != io.EOF {
@@ -461,7 +461,7 @@ func TestDecoderSkipInvalidDataError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < len(unmarshalTestCases); i++ {
+			for i := range unmarshalTestCases {
 				tc := unmarshalTestCases[i]
 				if err := decoder.Skip(); err != nil {
 					t.Fatalf("Skip() returned error %v", err)
@@ -471,7 +471,7 @@ func TestDecoderSkipInvalidDataError(t *testing.T) {
 					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
 				}
 			}
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				// last data item is invalid
 				err := decoder.Skip()
 				if err == nil {
@@ -523,7 +523,7 @@ func TestDecoderSkipUnexpectedEOFError(t *testing.T) {
 					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
 				}
 			}
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				// last data item is invalid
 				err := decoder.Skip()
 				if err != io.ErrUnexpectedEOF {
@@ -575,7 +575,7 @@ func TestDecoderSkipReadError(t *testing.T) {
 					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
 				}
 			}
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				// truncated data because Reader returned error
 				err := decoder.Skip()
 				if err != readerErr {
@@ -614,7 +614,7 @@ func TestDecoderSkipNoData(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				err := decoder.Skip()
 				if err != tc.wantErr {
 					t.Errorf("Decode() returned error %v, want error %v", err, tc.wantErr)
@@ -1646,10 +1646,7 @@ func newNBytesReaderWithError(data []byte, maxBytesPerRead int, err error) *nByt
 func (r *nBytesReader) Read(b []byte) (int, error) {
 	var n int
 	if r.off < len(r.data) {
-		numOfBytesToRead := len(r.data) - r.off
-		if numOfBytesToRead > r.maxBytesPerRead {
-			numOfBytesToRead = r.maxBytesPerRead
-		}
+		numOfBytesToRead := min(len(r.data)-r.off, r.maxBytesPerRead)
 		n = copy(b, r.data[r.off:r.off+numOfBytesToRead])
 		r.off += n
 	}

--- a/structfields.go
+++ b/structfields.go
@@ -190,7 +190,7 @@ func appendFields(
 	_flds fields,
 	_nTypes map[reflect.Type][][]int,
 ) {
-	for i := 0; i < t.NumField(); i++ {
+	for i := range t.NumField() {
 		f := t.Field(i)
 
 		ft := f.Type
@@ -202,11 +202,9 @@ func appendFields(
 			continue
 		}
 
-		cborTag := true
 		tag := f.Tag.Get("cbor")
 		if tag == "" {
 			tag = f.Tag.Get("json")
-			cborTag = false
 		}
 		if tag == "-" {
 			continue
@@ -219,11 +217,11 @@ func appendFields(
 		var omitempty, omitzero, keyasint bool
 		for j := 0; tag != ""; j++ {
 			var token string
-			idx := strings.IndexByte(tag, ',')
-			if idx == -1 {
+			before, after, ok := strings.Cut(tag, ",")
+			if !ok {
 				token, tag = tag, ""
 			} else {
-				token, tag = tag[:idx], tag[idx+1:]
+				token, tag = before, after
 			}
 			if j == 0 {
 				tagFieldName = token
@@ -232,9 +230,7 @@ func appendFields(
 				case "omitempty":
 					omitempty = true
 				case "omitzero":
-					if cborTag || jsonStdlibSupportsOmitzero {
-						omitzero = true
-					}
+					omitzero = true
 				case "keyasint":
 					keyasint = true
 				}

--- a/tag.go
+++ b/tag.go
@@ -183,7 +183,7 @@ func (t *tagItem) equalTagNum(num []uint64) bool {
 		return false
 	}
 
-	for i := 0; i < len(t.num); i++ {
+	for i := range len(t.num) {
 		if t.num[i] != num[i] {
 			return false
 		}
@@ -318,8 +318,8 @@ func newTagItem(opts TagOptions, contentType reflect.Type, num uint64, nestedNum
 }
 
 var (
-	typeTag    = reflect.TypeOf(Tag{})
-	typeRawTag = reflect.TypeOf(RawTag{})
+	typeTag    = reflect.TypeFor[Tag]()
+	typeRawTag = reflect.TypeFor[RawTag]()
 )
 
 // WrongTagError describes mismatch between CBOR tag and registered tag.

--- a/tag_test.go
+++ b/tag_test.go
@@ -5,6 +5,7 @@ package cbor
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -1430,7 +1431,7 @@ func (n *number3) UnmarshalCBOR(data []byte) (err error) {
 	}
 
 	if getType(rawTag.Content[0]) != cborTypeMap {
-		return fmt.Errorf("wrong tag content type, want map")
+		return errors.New("wrong tag content type, want map")
 	}
 
 	var v map[string]uint64

--- a/tag_test.go
+++ b/tag_test.go
@@ -35,24 +35,24 @@ func TestTagNewTypeWithBuiltinUnderlyingType(t *testing.T) {
 	type myMapIntInt map[int]int
 
 	types := []reflect.Type{
-		reflect.TypeOf(myBool(false)),
-		reflect.TypeOf(myUint(0)),
-		reflect.TypeOf(myUint8(0)),
-		reflect.TypeOf(myUint16(0)),
-		reflect.TypeOf(myUint32(0)),
-		reflect.TypeOf(myUint64(0)),
-		reflect.TypeOf(myInt(0)),
-		reflect.TypeOf(myInt8(0)),
-		reflect.TypeOf(myInt16(0)),
-		reflect.TypeOf(myInt32(0)),
-		reflect.TypeOf(myInt64(0)),
-		reflect.TypeOf(myFloat32(0)),
-		reflect.TypeOf(myFloat64(0)),
-		reflect.TypeOf(myString("")),
-		reflect.TypeOf(myByteSlice([]byte{})),
-		reflect.TypeOf(myIntSlice([]int{})),
-		reflect.TypeOf(myIntArray([4]int{})),
-		reflect.TypeOf(myMapIntInt(map[int]int{})),
+		reflect.TypeFor[myBool](),
+		reflect.TypeFor[myUint](),
+		reflect.TypeFor[myUint8](),
+		reflect.TypeFor[myUint16](),
+		reflect.TypeFor[myUint32](),
+		reflect.TypeFor[myUint64](),
+		reflect.TypeFor[myInt](),
+		reflect.TypeFor[myInt8](),
+		reflect.TypeFor[myInt16](),
+		reflect.TypeFor[myInt32](),
+		reflect.TypeFor[myInt64](),
+		reflect.TypeFor[myFloat32](),
+		reflect.TypeFor[myFloat64](),
+		reflect.TypeFor[myString](),
+		reflect.TypeFor[myByteSlice](),
+		reflect.TypeFor[myIntSlice](),
+		reflect.TypeFor[myIntArray](),
+		reflect.TypeFor[myMapIntInt](),
 	}
 
 	tags := NewTagSet()
@@ -163,8 +163,8 @@ func TestTagNewTypeWithBuiltinUnderlyingType(t *testing.T) {
 }
 
 func TestTagBinaryMarshalerUnmarshaler(t *testing.T) {
-	t1 := reflect.TypeOf((*number)(nil)) // Use *number for testing purpose
-	t2 := reflect.TypeOf(stru{})
+	t1 := reflect.TypeFor[*number]() // Use *number for testing purpose
+	t2 := reflect.TypeFor[stru]()
 
 	tags := NewTagSet()
 	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, t1, 123); err != nil {
@@ -198,7 +198,7 @@ func TestTagStruct(t *testing.T) {
 		S string `cbor:"s,omitempty"`
 	}
 
-	t1 := reflect.TypeOf(T{})
+	t1 := reflect.TypeFor[T]()
 
 	tags := NewTagSet()
 	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, t1, 100); err != nil {
@@ -227,7 +227,7 @@ func TestTagFixedLengthStruct(t *testing.T) {
 		S string `cbor:"s"`
 	}
 
-	t1 := reflect.TypeOf(T{})
+	t1 := reflect.TypeFor[T]()
 
 	tags := NewTagSet()
 	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, t1, 100); err != nil {
@@ -265,7 +265,7 @@ func TestTagToArrayStruct(t *testing.T) {
 		Signature   []byte
 	}
 
-	t1 := reflect.TypeOf(signedCWT{})
+	t1 := reflect.TypeFor[signedCWT]()
 
 	tags := NewTagSet()
 	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, t1, 18); err != nil {
@@ -304,7 +304,7 @@ func TestNestedTagStruct(t *testing.T) {
 		Tag         []byte
 	}
 
-	t1 := reflect.TypeOf(macedCOSE{})
+	t1 := reflect.TypeFor[macedCOSE]()
 
 	// Register tag CBOR Web Token (CWT) 61 and COSE_Mac0 17 with macedCOSE type
 	tags := NewTagSet()
@@ -348,21 +348,21 @@ func TestAddTagError(t *testing.T) {
 		},
 		{
 			name:         "DecTag is DecTagIgnored && EncTag is EncTagNone",
-			typ:          reflect.TypeOf(myInt(0)),
+			typ:          reflect.TypeFor[myInt](),
 			num:          100,
 			opts:         TagOptions{DecTag: DecTagIgnored, EncTag: EncTagNone},
 			wantErrorMsg: "cbor: cannot add tag with DecTagIgnored and EncTagNone options to TagSet",
 		},
 		{
 			name:         "time.Time",
-			typ:          reflect.TypeOf(time.Time{}),
+			typ:          reflect.TypeFor[time.Time](),
 			num:          101,
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: cannot add time.Time to TagSet, use EncOptions.TimeTag and DecOptions.TimeTag instead",
 		},
 		{
 			name:         "builtin type string",
-			typ:          reflect.TypeOf(""),
+			typ:          reflect.TypeFor[string](),
 			num:          102,
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: can only add named types to TagSet, got string",
@@ -376,28 +376,28 @@ func TestAddTagError(t *testing.T) {
 		},
 		{
 			name:         "interface",
-			typ:          reflect.TypeOf((*io.Reader)(nil)).Elem(),
+			typ:          reflect.TypeFor[io.Reader](),
 			num:          104,
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: can only add named types to TagSet, got io.Reader",
 		},
 		{
 			name:         "cbor.Tag",
-			typ:          reflect.TypeOf(Tag{}),
+			typ:          reflect.TypeFor[Tag](),
 			num:          105,
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: cannot add cbor.Tag to TagSet",
 		},
 		{
 			name:         "cbor.RawTag",
-			typ:          reflect.TypeOf(RawTag{}),
+			typ:          reflect.TypeFor[RawTag](),
 			num:          106,
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: cannot add cbor.RawTag to TagSet",
 		},
 		{
 			name:         "big.Int",
-			typ:          reflect.TypeOf(big.Int{}),
+			typ:          reflect.TypeFor[big.Int](),
 			num:          107,
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: cannot add big.Int to TagSet, it's built-in and supported automatically",
@@ -420,35 +420,35 @@ func TestAddTagError(t *testing.T) {
 		*/
 		{
 			name:         "tag number 0",
-			typ:          reflect.TypeOf(myInt(0)),
+			typ:          reflect.TypeFor[myInt](),
 			num:          0,
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: cannot add tag number 0 or 1 to TagSet, use EncOptions.TimeTag and DecOptions.TimeTag instead",
 		},
 		{
 			name:         "tag number 1",
-			typ:          reflect.TypeOf(myInt(0)),
+			typ:          reflect.TypeFor[myInt](),
 			num:          1,
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: cannot add tag number 0 or 1 to TagSet, use EncOptions.TimeTag and DecOptions.TimeTag instead",
 		},
 		{
 			name:         "tag number 2",
-			typ:          reflect.TypeOf(myInt(0)),
+			typ:          reflect.TypeFor[myInt](),
 			num:          2,
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: cannot add tag number 2 or 3 to TagSet, it's built-in and supported automatically",
 		},
 		{
 			name:         "tag number 3",
-			typ:          reflect.TypeOf(myInt(0)),
+			typ:          reflect.TypeFor[myInt](),
 			num:          3,
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: cannot add tag number 2 or 3 to TagSet, it's built-in and supported automatically",
 		},
 		{
 			name:         "tag number 55799",
-			typ:          reflect.TypeOf(myInt(0)),
+			typ:          reflect.TypeFor[myInt](),
 			num:          55799,
 			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
 			wantErrorMsg: "cbor: cannot add tag number 55799 to TagSet, it's built-in and ignored automatically",
@@ -474,7 +474,7 @@ func TestAddTagError(t *testing.T) {
 
 func TestAddDuplicateTagContentTypeError(t *testing.T) {
 	type myInt int
-	myIntType := reflect.TypeOf(myInt(0))
+	myIntType := reflect.TypeFor[myInt]()
 	wantErrorMsg := "cbor: content type cbor.myInt already exists in TagSet"
 
 	tags := NewTagSet()
@@ -493,8 +493,8 @@ func TestAddDuplicateTagContentTypeError(t *testing.T) {
 func TestAddDuplicateTagNumError(t *testing.T) {
 	type myBool bool
 	type myInt int
-	myBoolType := reflect.TypeOf(myBool(false))
-	myIntType := reflect.TypeOf(myInt(0))
+	myBoolType := reflect.TypeFor[myBool]()
+	myIntType := reflect.TypeFor[myInt]()
 	wantErrorMsg := "cbor: tag number [100] already exists in TagSet"
 
 	tags := NewTagSet()
@@ -514,8 +514,8 @@ func TestAddDuplicateTagNumError(t *testing.T) {
 func TestAddDuplicateTagNumsError(t *testing.T) {
 	type myBool bool
 	type myInt int
-	myBoolType := reflect.TypeOf(myBool(false))
-	myIntType := reflect.TypeOf(myInt(0))
+	myBoolType := reflect.TypeFor[myBool]()
+	myIntType := reflect.TypeFor[myInt]()
 	wantErrorMsg := "cbor: tag number [100 101] already exists in TagSet"
 
 	tags := NewTagSet()
@@ -535,10 +535,10 @@ func TestAddDuplicateTagNumsError(t *testing.T) {
 func TestAddRemoveTag(t *testing.T) {
 	type myInt int
 	type myFloat float64
-	myIntType := reflect.TypeOf(myInt(0))
-	myFloatType := reflect.TypeOf(myFloat(0.0))
-	pMyIntType := reflect.TypeOf((*myInt)(nil))
-	pMyFloatType := reflect.TypeOf((*myFloat)(nil))
+	myIntType := reflect.TypeFor[myInt]()
+	myFloatType := reflect.TypeFor[myFloat]()
+	pMyIntType := reflect.TypeFor[*myInt]()
+	pMyFloatType := reflect.TypeFor[*myFloat]()
 
 	tags := NewTagSet()
 	stags := tags.(*syncTagSet)
@@ -571,7 +571,7 @@ func TestAddRemoveTag(t *testing.T) {
 
 func TestTagSetRemoveNil(t *testing.T) {
 	type myInt int
-	myIntType := reflect.TypeOf(myInt(0))
+	myIntType := reflect.TypeFor[myInt]()
 
 	tags := NewTagSet()
 	stags := tags.(*syncTagSet)
@@ -634,92 +634,92 @@ func TestAddTagTypeAliasError(t *testing.T) {
 	}{
 		{
 			name:         "bool",
-			typ:          reflect.TypeOf(myBool(false)),
+			typ:          reflect.TypeFor[myBool](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got bool",
 		},
 		{
 			name:         "uint",
-			typ:          reflect.TypeOf(myUint(0)),
+			typ:          reflect.TypeFor[myUint](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got uint",
 		},
 		{
 			name:         "uint8",
-			typ:          reflect.TypeOf(myUint8(0)),
+			typ:          reflect.TypeFor[myUint8](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got uint8",
 		},
 		{
 			name:         "uint16",
-			typ:          reflect.TypeOf(myUint16(0)),
+			typ:          reflect.TypeFor[myUint16](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got uint16",
 		},
 		{
 			name:         "uint32",
-			typ:          reflect.TypeOf(myUint32(0)),
+			typ:          reflect.TypeFor[myUint32](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got uint32",
 		},
 		{
 			name:         "uint64",
-			typ:          reflect.TypeOf(myUint64(0)),
+			typ:          reflect.TypeFor[myUint64](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got uint64",
 		},
 		{
 			name:         "int",
-			typ:          reflect.TypeOf(myInt(0)),
+			typ:          reflect.TypeFor[myInt](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got int",
 		},
 		{
 			name:         "int8",
-			typ:          reflect.TypeOf(myInt8(0)),
+			typ:          reflect.TypeFor[myInt8](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got int8",
 		},
 		{
 			name:         "int16",
-			typ:          reflect.TypeOf(myInt16(0)),
+			typ:          reflect.TypeFor[myInt16](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got int16",
 		},
 		{
 			name:         "int32",
-			typ:          reflect.TypeOf(myInt32(0)),
+			typ:          reflect.TypeFor[myInt32](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got int32",
 		},
 		{
 			name:         "int64",
-			typ:          reflect.TypeOf(myInt64(0)),
+			typ:          reflect.TypeFor[myInt64](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got int64",
 		},
 		{
 			name:         "float32",
-			typ:          reflect.TypeOf(myFloat32(0.0)),
+			typ:          reflect.TypeFor[myFloat32](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got float32",
 		},
 		{
 			name:         "float64",
-			typ:          reflect.TypeOf(myFloat64(0.0)),
+			typ:          reflect.TypeFor[myFloat64](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got float64",
 		},
 		{
 			name:         "string",
-			typ:          reflect.TypeOf(myString("")),
+			typ:          reflect.TypeFor[myString](),
 			wantErrorMsg: "cbor: can only add named types to TagSet, got string",
 		},
 		{
 			name:         "[]byte",
-			typ:          reflect.TypeOf(myByteSlice([]byte{})), //nolint:unconvert
+			typ:          reflect.TypeFor[myByteSlice](), //nolint:unconvert
 			wantErrorMsg: "cbor: can only add named types to TagSet, got []uint8",
 		},
 		{
 			name:         "[]int",
-			typ:          reflect.TypeOf(myIntSlice([]int{})), //nolint:unconvert
+			typ:          reflect.TypeFor[myIntSlice](), //nolint:unconvert
 			wantErrorMsg: "cbor: can only add named types to TagSet, got []int",
 		},
 		{
 			name:         "[4]int",
-			typ:          reflect.TypeOf(myIntArray([4]int{})), //nolint:unconvert
+			typ:          reflect.TypeFor[myIntArray](), //nolint:unconvert
 			wantErrorMsg: "cbor: can only add named types to TagSet, got [4]int",
 		},
 		{
 			name:         "map[int]int",
-			typ:          reflect.TypeOf(myMapIntInt(map[int]int{})), //nolint:unconvert
+			typ:          reflect.TypeFor[myMapIntInt](), //nolint:unconvert
 			wantErrorMsg: "cbor: can only add named types to TagSet, got map[int]int",
 		},
 	}
@@ -750,10 +750,10 @@ func TestDecodeTagData(t *testing.T) {
 		n []uint64
 	}
 	tagInfos := []tagInfo{
-		{reflect.TypeOf((*number)(nil)), []uint64{123}}, // BinaryMarshaler *number
-		{reflect.TypeOf(stru{}), []uint64{124}},         // BinaryMarshaler stru
-		{reflect.TypeOf(myInt(0)), []uint64{125}},       // non-struct type
-		{reflect.TypeOf(s{}), []uint64{126}},            // struct type
+		{reflect.TypeFor[*number](), []uint64{123}}, // BinaryMarshaler *number
+		{reflect.TypeFor[stru](), []uint64{124}},    // BinaryMarshaler stru
+		{reflect.TypeFor[myInt](), []uint64{125}},   // non-struct type
+		{reflect.TypeFor[s](), []uint64{126}},       // struct type
 	}
 
 	tagsDecRequired := NewTagSet()
@@ -826,10 +826,10 @@ func TestDecodeNoTagData(t *testing.T) {
 		n []uint64
 	}
 	tagInfos := []tagInfo{
-		{reflect.TypeOf((*number)(nil)), []uint64{123}}, // BinaryMarshaler *number
-		{reflect.TypeOf(stru{}), []uint64{124}},         // BinaryMarshaler stru
-		{reflect.TypeOf(myInt(0)), []uint64{125}},       // non-struct type
-		{reflect.TypeOf(s{}), []uint64{126}},            // struct type
+		{reflect.TypeFor[*number](), []uint64{123}}, // BinaryMarshaler *number
+		{reflect.TypeFor[stru](), []uint64{124}},    // BinaryMarshaler stru
+		{reflect.TypeFor[myInt](), []uint64{125}},   // non-struct type
+		{reflect.TypeFor[s](), []uint64{126}},       // struct type
 	}
 
 	tagsDecRequired := NewTagSet()
@@ -915,10 +915,10 @@ func TestDecodeWrongTag(t *testing.T) {
 		n []uint64
 	}
 	tagInfos := []tagInfo{
-		{reflect.TypeOf((*number)(nil)), []uint64{123}}, // BinaryMarshaler *number
-		{reflect.TypeOf(stru{}), []uint64{124}},         // BinaryMarshaler stru
-		{reflect.TypeOf(myInt(0)), []uint64{100}},       // non-struct type
-		{reflect.TypeOf(s{}), []uint64{101, 102}},       // struct type
+		{reflect.TypeFor[*number](), []uint64{123}}, // BinaryMarshaler *number
+		{reflect.TypeFor[stru](), []uint64{124}},    // BinaryMarshaler stru
+		{reflect.TypeFor[myInt](), []uint64{100}},   // non-struct type
+		{reflect.TypeFor[s](), []uint64{101, 102}},  // struct type
 	}
 
 	tagsDecRequired := NewTagSet()
@@ -1014,7 +1014,7 @@ func TestDecodeWrongTag(t *testing.T) {
 func TestEncodeSharedTag(t *testing.T) {
 	type myInt int
 
-	myIntType := reflect.TypeOf(myInt(0))
+	myIntType := reflect.TypeFor[myInt]()
 
 	sharedTagSet := NewTagSet()
 
@@ -1074,7 +1074,7 @@ func TestEncodeSharedTag(t *testing.T) {
 func TestDecodeSharedTag(t *testing.T) {
 	type myInt int
 
-	myIntType := reflect.TypeOf(myInt(0))
+	myIntType := reflect.TypeFor[myInt]()
 
 	sharedTagSet := NewTagSet()
 
@@ -1319,8 +1319,8 @@ func TestDecodeTagToEmptyIface(t *testing.T) {
 	type myBool bool
 	type myUint uint
 
-	typeMyBool := reflect.TypeOf(myBool(false))
-	typeMyUint := reflect.TypeOf(myUint(0))
+	typeMyBool := reflect.TypeFor[myBool]()
+	typeMyUint := reflect.TypeFor[myUint]()
 
 	tags := NewTagSet()
 	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, typeMyBool, 100); err != nil {
@@ -1389,7 +1389,7 @@ func TestDecodeTagToEmptyIface(t *testing.T) {
 func TestDecodeRegisteredTagToEmptyIfaceError(t *testing.T) {
 	type myInt int
 
-	typeMyInt := reflect.TypeOf(myInt(0))
+	typeMyInt := reflect.TypeFor[myInt]()
 
 	tags := NewTagSet()
 	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, typeMyInt, 101, 102); err != nil {
@@ -1442,7 +1442,7 @@ func (n *number3) UnmarshalCBOR(data []byte) (err error) {
 }
 
 func TestDecodeRegisterTagForUnmarshaler(t *testing.T) {
-	typ := reflect.TypeOf(number3(0))
+	typ := reflect.TypeFor[number3]()
 
 	tags := NewTagSet()
 	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, typ, 100); err != nil {

--- a/valid.go
+++ b/valid.go
@@ -157,8 +157,8 @@ func (d *decoder) wellformedInternal(depth int, checkBuiltinTags bool) (int, err
 			count = 2
 		}
 		maxDepth := depth
-		for j := 0; j < count; j++ {
-			for i := 0; i < valInt; i++ {
+		for range count {
+			for range valInt {
 				var dpt int
 				if dpt, err = d.wellformedInternal(depth, checkBuiltinTags); err != nil {
 					return 0, err

--- a/valid_test.go
+++ b/valid_test.go
@@ -77,7 +77,7 @@ func TestValidOnStreamingData(t *testing.T) {
 		buf.Write(tc.wantData)
 	}
 	d := decoder{data: buf.Bytes(), dm: defaultDecMode}
-	for i := 0; i < len(marshalTestCases); i++ {
+	for range marshalTestCases {
 		if err := d.wellformed(true, false); err != nil {
 			t.Errorf("wellformed() returned error %v", err)
 		}


### PR DESCRIPTION
This PR bumps requirement from go 1.20 to go 1.24 and updates the code to use more modern coding standards.

The bump to go 1.24 removes the need to maintain separate files:
- omitzero_go124.go
- omitzero_pre_go124.go

This PR does not affect behavior of the codec.