### PR TITLE
Update comments to use newer terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ This library checks tag validity for built-in tags (currently tag numbers 0, 1, 
 
 Unknown tag data items (not tag number 0, 1, 2, 3, or 55799) are handled in two ways:
 
-* When decoding into an empty interface, unknown tag data item will be decoded into `cbor.Tag` data type, which contains tag number and tag content.  The tag content will be decoded into the default Go data type for the CBOR data type.
+* When decoding into a value of type any, unknown tag data item will be decoded into `cbor.Tag` data type, which contains tag number and tag content.  The tag content will be decoded into the default Go data type for the CBOR data type.
 * When decoding into other Go types, unknown tag data item is decoded into the specified Go type.  If Go type is registered with a tag number, the tag number can optionally be verified.
 
 Decoder also has an option to forbid tag data items (treat any tag data item as error) which is specified by protocols such as CTAP2 Canonical CBOR.  

--- a/bench_test.go
+++ b/bench_test.go
@@ -302,9 +302,9 @@ func BenchmarkUnmarshal(b *testing.B) {
 		data         []byte
 		decodeToType reflect.Type
 	}{
-		// Unmarshal CBOR map with string key to map[string]interface{}.
+		// Unmarshal CBOR map with string key to map[string]any.
 		{
-			name:         "CBOR map to Go map[string]interface{}",
+			name:         "CBOR map to Go map[string]any",
 			data:         mustHexDecode("a86154f56255691bffffffffffffffff61493903e76146fbc0106666666666666142581a0102030405060708090a0b0c0d0e0f101112131415161718191a6153782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6764536c6369981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a634d7373ad6163614361656145616661466167614761686148616e614e616d614d61616141616261426164614461696149616a614a616c614c"),
 			decodeToType: reflect.TypeFor[map[string]any](),
 		},
@@ -314,9 +314,9 @@ func BenchmarkUnmarshal(b *testing.B) {
 			data:         mustHexDecode("a86154f56255491bffffffffffffffff61493903e76146fbc0106666666666666142581a0102030405060708090a0b0c0d0e0f101112131415161718191a6153782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6764536c6369981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a634d7373ad6163614361656145616661466167614761686148616e614e616d614d61616141616261426164614461696149616a614a616c614c"),
 			decodeToType: reflect.TypeFor[T1](),
 		},
-		// Unmarshal CBOR map with integer key, such as COSE Key and SenML, to map[int]interface{}.
+		// Unmarshal CBOR map with integer key, such as COSE Key and SenML, to map[int]any.
 		{
-			name:         "CBOR map to Go map[int]interface{}",
+			name:         "CBOR map to Go map[int]any",
 			data:         mustHexDecode("a801f5021bffffffffffffffff033903e704fbc01066666666666605581a0102030405060708090a0b0c0d0e0f101112131415161718191a06782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6707981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a08ad61646144616661466167614761686148616d614d616e614e6161614161626142616361436165614561696149616a614a616c614c"),
 			decodeToType: reflect.TypeFor[map[int]any](),
 		},
@@ -326,9 +326,9 @@ func BenchmarkUnmarshal(b *testing.B) {
 			data:         mustHexDecode("a801f5021bffffffffffffffff033903e704fbc01066666666666605581a0102030405060708090a0b0c0d0e0f101112131415161718191a06782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6707981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a08ad61646144616661466167614761686148616d614d616e614e6161614161626142616361436165614561696149616a614a616c614c"),
 			decodeToType: reflect.TypeFor[T2](),
 		},
-		// Unmarshal CBOR array of known sequence of data types, such as signed/maced/encrypted CWT, to []interface{}.
+		// Unmarshal CBOR array of known sequence of data types, such as signed/maced/encrypted CWT, to []any.
 		{
-			name:         "CBOR array to Go []interface{}",
+			name:         "CBOR array to Go []any",
 			data:         mustHexDecode("88f51bffffffffffffffff3903e7fbc010666666666666581a0102030405060708090a0b0c0d0e0f101112131415161718191a782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67981a0102030405060708090a0b0c0d0e0f101112131415161718181819181aad616261426163614361646144616561456166614661696149616e614e616161416167614761686148616a614a616c614c616d614d"),
 			decodeToType: reflect.TypeFor[[]any](),
 		},
@@ -462,7 +462,7 @@ func BenchmarkMarshal(b *testing.B) {
 			})
 		}
 	}
-	// Marshal map[string]interface{} to CBOR map
+	// Marshal map[string]any to CBOR map
 	m1 := map[string]any{
 		"T":    true,
 		"UI":   uint(18446744073709551615),
@@ -484,7 +484,7 @@ func BenchmarkMarshal(b *testing.B) {
 		Slci: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
 		Mss:  map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
 	}
-	// Marshal map[int]interface{} to CBOR map
+	// Marshal map[int]any to CBOR map
 	m2 := map[int]any{
 		1: true,
 		2: uint(18446744073709551615),
@@ -506,7 +506,7 @@ func BenchmarkMarshal(b *testing.B) {
 		Slci: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
 		Mss:  map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
 	}
-	// Marshal []interface to CBOR array.
+	// Marshal []any to CBOR array.
 	slc := []any{
 		true,
 		uint(18446744073709551615),
@@ -533,7 +533,7 @@ func BenchmarkMarshal(b *testing.B) {
 		value any
 	}{
 		{
-			name:  "Go map[string]interface{} to CBOR map",
+			name:  "Go map[string]any to CBOR map",
 			value: m1,
 		},
 		{
@@ -570,7 +570,7 @@ func BenchmarkMarshal(b *testing.B) {
 			value: SomeFieldsOneOmitEmpty{},
 		},
 		{
-			name:  "Go map[int]interface{} to CBOR map",
+			name:  "Go map[int]any to CBOR map",
 			value: m2,
 		},
 		{
@@ -578,7 +578,7 @@ func BenchmarkMarshal(b *testing.B) {
 			value: v2,
 		},
 		{
-			name:  "Go []interface{} to CBOR map",
+			name:  "Go []any to CBOR map",
 			value: slc,
 		},
 		{

--- a/decode.go
+++ b/decode.go
@@ -39,7 +39,7 @@ import (
 // unmarshals CBOR into the value pointed to by the pointer.  If the
 // pointer is nil, Unmarshal creates a new value for it to point to.
 //
-// To unmarshal CBOR into an empty interface value, Unmarshal uses the
+// To unmarshal CBOR into a value of type any, Unmarshal uses the
 // following rules:
 //
 //	CBOR booleans decode to bool.
@@ -48,8 +48,8 @@ import (
 //	CBOR floating points decode to float64.
 //	CBOR byte strings decode to []byte.
 //	CBOR text strings decode to string.
-//	CBOR arrays decode to []interface{}.
-//	CBOR maps decode to map[interface{}]interface{}.
+//	CBOR arrays decode to []any.
+//	CBOR maps decode to map[any]any.
 //	CBOR null and undefined values decode to nil.
 //	CBOR times (tag 0 and 1) decode to time.Time.
 //	CBOR bignums (tag 2 and 3) decode to big.Int.
@@ -299,7 +299,7 @@ func (e *InadmissibleTagContentTypeError) Error() string {
 
 // DupMapKeyMode specifies how to enforce duplicate map key. Two map keys are considered duplicates if:
 //  1. When decoding into a struct, both keys match the same struct field. The keys are also
-//     considered duplicates if neither matches any field and decoding to interface{} would produce
+//     considered duplicates if neither matches any field and decoding to a value of type any would produce
 //     equal (==) values for both keys.
 //  2. When decoding into a map, both keys are equal (==) when decoded into values of the
 //     destination map's key type.
@@ -360,11 +360,11 @@ func (tm TagsMode) valid() bool {
 }
 
 // IntDecMode specifies which Go type (int64, uint64, or big.Int) should
-// be used when decoding CBOR integers (major type 0 and 1) to Go interface{}.
+// be used when decoding CBOR integers (major type 0 and 1) to a value of type any.
 type IntDecMode int
 
 const (
-	// IntDecConvertNone affects how CBOR integers (major type 0 and 1) decode to Go interface{}.
+	// IntDecConvertNone affects how CBOR integers (major type 0 and 1) decode to a value of type any.
 	// It decodes CBOR unsigned integer (major type 0) to:
 	// - uint64
 	// It decodes CBOR negative integer (major type 1) to:
@@ -372,7 +372,7 @@ const (
 	// - big.Int or *big.Int (see BigIntDecMode) if value doesn't fit into int64
 	IntDecConvertNone IntDecMode = iota
 
-	// IntDecConvertSigned affects how CBOR integers (major type 0 and 1) decode to Go interface{}.
+	// IntDecConvertSigned affects how CBOR integers (major type 0 and 1) decode to a value of type any.
 	// It decodes CBOR integers (major type 0 and 1) to:
 	// - int64 if value fits
 	// - big.Int or *big.Int (see BigIntDecMode) if value < math.MinInt64
@@ -382,13 +382,13 @@ const (
 	// Please use other options, such as IntDecConvertSignedOrError, IntDecConvertSignedOrBigInt, IntDecConvertNone.
 	IntDecConvertSigned
 
-	// IntDecConvertSignedOrFail affects how CBOR integers (major type 0 and 1) decode to Go interface{}.
+	// IntDecConvertSignedOrFail affects how CBOR integers (major type 0 and 1) decode to a value of type any.
 	// It decodes CBOR integers (major type 0 and 1) to:
 	// - int64 if value fits
 	// - return UnmarshalTypeError if value doesn't fit into int64
 	IntDecConvertSignedOrFail
 
-	// IntDecConvertSignedOrBigInt affects how CBOR integers (major type 0 and 1) decode to Go interface{}.
+	// IntDecConvertSignedOrBigInt affects how CBOR integers (major type 0 and 1) decode to a value of type any.
 	// It makes CBOR integers (major type 0 and 1) decode to:
 	// - int64 if value fits
 	// - big.Int or *big.Int (see BigIntDecMode) if value doesn't fit into int64
@@ -402,10 +402,10 @@ func (idm IntDecMode) valid() bool {
 }
 
 // MapKeyByteStringMode specifies how to decode CBOR byte string (major type 2)
-// as Go map key when decoding CBOR map key into an empty Go interface value.
+// as Go map key when decoding CBOR map key into a value of type any.
 // Specifically, this option applies when decoding CBOR map into
-// - Go empty interface, or
-// - Go map with empty interface as key type.
+// - any, or
+// - Go map with type any as key type.
 // The CBOR map key types handled by this option are
 // - byte string
 // - tagged byte string
@@ -420,7 +420,7 @@ const (
 	MapKeyByteStringAllowed MapKeyByteStringMode = iota
 
 	// MapKeyByteStringForbidden forbids CBOR byte string being decoded as Go map key.
-	// Attempting to decode CBOR byte string as map key into empty interface value
+	// Attempting to decode CBOR byte string as map key into a value of type any
 	// returns a decoding error.
 	MapKeyByteStringForbidden
 
@@ -489,16 +489,16 @@ func (fnmm FieldNameMatchingMode) valid() bool {
 	return fnmm >= 0 && fnmm < maxFieldNameMatchingMode
 }
 
-// BigIntDecMode specifies how to decode CBOR bignum to Go interface{}.
+// BigIntDecMode specifies how to decode CBOR bignum to a value of type any.
 type BigIntDecMode int
 
 const (
 	// BigIntDecodeValue makes CBOR bignum decode to big.Int (instead of *big.Int)
-	// when unmarshaling into a Go interface{}.
+	// when unmarshaling into a value of type any.
 	BigIntDecodeValue BigIntDecMode = iota
 
 	// BigIntDecodePointer makes CBOR bignum decode to *big.Int when
-	// unmarshaling into a Go interface{}.
+	// unmarshaling into a value of type any.
 	BigIntDecodePointer
 
 	maxBigIntDecMode
@@ -549,17 +549,17 @@ func (fnbsm FieldNameByteStringMode) valid() bool {
 	return fnbsm >= 0 && fnbsm < maxFieldNameByteStringMode
 }
 
-// UnrecognizedTagToAnyMode specifies how to decode unrecognized CBOR tag into an empty interface (any).
+// UnrecognizedTagToAnyMode specifies how to decode unrecognized CBOR tag into a value of type any.
 // Currently, recognized CBOR tag numbers are 0, 1, 2, 3, or registered by TagSet.
 type UnrecognizedTagToAnyMode int
 
 const (
 	// UnrecognizedTagNumAndContentToAny decodes CBOR tag number and tag content to cbor.Tag
-	// when decoding unrecognized CBOR tag into an empty interface.
+	// when decoding unrecognized CBOR tag into a value of type any.
 	UnrecognizedTagNumAndContentToAny UnrecognizedTagToAnyMode = iota
 
 	// UnrecognizedTagContentToAny decodes only CBOR tag content (into its default type)
-	// when decoding unrecognized CBOR tag into an empty interface.
+	// when decoding unrecognized CBOR tag into a value of type any.
 	UnrecognizedTagContentToAny
 
 	maxUnrecognizedTagToAny
@@ -569,21 +569,21 @@ func (uttam UnrecognizedTagToAnyMode) valid() bool {
 	return uttam >= 0 && uttam < maxUnrecognizedTagToAny
 }
 
-// TimeTagToAnyMode specifies how to decode CBOR tag 0 and 1 into an empty interface (any).
+// TimeTagToAnyMode specifies how to decode CBOR tag 0 and 1 into a value of type any.
 // Based on the specified mode, Unmarshal can return a time.Time value or a time string in a specific format.
 type TimeTagToAnyMode int
 
 const (
 	// TimeTagToTime decodes CBOR tag 0 and 1 into a time.Time value
-	// when decoding tag 0 or 1 into an empty interface.
+	// when decoding tag 0 or 1 into a value of type any.
 	TimeTagToTime TimeTagToAnyMode = iota
 
 	// TimeTagToRFC3339 decodes CBOR tag 0 and 1 into a time string in RFC3339 format
-	// when decoding tag 0 or 1 into an empty interface.
+	// when decoding tag 0 or 1 into a value of type any.
 	TimeTagToRFC3339
 
 	// TimeTagToRFC3339Nano decodes CBOR tag 0 and 1 into a time string in RFC3339Nano format
-	// when decoding tag 0 or 1 into an empty interface.
+	// when decoding tag 0 or 1 into a value of type any.
 	TimeTagToRFC3339Nano
 
 	maxTimeTagToAnyMode
@@ -818,11 +818,11 @@ type DecOptions struct {
 	TagsMd TagsMode
 
 	// IntDec specifies which Go integer type (int64, uint64, or [big.Int]) to use
-	// when decoding CBOR int (major type 0 and 1) to Go interface{}.
+	// when decoding CBOR int (major type 0 and 1) to a value of type any.
 	IntDec IntDecMode
 
 	// MapKeyByteString specifies how to decode CBOR byte string as map key
-	// when decoding CBOR map with byte string key into an empty interface value.
+	// when decoding CBOR map with byte string key into a value of type any.
 	// By default, an error is returned when attempting to decode CBOR byte string
 	// as map key because Go doesn't allow []byte as map key.
 	MapKeyByteString MapKeyByteStringMode
@@ -831,8 +831,8 @@ type DecOptions struct {
 	ExtraReturnErrors ExtraDecErrorCond
 
 	// DefaultMapType specifies Go map type to create and decode to
-	// when unmarshaling CBOR into an empty interface value.
-	// By default, unmarshal uses map[interface{}]interface{}.
+	// when unmarshaling CBOR into a value of type any.
+	// By default, unmarshal uses map[any]any.
 	DefaultMapType reflect.Type
 
 	// UTF8 specifies if decoder should decode CBOR Text containing invalid UTF-8.
@@ -842,11 +842,11 @@ type DecOptions struct {
 	// FieldNameMatching specifies how string keys in CBOR maps are matched to Go struct field names.
 	FieldNameMatching FieldNameMatchingMode
 
-	// BigIntDec specifies how to decode CBOR bignum to Go interface{}.
+	// BigIntDec specifies how to decode CBOR bignum to a value of type any.
 	BigIntDec BigIntDecMode
 
 	// DefaultByteStringType is the Go type that should be produced when decoding a CBOR byte
-	// string into an empty interface value. Types to which a []byte is convertible are valid
+	// string into a value of type any. Types to which a []byte is convertible are valid
 	// for this option, except for array and pointer-to-array types. If nil, the default is
 	// []byte.
 	DefaultByteStringType reflect.Type
@@ -858,11 +858,11 @@ type DecOptions struct {
 	// Go struct field name.
 	FieldNameByteString FieldNameByteStringMode
 
-	// UnrecognizedTagToAny specifies how to decode unrecognized CBOR tag into an empty interface.
+	// UnrecognizedTagToAny specifies how to decode unrecognized CBOR tag into a value of type any.
 	// Currently, recognized CBOR tag numbers are 0, 1, 2, 3, or registered by TagSet.
 	UnrecognizedTagToAny UnrecognizedTagToAnyMode
 
-	// TimeTagToAny specifies how to decode CBOR tag 0 and 1 into an empty interface (any).
+	// TimeTagToAny specifies how to decode CBOR tag 0 and 1 into a value of type any.
 	// Based on the specified mode, Unmarshal can return a time.Time value or a time string in a specific format.
 	TimeTagToAny TimeTagToAnyMode
 
@@ -2486,7 +2486,7 @@ func (d *decoder) parseMapToMap(v reflect.Value, tInfo *typeInfo) error { //noli
 	keyType, eleType := tInfo.keyTypeInfo.typ, tInfo.elemTypeInfo.typ
 	reuseKey, reuseEle := isImmutableKind(tInfo.keyTypeInfo.kind), isImmutableKind(tInfo.elemTypeInfo.kind)
 	var keyValue, eleValue reflect.Value
-	keyIsInterfaceType := keyType == typeIntf // If key type is interface{}, need to check if key value is hashable.
+	keyIsInterfaceType := keyType == typeIntf // If key type is any, need to check if key value is hashable.
 	var err, lastErr error
 	keyCount := v.Len()
 	var existingKeys map[any]bool // Store existing map keys, used for detecting duplicate map key.

--- a/decode_test.go
+++ b/decode_test.go
@@ -1818,7 +1818,7 @@ var unmarshalTestCases = []unmarshalTestCase{
 	// {
 	// data: hexDecode("f818"),
 	// wantInterfaceValue: uint64(24),
-	// wantValues: []interface{}{uint8(24), uint16(24), uint32(24), uint64(24), uint(24), int8(24), int16(24), int32(24), int64(24), int(24), float32(24), float64(24)},
+	// wantValues: []any{uint8(24), uint16(24), uint32(24), uint64(24), uint(24), int8(24), int16(24), int32(24), int64(24), int(24), float32(24), float64(24)},
 	// wrongTypes: []reflect.Type{typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt},
 	// },
 	{
@@ -2561,7 +2561,7 @@ func compareFloats(t *testing.T, data []byte, got any, want any, equalityThresho
 func TestNegIntOverflow(t *testing.T) {
 	data := mustHexDecode("3bffffffffffffffff") // -18446744073709551616
 
-	// Decode CBOR neg int that overflows Go int64 to empty interface
+	// Decode CBOR neg int that overflows Go int64 to a value of type any.
 	var v1 any
 	wantObj := mustBigInt("-18446744073709551616")
 	if err := Unmarshal(data, &v1); err != nil {
@@ -2966,7 +2966,7 @@ var invalidUnmarshalTestCases = []struct {
 	wantErrorMsg string
 }{
 	{
-		name:         "unmarshal into nil interface{}",
+		name:         "unmarshal into nil",
 		v:            nil,
 		wantErrorMsg: "cbor: Unmarshal(nil)",
 	},
@@ -3569,7 +3569,7 @@ func TestValidUTF8String(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Decode to empty interface
+			// Decode to a value of type any.
 			var i any
 			err = tc.dm.Unmarshal(tc.data, &i)
 			if err != nil {
@@ -3661,7 +3661,7 @@ func TestInvalidUTF8String(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Decode to empty interface
+			// Decode to a value of type any.
 			var v any
 			err = tc.dm.Unmarshal(tc.data, &v)
 			if tc.wantErrorMsg != "" {
@@ -3952,7 +3952,7 @@ func TestUnmarshalPrefilledStruct(t *testing.T) {
 	}
 	prefilledStruct := s{a: 100, B: []int{200, 300, 400, 500}, C: true}
 	want := s{a: 100, B: []int{2, 3}, C: true}
-	data := mustHexDecode("a26161016162820203") // map[string]interface{} {"a": 1, "b": []int{2, 3}}
+	data := mustHexDecode("a26161016162820203") // map[string]any {"a": 1, "b": []int{2, 3}}
 	if err := Unmarshal(data, &prefilledStruct); err != nil {
 		t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
 	}
@@ -4441,7 +4441,7 @@ func TestDecodeTag0Error(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Decode to interface{}
+			// Decode to a value of type any.
 			var v any
 			if err := tc.dm.Unmarshal(data, &v); err == nil {
 				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", data, wantErrorMsg)
@@ -4487,7 +4487,7 @@ func TestDecodeTag1Error(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Decode to interface{}
+			// Decode to a value of type any.
 			var v any
 			if err := tc.dm.Unmarshal(data, &v); err == nil {
 				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", data, wantErrorMsg)
@@ -5309,7 +5309,7 @@ func TestUnmarshalIntoSliceError(t *testing.T) {
 	wantErrorMsg := invalidUTF8ErrorMsg
 	var want any
 
-	// Unmarshal CBOR array into Go empty interface.
+	// Unmarshal CBOR array into a value of type any.
 	var v1 any
 	want = []any{"a", any(nil), "b"}
 	if err := Unmarshal(data, &v1); err == nil {
@@ -5367,7 +5367,7 @@ func TestUnmarshalIntoMapError(t *testing.T) {
 	var want any
 
 	for _, data := range data {
-		// Unmarshal CBOR map into Go empty interface.
+		// Unmarshal CBOR map into a value of type any.
 		var v1 any
 		want = map[any]any{"a": "A", "b": "B"}
 		if err := Unmarshal(data, &v1); err == nil {
@@ -5379,7 +5379,7 @@ func TestUnmarshalIntoMapError(t *testing.T) {
 			t.Errorf("Unmarshal(0x%x) = %v, want %v", data, v1, want)
 		}
 
-		// Unmarshal CBOR map into Go map[interface{}]interface{}.
+		// Unmarshal CBOR map into Go map[any]any.
 		var v2 map[any]any
 		want = map[any]any{"a": "A", "b": "B"}
 		if err := Unmarshal(data, &v2); err == nil {
@@ -5512,7 +5512,7 @@ func TestStructKeyAsIntError(t *testing.T) {
 func TestUnmarshalToNotNilInterface(t *testing.T) {
 	data := mustHexDecode("83010203") // []uint64{1, 2, 3}
 	s := "hello"                      //nolint:goconst
-	var v any = s                     // Unmarshal() sees v as type interface{} and sets CBOR data as default Go type.  s is unmodified.  Same behavior as encoding/json.
+	var v any = s                     // Unmarshal() sees v as a value of type any and sets CBOR data as default Go type.  s is unmodified.  Same behavior as encoding/json.
 	wantV := []any{uint64(1), uint64(2), uint64(3)}
 	if err := Unmarshal(data, &v); err != nil {
 		t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
@@ -7562,7 +7562,7 @@ func TestUnmarshalTagNum55799(t *testing.T) {
 		copy(data[3:], tagNum55799)
 		copy(data[6:], tc.data)
 
-		// Test unmarshaling CBOR into empty interface.
+		// Test unmarshaling CBOR into a value of type any.
 		var v any
 		if err := Unmarshal(data, &v); err != nil {
 			t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
@@ -7627,7 +7627,7 @@ func TestUnmarshalFloatWithTagNum55799(t *testing.T) {
 		copy(data, tagNum55799)
 		copy(data[3:], tc.data)
 
-		// Test unmarshaling CBOR into empty interface.
+		// Test unmarshaling CBOR into a value of type any.
 		var v any
 		if err := Unmarshal(tc.data, &v); err != nil {
 			t.Errorf("Unmarshal(0x%x) returned error %v", tc.data, err)
@@ -7694,7 +7694,7 @@ func TestUnmarshalTagNum55799AsElement(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Test unmarshaling CBOR into empty interface.
+			// Test unmarshaling CBOR into a value of type any.
 			var v any
 			if err := Unmarshal(tc.data, &v); err != nil {
 				t.Errorf("Unmarshal(0x%x) returned error %v", tc.data, err)
@@ -8275,7 +8275,7 @@ func TestUnmarshalToInterface(t *testing.T) {
 				t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.v, data, tc.data)
 			}
 
-			// Unmarshal to empty interface
+			// Unmarshal to a value of type TestExample with uninitialized Foo interface.
 			var einterface TestExample
 			if err = Unmarshal(data, &einterface); err == nil {
 				t.Errorf("Unmarshal(0x%x) didn't return an error, want error (*UnmarshalTypeError)", data)
@@ -8334,7 +8334,7 @@ func TestUnmarshalTaggedDataToInterface(t *testing.T) {
 
 	dm, _ := DecOptions{}.DecModeWithTags(tags)
 
-	// Unmarshal to empty interface
+	// Unmarshal to wrong type.
 	var v1 Bar
 	if err = dm.Unmarshal(data, &v1); err == nil {
 		t.Errorf("Unmarshal(0x%x) didn't return an error, want error (*UnmarshalTypeError)", data)
@@ -8502,21 +8502,21 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 		wantValue    any
 		wantErrorMsg string
 	}{
-		// Decode CBOR map to map[interface{}]interface{} using default options
+		// Decode CBOR map to map[any]any using default options
 		{
-			name:      "decode CBOR map[int]int to Go map[interface{}]interface{} (default)",
+			name:      "decode CBOR map[int]int to Go map[any]any (default)",
 			opts:      decOptionsDefault,
 			data:      cborDataMapIntInt,
 			wantValue: map[any]any{uint64(1): uint64(2), uint64(3): uint64(4)},
 		},
 		{
-			name:      "decode CBOR map[string]int to Go map[interface{}]interface{} (default)",
+			name:      "decode CBOR map[string]int to Go map[any]any (default)",
 			opts:      decOptionsDefault,
 			data:      cborDataMapStringInt,
 			wantValue: map[any]any{"a": uint64(1), "b": uint64(2)},
 		},
 		{
-			name: "decode CBOR array of map[string]int to Go []map[interface{}]interface{} (default)",
+			name: "decode CBOR array of map[string]int to Go []map[any]any (default)",
 			opts: decOptionsDefault,
 			data: cborDataArrayOfMapStringint,
 			wantValue: []any{
@@ -8525,7 +8525,7 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 			},
 		},
 		{
-			name: "decode CBOR nested map to Go map[interface{}]interface{} (default)",
+			name: "decode CBOR nested map to Go map[any]any (default)",
 			opts: decOptionsDefault,
 			data: cborDataNestedMap,
 			wantValue: map[any]any{
@@ -8533,21 +8533,21 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 				"MapField": map[any]any{"a": uint64(1), "b": uint64(2)},
 			},
 		},
-		// Decode CBOR map to map[interface{}]interface{} using default map type option
+		// Decode CBOR map to map[any]any using default map type option
 		{
-			name:      "decode CBOR map[int]int to Go map[interface{}]interface{}",
+			name:      "decode CBOR map[int]int to Go map[any]any",
 			opts:      decOptionsMapIntfIntfType,
 			data:      cborDataMapIntInt,
 			wantValue: map[any]any{uint64(1): uint64(2), uint64(3): uint64(4)},
 		},
 		{
-			name:      "decode CBOR map[string]int to Go map[interface{}]interface{}",
+			name:      "decode CBOR map[string]int to Go map[any]any",
 			opts:      decOptionsMapIntfIntfType,
 			data:      cborDataMapStringInt,
 			wantValue: map[any]any{"a": uint64(1), "b": uint64(2)},
 		},
 		{
-			name: "decode CBOR array of map[string]int to Go []map[interface{}]interface{}",
+			name: "decode CBOR array of map[string]int to Go []map[any]any",
 			opts: decOptionsMapIntfIntfType,
 			data: cborDataArrayOfMapStringint,
 			wantValue: []any{
@@ -8556,7 +8556,7 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 			},
 		},
 		{
-			name: "decode CBOR nested map to Go map[interface{}]interface{}",
+			name: "decode CBOR nested map to Go map[any]any",
 			opts: decOptionsMapIntfIntfType,
 			data: cborDataNestedMap,
 			wantValue: map[any]any{
@@ -8564,21 +8564,21 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 				"MapField": map[any]any{"a": uint64(1), "b": uint64(2)},
 			},
 		},
-		// Decode CBOR map to map[string]interface{} using default map type option
+		// Decode CBOR map to map[string]any using default map type option
 		{
-			name:         "decode CBOR map[int]int to Go map[string]interface{}",
+			name:         "decode CBOR map[int]int to Go map[string]any",
 			opts:         decOptionsMapStringIntfType,
 			data:         cborDataMapIntInt,
 			wantErrorMsg: "cbor: cannot unmarshal positive integer into Go value of type string",
 		},
 		{
-			name:      "decode CBOR map[string]int to Go map[string]interface{}",
+			name:      "decode CBOR map[string]int to Go map[string]any",
 			opts:      decOptionsMapStringIntfType,
 			data:      cborDataMapStringInt,
 			wantValue: map[string]any{"a": uint64(1), "b": uint64(2)},
 		},
 		{
-			name: "decode CBOR array of map[string]int to Go []map[string]interface{}",
+			name: "decode CBOR array of map[string]int to Go []map[string]any",
 			opts: decOptionsMapStringIntfType,
 			data: cborDataArrayOfMapStringint,
 			wantValue: []any{
@@ -8587,7 +8587,7 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 			},
 		},
 		{
-			name: "decode CBOR nested map to Go map[string]interface{}",
+			name: "decode CBOR nested map to Go map[string]any",
 			opts: decOptionsMapStringIntfType,
 			data: cborDataNestedMap,
 			wantValue: map[string]any{
@@ -8633,7 +8633,7 @@ func TestUnmarshalToDefaultMapType(t *testing.T) {
 			err := decMode.Unmarshal(tc.data, &v)
 			if err != nil {
 				if tc.wantErrorMsg == "" {
-					t.Errorf("Unmarshal(0x%x) to empty interface returned error %v", tc.data, err)
+					t.Errorf("Unmarshal(0x%x) to type any returned error %v", tc.data, err)
 				} else if tc.wantErrorMsg != err.Error() {
 					t.Errorf("Unmarshal(0x%x) error %q, want %q", tc.data, err.Error(), tc.wantErrorMsg)
 				}
@@ -8896,7 +8896,7 @@ func TestDecodeBignumToEmptyInterface(t *testing.T) {
 			var v any
 			err := decMode.Unmarshal(tc.data, &v)
 			if err != nil {
-				t.Errorf("Unmarshal(0x%x) to empty interface returned error %v", tc.data, err)
+				t.Errorf("Unmarshal(0x%x) to type any returned error %v", tc.data, err)
 			} else { //nolint:gocritic // ignore elseif
 				if !reflect.DeepEqual(v, tc.wantValue) {
 					t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.data, v, v, tc.wantValue, tc.wantValue)
@@ -9365,7 +9365,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 		assertOnError func(t *testing.T, e error)
 	}{
 		{
-			name:          "default false into interface{}",
+			name:          "default false into any",
 			fns:           nil,
 			data:          []byte{0xf4},
 			into:          typeIntf,
@@ -9381,7 +9381,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 			assertOnError: assertNilError,
 		},
 		{
-			name:          "default true into interface{}",
+			name:          "default true into any",
 			fns:           nil,
 			data:          []byte{0xf5},
 			into:          typeIntf,
@@ -9397,7 +9397,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 			assertOnError: assertNilError,
 		},
 		{
-			name:          "default null into interface{}",
+			name:          "default null into any",
 			fns:           nil,
 			data:          []byte{0xf6},
 			into:          typeIntf,
@@ -9405,7 +9405,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 			assertOnError: assertNilError,
 		},
 		{
-			name:          "default undefined into interface{}",
+			name:          "default undefined into any",
 			fns:           nil,
 			data:          []byte{0xf7},
 			into:          typeIntf,
@@ -9413,7 +9413,7 @@ func TestUnmarshalSimpleValues(t *testing.T) {
 			assertOnError: assertNilError,
 		},
 		{
-			name: "reject undefined into interface{}",
+			name: "reject undefined into any",
 			fns:  []func(*SimpleValueRegistry) error{WithRejectedSimpleValue(23)},
 			data: []byte{0xf7},
 			into: typeIntf,

--- a/doc.go
+++ b/doc.go
@@ -144,8 +144,6 @@ very compact formats like COSE and CWT (CBOR Web Tokens) with structs.
 
 The "omitzero" option omits zero values from encoding, matching
 [stdlib encoding/json behavior](https://pkg.go.dev/encoding/json#Marshal).
-When specified in the `cbor` tag, the option is always honored.
-When specified in the `json` tag, the option is honored when building with Go 1.24+.
 
 For example, "toarray" makes struct fields encode to array elements.  And "keyasint"
 makes struct fields encode to elements of CBOR map with int keys.
@@ -156,7 +154,7 @@ Struct tag options are listed at https://github.com/fxamacker/cbor#struct-tags-1
 
 # Tests and Fuzzing
 
-Over 375 tests are included in this package. Cover-guided fuzzing is handled by
+Over 400 tests are included in this package. Cover-guided fuzzing is handled by
 a private fuzzer that replaced fxamacker/cbor-fuzz years ago.
 */
 package cbor

--- a/encode.go
+++ b/encode.go
@@ -60,8 +60,7 @@ import (
 // field's tag.  CBOR format string can specify the name of the field,
 // "omitempty", "omitzero" and "keyasint" options, and special case "-" for
 // field omission. If "cbor" key is absent, Marshal uses "json" key.
-// When using the "json" key, the "omitzero" option is honored when building
-// with Go 1.24+ to match stdlib encoding/json behavior.
+// The "omitzero" option matches Go 1.24+ stdlib encoding/json behavior.
 //
 // Struct field name is treated as integer if it has "keyasint" option in
 // its format string.  The format string must specify an integer as its

--- a/encode_test.go
+++ b/encode_test.go
@@ -235,7 +235,6 @@ var marshalTestCases = []marshalTestCase{
 		values: []any{
 			[...]any{1, [...]int{2, 3}, [...]int{4, 5}},
 			[]any{1, []uint{2, 3}, []uint{4, 5}},
-			// []interface{}{1, []uint8{2, 3}, []uint8{4, 5}},
 			[]any{1, []uint16{2, 3}, []uint16{4, 5}},
 			[]any{1, []uint32{2, 3}, []uint32{4, 5}},
 			[]any{1, []uint64{2, 3}, []uint64{4, 5}},

--- a/json_test.go
+++ b/json_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestStdlibJSONCompatibility tests compatibility as a drop-in replacement for the standard library
-// encoding/json package on a round trip encoding from Go object to interface{}.
+// encoding/json package on a round trip encoding from Go object to a value of type any.
 func TestStdlibJSONCompatibility(t *testing.T) {
 	// TODO: With better coverage and compatibility, it could be useful to expose these option
 	// configurations to users.
@@ -38,7 +38,7 @@ func TestStdlibJSONCompatibility(t *testing.T) {
 	testCases := []struct {
 		name       string
 		original   any
-		ifaceEqual bool // require equal intermediate interface{} values from both protocols
+		ifaceEqual bool // require equal intermediate values of type any from both protocols
 	}{
 		{
 			name:       "byte slice to base64-encoded string",
@@ -76,20 +76,20 @@ func TestStdlibJSONCompatibility(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.Logf("json to interface{} (%T): %#v", jintf, jintf)
+			t.Logf("json to any (%T): %#v", jintf, jintf)
 
 			var cintf any
 			err = dec.Unmarshal(c1, &cintf)
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.Logf("cbor to interface{} (%T): %#v", cintf, cintf)
+			t.Logf("cbor to any (%T): %#v", cintf, cintf)
 
 			j2, err := json.Marshal(jintf)
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.Logf("interface{} to json: %s", string(j2))
+			t.Logf("any to json: %s", string(j2))
 
 			c2, err := enc.Marshal(cintf)
 			if err != nil {
@@ -99,13 +99,13 @@ func TestStdlibJSONCompatibility(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.Logf("interface{} to cbor: %s", diag2)
+			t.Logf("any to cbor: %s", diag2)
 
 			if !reflect.DeepEqual(jintf, cintf) {
 				if tc.ifaceEqual {
-					t.Errorf("native-to-interface{} via cbor differed from native-to-interface{} via json")
+					t.Errorf("native-to-any via cbor differed from native-to-any via json")
 				} else {
-					t.Logf("native-to-interface{} via cbor differed from native-to-interface{} via json")
+					t.Logf("native-to-any via cbor differed from native-to-any via json")
 				}
 			}
 

--- a/tag_test.go
+++ b/tag_test.go
@@ -1373,7 +1373,7 @@ func TestDecodeTagToEmptyIface(t *testing.T) {
 				t.Errorf("Unmarshal() returned error %v", err)
 			}
 			if !reflect.DeepEqual(tc.wantObj, v1) {
-				t.Errorf("Unmarshal to interface{} returned different values: %v, %v", tc.wantObj, v1)
+				t.Errorf("Unmarshal to any returned different values: %v, %v", tc.wantObj, v1)
 			}
 
 			var v2 any
@@ -1381,7 +1381,7 @@ func TestDecodeTagToEmptyIface(t *testing.T) {
 				t.Errorf("Unmarshal() returned error %v", err)
 			}
 			if !reflect.DeepEqual(tc.wantObj, v2) {
-				t.Errorf("Unmarshal to interface{} returned different values: %v, %v", tc.wantObj, v2)
+				t.Errorf("Unmarshal to any returned different values: %v, %v", tc.wantObj, v2)
 			}
 		})
 	}
@@ -1456,7 +1456,7 @@ func TestDecodeRegisterTagForUnmarshaler(t *testing.T) {
 	dm, _ := DecOptions{}.DecModeWithTags(tags)
 	em, _ := EncOptions{}.EncModeWithTags(tags)
 
-	// Decode to empty interface.  Unmarshal() should return object of registered type.
+	// Decode to a value of type any.  Unmarshal() should return object of registered type.
 	var v1 any
 	if err := dm.Unmarshal(data, &v1); err != nil {
 		t.Errorf("Unmarshal() returned error %v", err)


### PR DESCRIPTION
This PR updates code comments to migrate from old terminology to use newer terminology/features introduced since 2022 (e.g., Go 1.18 introduced `any`).

For example, "empty interface" is replaced by "a value of type any".