### PR TITLE
Refactor to use slices.SortFunc (Go 1.21+)

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -5,10 +5,11 @@ package cbor
 
 import (
 	"bytes"
+	"cmp"
 	"errors"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -222,39 +223,15 @@ func (st *encodingStructType) getFields(em *encMode) encodingFields {
 	}
 }
 
-type bytewiseFieldSorter struct {
-	fields encodingFields
+func bytewiseFieldCmp(fi, fj *encodingField) int {
+	return bytes.Compare(fi.cborName, fj.cborName)
 }
 
-func (x *bytewiseFieldSorter) Len() int {
-	return len(x.fields)
-}
-
-func (x *bytewiseFieldSorter) Swap(i, j int) {
-	x.fields[i], x.fields[j] = x.fields[j], x.fields[i]
-}
-
-func (x *bytewiseFieldSorter) Less(i, j int) bool {
-	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) < 0
-}
-
-type lengthFirstFieldSorter struct {
-	fields encodingFields
-}
-
-func (x *lengthFirstFieldSorter) Len() int {
-	return len(x.fields)
-}
-
-func (x *lengthFirstFieldSorter) Swap(i, j int) {
-	x.fields[i], x.fields[j] = x.fields[j], x.fields[i]
-}
-
-func (x *lengthFirstFieldSorter) Less(i, j int) bool {
-	if len(x.fields[i].cborName) != len(x.fields[j].cborName) {
-		return len(x.fields[i].cborName) < len(x.fields[j].cborName)
+func lengthFirstFieldCmp(fi, fj *encodingField) int {
+	if len(fi.cborName) != len(fj.cborName) {
+		return cmp.Compare(len(fi.cborName), len(fj.cborName))
 	}
-	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) < 0
+	return bytes.Compare(fi.cborName, fj.cborName)
 }
 
 func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
@@ -347,13 +324,13 @@ func getEncodingStructType(t reflect.Type) (*encodingStructType, error) {
 	// Sort fields by canonical order
 	bytewiseFields := make(encodingFields, len(encFlds))
 	copy(bytewiseFields, encFlds)
-	sort.Sort(&bytewiseFieldSorter{bytewiseFields})
+	slices.SortFunc(bytewiseFields, bytewiseFieldCmp)
 
 	lengthFirstFields := bytewiseFields
 	if hasKeyAsInt && hasKeyAsStr {
 		lengthFirstFields = make(encodingFields, len(encFlds))
 		copy(lengthFirstFields, encFlds)
-		sort.Sort(&lengthFirstFieldSorter{lengthFirstFields})
+		slices.SortFunc(lengthFirstFields, lengthFirstFieldCmp)
 	}
 
 	structType := &encodingStructType{

--- a/encode.go
+++ b/encode.go
@@ -14,7 +14,7 @@ import (
 	"math/big"
 	"math/rand"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -1391,9 +1391,18 @@ func (me mapEncodeFunc) encode(e *bytes.Buffer, em *encMode, v reflect.Value) er
 	dst := e.Bytes()[kvBeginOffset:]
 
 	if em.sort == SortBytewiseLexical {
-		sort.Sort(&bytewiseKeyValueSorter{kvs: kvs, data: dst})
+		// Sort kvs by map keys in bytewise lexical order.
+		slices.SortFunc(kvs, func(kvi, kvj keyValue) int {
+			return bytes.Compare(dst[kvi.offset:kvi.valueOffset], dst[kvj.offset:kvj.valueOffset])
+		})
 	} else {
-		sort.Sort(&lengthFirstKeyValueSorter{kvs: kvs, data: dst})
+		// Sort kvs by map keys in length first order.
+		slices.SortFunc(kvs, func(kvi, kvj keyValue) int {
+			if keyLengthDifference := (kvi.valueOffset - kvi.offset) - (kvj.valueOffset - kvj.offset); keyLengthDifference != 0 {
+				return keyLengthDifference
+			}
+			return bytes.Compare(dst[kvi.offset:kvi.valueOffset], dst[kvj.offset:kvj.valueOffset])
+		})
 	}
 
 	// This is where the encoded bytes are actually rearranged in the output buffer to reflect
@@ -1415,45 +1424,6 @@ type keyValue struct {
 	offset      int
 	valueOffset int
 	nextOffset  int
-}
-
-type bytewiseKeyValueSorter struct {
-	kvs  []keyValue
-	data []byte
-}
-
-func (x *bytewiseKeyValueSorter) Len() int {
-	return len(x.kvs)
-}
-
-func (x *bytewiseKeyValueSorter) Swap(i, j int) {
-	x.kvs[i], x.kvs[j] = x.kvs[j], x.kvs[i]
-}
-
-func (x *bytewiseKeyValueSorter) Less(i, j int) bool {
-	kvi, kvj := x.kvs[i], x.kvs[j]
-	return bytes.Compare(x.data[kvi.offset:kvi.valueOffset], x.data[kvj.offset:kvj.valueOffset]) < 0
-}
-
-type lengthFirstKeyValueSorter struct {
-	kvs  []keyValue
-	data []byte
-}
-
-func (x *lengthFirstKeyValueSorter) Len() int {
-	return len(x.kvs)
-}
-
-func (x *lengthFirstKeyValueSorter) Swap(i, j int) {
-	x.kvs[i], x.kvs[j] = x.kvs[j], x.kvs[i]
-}
-
-func (x *lengthFirstKeyValueSorter) Less(i, j int) bool {
-	kvi, kvj := x.kvs[i], x.kvs[j]
-	if keyLengthDifference := (kvi.valueOffset - kvi.offset) - (kvj.valueOffset - kvj.offset); keyLengthDifference != 0 {
-		return keyLengthDifference < 0
-	}
-	return bytes.Compare(x.data[kvi.offset:kvi.valueOffset], x.data[kvj.offset:kvj.valueOffset]) < 0
 }
 
 var keyValuePool = sync.Pool{}

--- a/structfields.go
+++ b/structfields.go
@@ -4,7 +4,9 @@
 package cbor
 
 import (
+	"cmp"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -44,27 +46,15 @@ type decodingField struct {
 
 type decodingFields []*decodingField
 
-// indexFieldSorter sorts fields by field idx at each level, breaking ties with idx depth.
-type indexFieldSorter struct {
-	fields fields
-}
-
-func (x *indexFieldSorter) Len() int {
-	return len(x.fields)
-}
-
-func (x *indexFieldSorter) Swap(i, j int) {
-	x.fields[i], x.fields[j] = x.fields[j], x.fields[i]
-}
-
-func (x *indexFieldSorter) Less(i, j int) bool {
-	iIdx, jIdx := x.fields[i].idx, x.fields[j].idx
+// indexFieldCmp compares fields by field idx at each level, breaking ties with idx depth.
+func indexFieldCmp(fi, fj *field) int {
+	iIdx, jIdx := fi.idx, fj.idx
 	for k := 0; k < len(iIdx) && k < len(jIdx); k++ {
 		if iIdx[k] != jIdx[k] {
-			return iIdx[k] < jIdx[k]
+			return cmp.Compare(iIdx[k], jIdx[k])
 		}
 	}
-	return len(iIdx) < len(jIdx)
+	return cmp.Compare(len(iIdx), len(jIdx))
 }
 
 // nameLevelAndTagFieldSorter sorts fields by field name, idx depth, and presence of tag.
@@ -175,7 +165,7 @@ func getFields(t reflect.Type) (flds fields, structOptions string) {
 	}
 
 	// Sort fields by field index
-	sort.Sort(&indexFieldSorter{flds})
+	slices.SortFunc(flds, indexFieldCmp)
 
 	return flds, structOptions
 }


### PR DESCRIPTION
This PR reduces memory allocs and simplifies code by replacing the old `sort.Interface` implementations with `slices.SortFunc()`:

- `bytewiseFieldSorter`
- `lengthFirstFieldSorter`
- `indexFieldSorter`
- `bytewiseKeyValueSorter`
- `lengthFirstKeyValueSorter`

The main benefit is less code to maintain, with the new code being simpler and more modern.  The performance improvement in the CBOR codec is modest.