### PR TITLE
test(decode): fix Errorf argument order in array-to-struct case

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -5126,7 +5126,7 @@ func TestUnmarshalArrayToStructNoToArrayOptionError(t *testing.T) {
 	} else if _, ok := err.(*UnmarshalTypeError); !ok {
 		t.Errorf("Decode(%+v) returned wrong error type %T, want (*UnmarshalTypeError)", v1, err)
 	} else if !strings.Contains(err.Error(), "cannot unmarshal") {
-		t.Errorf("Decode(%+v) returned error %q, want error containing %q", err.Error(), v1, "cannot unmarshal")
+		t.Errorf("Decode(%+v) returned error %q, want error containing %q", v1, err.Error(), "cannot unmarshal")
 	}
 	if !reflect.DeepEqual(v1, wantT) {
 		t.Errorf("Decode() = %+v (%T), want %+v (%T)", v1, v1, wantT, wantT)


### PR DESCRIPTION
## Summary
In `TestUnmarshalArrayToStructNoToArrayOptionError`, the `t.Errorf` call for the "want error containing" branch swapped `err.Error()` and `v1`.

That makes failure messages misleading (and mismatches the format verbs).

## Fix
Pass `v1` then `err.Error()` to match:
`Decode(%+v) returned error %q, want error containing %q`

Fixes #784

## Test plan
- [x] `go test -run TestUnmarshalArrayToStruct .`