### PR TITLE
Reduce decoding time up to 17% for all CBOR data types

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1667,10 +1667,7 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 			// If conversion for interoperability with text encodings is not configured,
 			// treat tags 21-23 as unregistered tags.
 			if d.dm.byteStringToString == ByteStringToStringAllowedWithExpectedLaterEncoding || d.dm.byteStringExpectedFormat != ByteStringExpectedFormatNone {
-				d.expectedLaterEncodingTags = append(d.expectedLaterEncodingTags, tagNum)
-				defer func() {
-					d.expectedLaterEncodingTags = d.expectedLaterEncodingTags[:len(d.expectedLaterEncodingTags)-1]
-				}()
+				return d.parseToValueWithExpectedLaterEncodingTag(v, tInfo, tagNum)
 			}
 		}
 
@@ -2118,11 +2115,7 @@ func (d *decoder) parse(skipSelfDescribedTag bool) (any, error) { //nolint:gocyc
 			// treat tags 21-23 as unregistered tags.
 			if d.dm.byteStringToString == ByteStringToStringAllowedWithExpectedLaterEncoding ||
 				d.dm.byteStringExpectedFormat != ByteStringExpectedFormatNone {
-				d.expectedLaterEncodingTags = append(d.expectedLaterEncodingTags, tagNum)
-				defer func() {
-					d.expectedLaterEncodingTags = d.expectedLaterEncodingTags[:len(d.expectedLaterEncodingTags)-1]
-				}()
-				return d.parse(false)
+				return d.parseWithExpectedLaterEncodingTag(tagNum)
 			}
 		}
 
@@ -2205,6 +2198,22 @@ func (d *decoder) parse(skipSelfDescribedTag bool) (any, error) { //nolint:gocyc
 	}
 
 	return nil, nil
+}
+
+func (d *decoder) parseToValueWithExpectedLaterEncodingTag(v reflect.Value, tInfo *typeInfo, tagNum uint64) error {
+	d.expectedLaterEncodingTags = append(d.expectedLaterEncodingTags, tagNum)
+	defer func() {
+		d.expectedLaterEncodingTags = d.expectedLaterEncodingTags[:len(d.expectedLaterEncodingTags)-1]
+	}()
+	return d.parseToValue(v, tInfo)
+}
+
+func (d *decoder) parseWithExpectedLaterEncodingTag(tagNum uint64) (any, error) {
+	d.expectedLaterEncodingTags = append(d.expectedLaterEncodingTags, tagNum)
+	defer func() {
+		d.expectedLaterEncodingTags = d.expectedLaterEncodingTags[:len(d.expectedLaterEncodingTags)-1]
+	}()
+	return d.parse(false)
 }
 
 // parseByteString parses a CBOR encoded byte string. The returned byte slice


### PR DESCRIPTION
On existing benchmarks, this PR reduces decoding times by up to 17%, depending on the data structure and values being decoded. Decoding CBOR maps and arrays into Go structs takes about 6-8% less time, including with `keyasint` and `toarray` tag options.

This optimization moves the unoptimized `defer` in `parseToValue()` and `parse()` to cold helper functions.

Previously, the `defer` in each decoding function popped `d.expectedLaterEncodingTags` after decoding CBOR tags 21 to 23. Since the `defer` wasn't open-coded, the compiler couldn't optimize it and decoding every data item had to pay for it.

Moving each `defer` into its own small helper removes defer from the hot path.  Also, the `defer`s in helper functions are open-coded and can be optimized.

### Benchmarks

Benchmark results for `Unmarshal()` omit allocs/op and B/op because they are unchanged:

```
goos: linux
goarch: amd64
pkg: github.com/fxamacker/cbor/v2

NOTE: These benchmark results were produced on a PC running other processes.
Please measure on your own hardware with appropriate settings and workloads.

                                                            │     old      │                 new                 │
                                                            │    sec/op    │   sec/op     vs base                │
Unmarshal/CBOR_bool_to_Go_interface_{}                        66.27n ± 1%   57.89n ± 2%  -12.65% (p=0.000 n=20)
Unmarshal/CBOR_bool_to_Go_bool                                38.07n ± 0%   34.71n ± 0%   -8.81% (p=0.000 n=20)
Unmarshal/CBOR_positive_int_to_Go_interface_{}                90.24n ± 1%   77.82n ± 3%  -13.77% (p=0.000 n=20)
Unmarshal/CBOR_positive_int_to_Go_uint64                      43.91n ± 0%   39.27n ± 0%  -10.57% (p=0.000 n=20)
Unmarshal/CBOR_negative_int_to_Go_interface_{}                89.56n ± 1%   74.54n ± 2%  -16.77% (p=0.000 n=20)
Unmarshal/CBOR_negative_int_to_Go_int64                       43.14n ± 0%   38.63n ± 0%  -10.45% (p=0.000 n=20)
Unmarshal/CBOR_float_to_Go_interface_{}                       92.55n ± 1%   77.89n ± 3%  -15.85% (p=0.000 n=20)
Unmarshal/CBOR_float_to_Go_float64                            44.42n ± 0%   39.89n ± 0%  -10.21% (p=0.000 n=20)
Unmarshal/CBOR_byte_string_to_Go_interface_{}                 175.6n ± 8%   159.5n ± 7%   -9.17% (p=0.026 n=20)
Unmarshal/CBOR_byte_string_to_Go_[]uint8                      139.5n ± 5%   130.8n ± 5%   -6.27% (p=0.009 n=20)
Unmarshal/CBOR_indef-len_byte_string_to_Go_interface_{}       377.2n ± 1%   369.9n ± 1%   -1.94% (p=0.000 n=20)
Unmarshal/CBOR_indef-len_byte_string_to_Go_[]uint8            346.2n ± 1%   339.2n ± 1%   -2.01% (p=0.000 n=20)
Unmarshal/CBOR_text_string_to_Go_interface_{}                 191.6n ± 6%   175.2n ± 4%   -8.56% (p=0.004 n=20)
Unmarshal/CBOR_text_string_to_Go_string                       147.5n ± 8%   138.4n ± 7%   -6.14% (p=0.021 n=20)
Unmarshal/CBOR_indef-len_text_string_to_Go_interface_{}       657.4n ± 2%   642.7n ± 3%        ~ (p=0.102 n=20)
Unmarshal/CBOR_indef-len_text_string_to_Go_string             612.7n ± 2%   594.8n ± 2%   -2.91% (p=0.005 n=20)
Unmarshal/CBOR_array_to_Go_interface_{}                       934.4n ± 5%   906.0n ± 5%        ~ (p=0.165 n=20)
Unmarshal/CBOR_array_to_Go_[]int                              729.9n ± 4%   643.4n ± 7%  -11.85% (p=0.000 n=20)
Unmarshal/CBOR_indef-len_array_to_Go_interface_{}            1012.0n ± 6%   876.0n ± 3%  -13.44% (p=0.000 n=20)
Unmarshal/CBOR_indef-len_array_to_Go_[]int                    824.6n ± 2%   695.5n ± 4%  -15.66% (p=0.000 n=20)
Unmarshal/CBOR_map_to_Go_interface_{}                         2.927µ ± 5%   2.709µ ± 7%   -7.45% (p=0.028 n=20)
Unmarshal/CBOR_map_to_Go_map[string]interface_{}              2.338µ ± 3%   2.138µ ± 5%   -8.56% (p=0.000 n=20)
Unmarshal/CBOR_map_to_Go_map[string]string                    1.706µ ± 5%   1.592µ ± 8%   -6.65% (p=0.021 n=20)
Unmarshal/CBOR_indef-len_map_to_Go_interface_{}               3.022µ ± 6%   2.713µ ± 9%  -10.23% (p=0.017 n=20)
Unmarshal/CBOR_indef-len_map_to_Go_map[string]interface_{}    2.891µ ± 8%   2.798µ ± 8%        ~ (p=0.149 n=20)
Unmarshal/CBOR_indef-len_map_to_Go_map[string]string          2.201µ ± 9%   2.198µ ± 5%        ~ (p=0.941 n=20)
Unmarshal/CBOR_map_to_Go_map[string]any                       4.917µ ± 4%   4.846µ ± 5%        ~ (p=0.723 n=20)
Unmarshal/CBOR_map_to_Go_struct                               3.037µ ± 1%   2.856µ ± 6%   -5.96% (p=0.000 n=20)
Unmarshal/CBOR_map_to_Go_map[int]any                          4.944µ ± 5%   4.774µ ± 3%        ~ (p=0.064 n=20)
Unmarshal/CBOR_map_to_Go_struct_keyasint                      2.999µ ± 5%   2.787µ ± 3%   -7.07% (p=0.000 n=20)
Unmarshal/CBOR_array_to_Go_[]any                              4.554µ ± 5%   4.309µ ± 7%        ~ (p=0.060 n=20)
Unmarshal/CBOR_array_to_Go_struct_toarray                     2.920µ ± 3%   2.684µ ± 9%   -8.08% (p=0.003 n=20)
UnmarshalCOSE/128-Bit_Symmetric_Key                           443.4n ± 4%   436.6n ± 6%        ~ (p=0.947 n=20)
UnmarshalCOSE/256-Bit_Symmetric_Key                           477.5n ± 5%   457.4n ± 8%        ~ (p=0.102 n=20)
UnmarshalCOSE/ECDSA_P256_256-Bit_Key                          746.1n ± 7%   726.8n ± 4%        ~ (p=0.344 n=20)
UnmarshalCWTClaims                                            461.5n ± 2%   434.1n ± 2%   -5.94% (p=0.000 n=20)
UnmarshalCWTClaimsWithDupMapKeyOpt                            450.3n ± 5%   437.9n ± 4%   -2.74% (p=0.015 n=20)
UnmarshalSenML                                                2.723µ ± 9%   2.627µ ± 5%        ~ (p=0.091 n=20)
UnmarshalWebAuthn                                             1.444µ ± 5%   1.386µ ± 4%   -4.05% (p=0.019 n=20)
UnmarshalCOSEMAC                                              545.6n ± 3%   539.9n ± 7%        ~ (p=0.157 n=20)
UnmarshalCOSEMACWithTag                                       590.0n ± 4%   581.8n ± 4%        ~ (p=0.418 n=20)
```

To reduce scrolling, "indefinite-length" was abbreviated to "indef-len" and "-12" suffix was removed.