### PR TITLE
Add more linters to .golangci.yml and lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,25 +1,51 @@
+# .golangci.yml for https://github.com/fxamacker/cbor
+# Updated on May 10, 2026.
 version: "2"
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/fxamacker/cbor
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
 linters:
   default: none
   enable:
     - asciicheck
     - bidichk
     - depguard
+    - dogsled
+    - dupword
     - errcheck
+    - exptostd
     - forbidigo
     - goconst
     - gocritic
     - gocyclo
+    - godoclint
     - goprintffuncname
     - gosec
     - govet
     - ineffassign
+    - intrange
     - misspell
-    - nilerr
+    - nilnesserr
+    - perfsprint
+    - predeclared
+    - reassign
     - revive
     - staticcheck
     - unconvert
     - unused
+    - usestdlibvars
+    - wastedassign
   settings:
     depguard:
       rules:
@@ -31,9 +57,6 @@ linters:
           allow:
             - $gostd
             - github.com/x448/float16
-          deny:
-            - pkg: io/ioutil
-              desc: 'replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil'
     dupl:
       threshold: 100
     funlen:
@@ -58,7 +81,12 @@ linters:
         - style
     govet:
       enable:
+        - deepequalerrors
+        - nilness
+        - reflectvaluecompare
         - shadow
+        - sortslice
+        - unusedwrite
     lll:
       line-length: 140
     misspell:
@@ -95,22 +123,4 @@ linters:
       - third_party$
       - builtin$
       - examples$
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
-formatters:
-  enable:
-    - gofmt
-    - goimports
-  settings:
-    gofmt:
-      simplify: false
-    goimports:
-      local-prefixes:
-        - github.com/fxamacker/cbor
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+

--- a/bench_test.go
+++ b/bench_test.go
@@ -288,7 +288,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 				name = "CBOR " + bm.name + " to Go " + t.Kind().String()
 			}
 			b.Run(name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					vPtr := reflect.New(t).Interface()
 					if err := Unmarshal(bm.data, vPtr); err != nil {
 						b.Fatal("Unmarshal:", err)
@@ -341,7 +341,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 	}
 	for _, bm := range moreBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				vPtr := reflect.New(bm.decodeToType).Interface()
 				if err := Unmarshal(bm.data, vPtr); err != nil {
 					b.Fatal("Unmarshal:", err)
@@ -364,7 +364,7 @@ func BenchmarkUnmarshalFirst(b *testing.B) {
 			data = append(data, bm.data...)
 			data = append(data, trailingData...)
 			b.Run(name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					vPtr := reflect.New(t).Interface()
 					if _, err := UnmarshalFirst(data, vPtr); err != nil {
 						b.Fatal("UnmarshalFirst:", err)
@@ -388,7 +388,7 @@ func BenchmarkUnmarshalFirstViaDecoder(b *testing.B) {
 			data = append(data, bm.data...)
 			data = append(data, trailingData...)
 			b.Run(name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					vPtr := reflect.New(t).Interface()
 					if err := NewDecoder(bytes.NewReader(data)).Decode(vPtr); err != nil {
 						b.Fatal("UnmarshalDecoder:", err)
@@ -409,7 +409,7 @@ func BenchmarkDecode(b *testing.B) {
 			buf := bytes.NewReader(bm.data)
 			decoder := NewDecoder(buf)
 			b.Run(name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					vPtr := reflect.New(t).Interface()
 					if err := decoder.Decode(vPtr); err != nil {
 						b.Fatal("Decode:", err)
@@ -424,7 +424,7 @@ func BenchmarkDecode(b *testing.B) {
 func BenchmarkDecodeStream(b *testing.B) {
 	var data []byte
 	for _, bm := range decodeBenchmarks {
-		for i := 0; i < len(bm.decodeToTypes); i++ {
+		for range len(bm.decodeToTypes) {
 			data = append(data, bm.data...)
 		}
 	}
@@ -454,7 +454,7 @@ func BenchmarkMarshal(b *testing.B) {
 				name = "Go " + reflect.TypeOf(v).Kind().String() + " to CBOR " + bm.name
 			}
 			b.Run(name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					if _, err := Marshal(v); err != nil {
 						b.Fatal("Marshal:", err)
 					}
@@ -588,7 +588,7 @@ func BenchmarkMarshal(b *testing.B) {
 	}
 	for _, bm := range moreBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				if _, err := Marshal(bm.value); err != nil {
 					b.Fatal("Marshal:", err)
 				}
@@ -634,7 +634,7 @@ func BenchmarkMarshalCanonical(b *testing.B) {
 				name = "Go " + reflect.TypeOf(v).Kind().String() + " to CBOR " + bm.name
 			}
 			b.Run(name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					if _, err := Marshal(v); err != nil {
 						b.Fatal("Marshal:", err)
 					}
@@ -647,7 +647,7 @@ func BenchmarkMarshalCanonical(b *testing.B) {
 			}
 			em, _ := EncOptions{Sort: SortCanonical}.EncMode()
 			b.Run(name, func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					if _, err := em.Marshal(v); err != nil {
 						b.Fatal("Marshal:", err)
 					}
@@ -666,8 +666,7 @@ func BenchmarkNewEncoderEncode(b *testing.B) {
 				name = "Go " + reflect.TypeOf(v).Kind().String() + " to CBOR " + bm.name
 			}
 			b.Run(name, func(b *testing.B) {
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					encoder := NewEncoder(io.Discard)
 					if err := encoder.Encode(v); err != nil {
 						b.Fatal("Encode:", err)
@@ -689,8 +688,7 @@ func BenchmarkEncode(b *testing.B) {
 			}
 			b.Run(name, func(b *testing.B) {
 				encoder := NewEncoder(io.Discard)
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					if err := encoder.Encode(v); err != nil {
 						b.Fatal("Encode:", err)
 					}
@@ -736,7 +734,7 @@ func BenchmarkUnmarshalCOSE(b *testing.B) {
 	}
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				var v coseKey
 				if err := Unmarshal(tc.data, &v); err != nil {
 					b.Fatal("Unmarshal:", err)
@@ -771,7 +769,7 @@ func BenchmarkMarshalCOSE(b *testing.B) {
 			b.Fatal("Unmarshal:", err)
 		}
 		b.Run(tc.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				if _, err := Marshal(v); err != nil {
 					b.Fatal("Marshal:", err)
 				}
@@ -1149,8 +1147,7 @@ func BenchmarkUnmarshalMapToStruct(b *testing.B) {
 
 				dst := reflect.New(reflect.TypeOf(in.into)).Interface()
 
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					if err := dm.Unmarshal(in.data, dst); !in.reject && err != nil {
 						b.Fatalf("unexpected error: %v", err)
 					} else if in.reject && err == nil {

--- a/decode_test.go
+++ b/decode_test.go
@@ -5560,7 +5560,7 @@ func TestDecOptions(t *testing.T) {
 		JSONUnmarshalerTranscoder: stubTranscoder{},
 	}
 	ov := reflect.ValueOf(opts1)
-	for i := 0; i < ov.NumField(); i++ {
+	for i := range ov.NumField() {
 		fv := ov.Field(i)
 		if fv.IsZero() {
 			t.Errorf("options field %q is unset or set to the zero value for its type", ov.Type().Field(i).Name)

--- a/diagnose_test.go
+++ b/diagnose_test.go
@@ -1160,8 +1160,7 @@ func BenchmarkDiagnose(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_, _ = dm.Diagnose(tc.input)
 			}
 		})

--- a/encode_test.go
+++ b/encode_test.go
@@ -5623,7 +5623,7 @@ func TestEncOptions(t *testing.T) {
 		JSONMarshalerTranscoder: stubTranscoder{},
 	}
 	ov := reflect.ValueOf(opts1)
-	for i := 0; i < ov.NumField(); i++ {
+	for i := range ov.NumField() {
 		fv := ov.Field(i)
 		if fv.IsZero() {
 			fn := ov.Type().Field(i).Name

--- a/simplevalue_test.go
+++ b/simplevalue_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestUnmarshalSimpleValue(t *testing.T) {
 	t.Run("0..23", func(t *testing.T) {
-		for i := 0; i <= 23; i++ {
+		for i := range 24 {
 			data := []byte{byte(cborTypePrimitives) | byte(i)}
 			want := SimpleValue(i)
 
@@ -253,7 +253,7 @@ func testUnmarshalSimpleValue(t *testing.T, data []byte, want SimpleValue) {
 
 func TestMarshalSimpleValue(t *testing.T) {
 	t.Run("0..23", func(t *testing.T) {
-		for i := 0; i <= 23; i++ {
+		for i := range 24 {
 			wantData := []byte{byte(cborTypePrimitives) | byte(i)}
 			v := SimpleValue(i)
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -82,7 +82,7 @@ func TestDecoderUnmarshalTypeError(t *testing.T) {
 	var buf bytes.Buffer
 	for range 5 {
 		for _, tc := range unmarshalTestCases {
-			for j := 0; j < len(tc.wrongTypes)*2; j++ {
+			for range len(tc.wrongTypes) * 2 {
 				buf.Write(tc.data)
 			}
 		}
@@ -187,7 +187,7 @@ func TestDecoderUnexpectedEOFError(t *testing.T) {
 
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < len(unmarshalTestCases)-1; i++ {
+			for i := range len(unmarshalTestCases) - 1 {
 				tc := unmarshalTestCases[i]
 				var v any
 				if err := decoder.Decode(&v); err != nil {
@@ -251,7 +251,7 @@ func TestDecoderReadError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < len(unmarshalTestCases)-1; i++ {
+			for i := range len(unmarshalTestCases) - 1 {
 				tc := unmarshalTestCases[i]
 				var v any
 				if err := decoder.Decode(&v); err != nil {
@@ -513,7 +513,7 @@ func TestDecoderSkipUnexpectedEOFError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < len(unmarshalTestCases)-1; i++ {
+			for i := range len(unmarshalTestCases) - 1 {
 				tc := unmarshalTestCases[i]
 				if err := decoder.Skip(); err != nil {
 					t.Fatalf("Skip() returned error %v", err)
@@ -565,7 +565,7 @@ func TestDecoderSkipReadError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := NewDecoder(tc.reader)
 			bytesRead := 0
-			for i := 0; i < len(unmarshalTestCases)-1; i++ {
+			for i := range len(unmarshalTestCases) - 1 {
 				tc := unmarshalTestCases[i]
 				if err := decoder.Skip(); err != nil {
 					t.Fatalf("Skip() returned error %v", err)


### PR DESCRIPTION
This PR updates `.golangci.yml` and also modernizes more code by replacing left-over for-loops with range over integers (Go 1.22+), etc.

Changes to .golangci.yml:
- enable more linters
- add more `govet` settings to do more lint checks
- reorganize sections
- remove some obsolete settings