### PR TITLE
Speed up map-to-struct field fallback matching

### DIFF
--- a/decode_map_utils.go
+++ b/decode_map_utils.go
@@ -88,7 +88,7 @@ func equalFoldASCIIStringBytes(s string, b []byte) (match bool, ascii bool) {
 		return false, true
 	}
 
-	for i := 0; i < len(b); i++ {
+	for i := range b {
 		c := s[i]
 		d := b[i]
 		if c|d >= 0x80 {

--- a/decode_map_utils.go
+++ b/decode_map_utils.go
@@ -42,24 +42,70 @@ func findStructFieldByKey(
 		return fldIdx, true
 	}
 	if caseInsensitive {
-		return findFieldCaseInsensitive(structType.fields, string(keyBytes))
+		return findFieldCaseInsensitiveBytes(structType.fields, keyBytes)
 	}
 	return -1, false
 }
 
-// findFieldCaseInsensitive returns the index of the first field whose name
-// case-insensitively matches key, or -1 and false if no field matches.
-func findFieldCaseInsensitive(flds decodingFields, key string) (int, bool) {
-	keyLen := len(key)
+// findFieldCaseInsensitiveBytes returns the index of the first field whose name
+// case-insensitively matches keyBytes, or -1 and false if no field matches.
+//
+// It keeps the common ASCII path allocation-free and avoids strings.EqualFold's
+// Unicode machinery unless either side contains non-ASCII bytes.
+func findFieldCaseInsensitiveBytes(flds decodingFields, keyBytes []byte) (int, bool) {
+	keyLen := len(keyBytes)
+	var key string
+	var keySet bool
+
 	for i, f := range flds {
-		if f.keyAsInt {
+		if f.keyAsInt || len(f.name) != keyLen {
 			continue
 		}
-		if len(f.name) == keyLen && strings.EqualFold(f.name, key) {
+
+		if match, ascii := equalFoldASCIIStringBytes(f.name, keyBytes); ascii {
+			if match {
+				return i, true
+			}
+			continue
+		}
+
+		if !keySet {
+			key = string(keyBytes)
+			keySet = true
+		}
+		if strings.EqualFold(f.name, key) {
 			return i, true
 		}
 	}
 	return -1, false
+}
+
+// equalFoldASCIIStringBytes compares s and b using ASCII case folding.
+// ascii is false if either input contains non-ASCII bytes, in which case the
+// caller must use strings.EqualFold to preserve Unicode case-folding semantics.
+func equalFoldASCIIStringBytes(s string, b []byte) (match bool, ascii bool) {
+	if len(s) != len(b) {
+		return false, true
+	}
+
+	for i := 0; i < len(b); i++ {
+		c := s[i]
+		d := b[i]
+		if c|d >= 0x80 {
+			return false, false
+		}
+
+		if 'A' <= c && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if 'A' <= d && d <= 'Z' {
+			d += 'a' - 'A'
+		}
+		if c != d {
+			return false, true
+		}
+	}
+	return true, true
 }
 
 // handleUnmatchedMapKey handles a map entry whose key does not match any struct


### PR DESCRIPTION
## Summary

This speeds up the case-insensitive fallback path used by map-to-struct decoding.

The exact field-name map lookup still runs first. When fallback matching is enabled, the new helper compares the struct field name with the raw key bytes on an allocation-free ASCII path and only converts the key bytes to a string if Unicode `strings.EqualFold` behavior is actually needed.

## Results

Run on Apple M4:

```sh
go test -run '^$' -bench '^BenchmarkUnmarshalMapToStruct/' -benchmem -count=20 .
```

Selected `benchstat` results:

```text
UnmarshalMapToStruct/default_options/all_known_fields-10                  480.8n -> 459.8n   -4.37%
UnmarshalMapToStruct/default_options/all_unknown_fields-10                773.9n -> 633.0n  -18.21%
UnmarshalMapToStruct/default_options/all_unknown_duplicate_fields-10      697.3n -> 579.4n  -16.91%
UnmarshalMapToStruct/reject_unknown/all_unknown_fields-10                 224.7n -> 211.6n   -5.85%
UnmarshalMapToStruct/reject_duplicate/all_unknown_fields-10               1.208µ -> 1.052µ  -12.88%
UnmarshalMapToStruct/reject_unknown_and_duplicate/all_unknown_fields-10   237.8n -> 211.6n  -11.00%
geomean                                                                   432.1n -> 402.3n   -6.91%
```

`B/op` and `allocs/op` were unchanged across the benchmark matrix.

## Correctness

The exact match path and integer-key handling are unchanged. The new ASCII helper returns to `strings.EqualFold` whenever either input contains non-ASCII bytes, preserving the previous Unicode case-folding behavior.

I also checked the new helper against the previous `strings.EqualFold` implementation with fixed ASCII/Unicode cases and 10,000 deterministic random byte-string cases before dropping the temporary oracle test from this PR.

Validation:

```sh
go test -count=1 ./...
```

I found the candidate while experimenting with Sleepy - https://sleepy.run/mcp, then manually reviewed and validated it.
